### PR TITLE
#12 Transaction MFE + Hot replacement

### DIFF
--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "outDir": "./dist",
-  "rootDir": "./src",
-  "strict": false
+  "rootDir": "./src"
 }

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "outDir": "./dist",
-  "rootDir": "./src",
-  "strict": false
+  "rootDir": "./src"
 }

--- a/packages/transactions/.swcrc
+++ b/packages/transactions/.swcrc
@@ -1,0 +1,10 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dynamicImport": true
+    },
+    "target": "es5"
+  }
+}

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openmsupply-client/transactions",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "7.14.6",
+    "@babel/preset-react": "7.14.5",
+    "@pmmmwh/react-refresh-webpack-plugin": "https://github.com/pmmmwh/react-refresh-webpack-plugin",
+    "babel-loader": "8.2.2",
+    "eslint-config-prettier": "^8.3.0",
+    "find-up": "5.0.0",
+    "html-webpack-plugin": "5.3.1",
+    "husky": "^7.0.1",
+    "lint-staged": "^11.1.1",
+    "prettier": "^2.3.2",
+    "react-refresh": "^0.10.0",
+    "react-refresh-typescript": "^2.0.2",
+    "serve": "11.3.2",
+    "typescript": "^4.3.5",
+    "webpack": "5.40.0",
+    "webpack-cli": "4.7.2",
+    "webpack-dev-server": "4.0.0-beta.3"
+  },
+  "scripts": {
+    "start": "webpack-cli serve",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3004",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "history": "^5.0.0",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
+    "react-router": "6.0.0-beta.0",
+    "react-router-dom": "6.0.0-beta.0"
+  }
+}

--- a/packages/transactions/public/index.html
+++ b/packages/transactions/public/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/transactions/src/App.tsx
+++ b/packages/transactions/src/App.tsx
@@ -1,0 +1,10 @@
+import React, { FC } from 'react';
+import { LoadingApp } from '@openmsupply-client/common';
+
+const App: FC = () => (
+  <React.Suspense fallback={<LoadingApp />}>
+    <span>Transactions</span>
+  </React.Suspense>
+);
+
+export default App;

--- a/packages/transactions/src/TransactionService.tsx
+++ b/packages/transactions/src/TransactionService.tsx
@@ -1,0 +1,5 @@
+import { FC } from 'react';
+
+const TransactionService: FC = () => null;
+
+export default TransactionService;

--- a/packages/transactions/src/bootstrap.tsx
+++ b/packages/transactions/src/bootstrap.tsx
@@ -1,0 +1,5 @@
+import App from './App';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/packages/transactions/tsconfig.json
+++ b/packages/transactions/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "outDir": "./dist",
+  "rootDir": "./src",
+  "strict": false
+}

--- a/packages/transactions/tsconfig.json
+++ b/packages/transactions/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "outDir": "./dist",
-  "rootDir": "./src",
-  "strict": false
+  "rootDir": "./src"
 }

--- a/packages/transactions/webpack.config.js
+++ b/packages/transactions/webpack.config.js
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ModuleFederationPlugin =
+  require('webpack').container.ModuleFederationPlugin;
+const path = require('path');
+const deps = require('./package.json').dependencies;
+const webpack = require('webpack');
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+const ReactRefreshTypeScript = require('react-refresh-typescript');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+
+module.exports = {
+  entry: './src/index',
+  mode: isDevelopment ? 'development' : 'production',
+  devServer: {
+    static: path.join(__dirname, 'dist'),
+    port: 3005,
+    historyApiFallback: true,
+    hot: true,
+  },
+  output: {
+    publicPath: 'auto',
+    chunkFilename: '[id].[contenthash].js',
+  },
+  optimization: {
+    runtimeChunk: 'single',
+  },
+  resolve: {
+    extensions: ['.js', '.ts', '.tsx', '.css'],
+  },
+
+  module: {
+    rules: [
+      {
+        test: /\.[t|j]sx?$/,
+        loader: 'swc-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'transactions',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './TransactionService': './src/TransactionService',
+      },
+      shared: {
+        ...deps,
+        react: {
+          singleton: true,
+          requiredVersion: deps.react,
+        },
+        'react-dom': {
+          singleton: true,
+          requiredVersion: deps['react-dom'],
+        },
+        '@openmsupply-client/common': {
+          requiredVersion: require('../common/package.json').version,
+        },
+      },
+    }),
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+    }),
+    isDevelopment && new webpack.HotModuleReplacementPlugin(),
+    isDevelopment && new ReactRefreshWebpackPlugin(),
+  ].filter(Boolean),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,6 +1328,18 @@
   dependencies:
     "@octokit/openapi-types" "^9.1.0"
 
+"@pmmmwh/react-refresh-webpack-plugin@https://github.com/pmmmwh/react-refresh-webpack-plugin":
+  version "0.5.0-rc.2"
+  resolved "https://github.com/pmmmwh/react-refresh-webpack-plugin#fbe1f270de46c4a308d996a4487653a95aebfc25"
+  dependencies:
+    ansi-html "^0.0.7"
+    core-js-pure "^3.8.1"
+    error-stack-parser "^2.0.6"
+    html-entities "^2.1.0"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+    source-map "^0.7.3"
+
 "@polka/url@^1.0.0-next.15":
   version "1.0.0-next.15"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.15.tgz#6a9d143f7f4f49db2d782f9e1c8839a29b43ae23"
@@ -2967,6 +2979,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js-pure@^3.8.1:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.16.0.tgz#218e07add3f1844e53fab195c47871fc5ba18de8"
+  integrity sha512-wzlhZNepF/QA9yvx3ePDgNGudU5KDB8lu/TRPKelYA/QtSnkS/cLl2W+TIdEX1FAFcBr0YpY7tPDlcmXJ7AyiQ==
+
 core-js@^2.6.10:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
@@ -3575,6 +3592,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
+  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
+  dependencies:
+    stackframe "^1.1.1"
 
 es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-abstract@^1.18.2:
   version "1.18.3"
@@ -4656,7 +4680,7 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-html-entities@^2.3.2:
+html-entities@^2.1.0, html-entities@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.2.tgz#760b404685cb1d794e4f4b744332e3b00dcfe488"
   integrity sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==
@@ -7340,6 +7364,16 @@ react-redux@^7.2.4:
     prop-types "^15.7.2"
     react-is "^16.13.1"
 
+react-refresh-typescript@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-refresh-typescript/-/react-refresh-typescript-2.0.2.tgz#5108257b5437e186e8db3e9276b376b5f859ffc2"
+  integrity sha512-Gevwf67IgOFZW2ub/tZ8gmcXawWnhMuoFjCW85v4LcOzMgD2PMrH2zkr3sie2Y2bvLp/7tpRdhbG0yshxlJYHw==
+
+react-refresh@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
+  integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
+
 react-resize-detector@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-2.3.0.tgz#57bad1ae26a28a62a2ddb678ba6ffdf8fa2b599c"
@@ -8359,6 +8393,11 @@ ssri@^6.0.0, ssri@^6.0.1:
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
+
+stackframe@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
+  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Fixes #12  - kind of

- Aim was to get HMR 'working'. This only works when you are working on the standalone MFE. I.e. if we run this branch and go to `localhost:3005` - HMR is working, but it wouldn't work if I had a `TransactionService` imported into `Host`- the `TransactionService` wouldn't auto-replace.
- I think this isn't ideal but it is still useful. I could see us developing the 'main container' - i.e. with the appbar and top bar as components, and the `transactions` MFE could use that container as it's primary app, so that when you're developing transactions, you just use the specific url for that MFE. I think there's issues when a MFE starts utilizing other MFE's, though ..
- I chose `transactions` because the ui designs and also the backend team seem to be looking at customer invoices, so I figure we should just start with that.
- The `pmmmwh` dep is a bit dodge - needed this for it to work, which isn't in the latest release.. : https://github.com/pmmmwh/react-refresh-webpack-plugin/pull/392 