### PR TITLE
#36 customer package navigation

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useRemoteFn } from './useRemoteFn';
 export { useRemoteScript } from './useRemoteScript';
+export { useDrawer } from './useDrawer';
+export { useLocalStorageSync } from './useLocalStorageSync';

--- a/packages/common/src/hooks/useDrawer.ts
+++ b/packages/common/src/hooks/useDrawer.ts
@@ -1,0 +1,23 @@
+import { useLocalStorageSync } from './useLocalStorageSync';
+
+interface DrawerController {
+  open: boolean;
+  closeDrawer: () => void;
+  openDrawer: () => void;
+}
+
+export const useDrawer = (): DrawerController => {
+  const { value, setItem } = useLocalStorageSync<boolean>(
+    '@openmsupply-client/appdrawer/open'
+  );
+
+  return {
+    open: !!value,
+    closeDrawer() {
+      setItem(false);
+    },
+    openDrawer() {
+      setItem(true);
+    },
+  };
+};

--- a/packages/common/src/hooks/useLocalStorageSync.ts
+++ b/packages/common/src/hooks/useLocalStorageSync.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 
 type LocalStorageSetter<T> = {

--- a/packages/common/src/ui/components/NavLink.tsx
+++ b/packages/common/src/ui/components/NavLink.tsx
@@ -8,7 +8,7 @@ import { useMatch, Link } from 'react-router-dom';
 const useStyles = makeStyles(theme => ({
   drawerMenuItem: {
     height: 32,
-    marginTop: '20px',
+    marginTop: 20,
     '& svg': { ...theme.mixins.icon.medium },
     '&:hover': {
       backgroundColor: theme.palette.background.white,

--- a/packages/common/src/ui/components/NavLink.tsx
+++ b/packages/common/src/ui/components/NavLink.tsx
@@ -8,7 +8,7 @@ import { useMatch, Link } from 'react-router-dom';
 const useStyles = makeStyles(theme => ({
   drawerMenuItem: {
     height: 32,
-    margin: '20px 0',
+    marginTop: '20px',
     '& svg': { ...theme.mixins.icon.medium },
     '&:hover': {
       backgroundColor: theme.palette.background.white,
@@ -22,7 +22,6 @@ const useStyles = makeStyles(theme => ({
 }));
 
 interface ListItemLinkProps {
-  classes: Record<string, string>;
   to: string;
   icon: JSX.Element;
   text?: string;
@@ -30,7 +29,7 @@ interface ListItemLinkProps {
 
 export const AppNavLink: FC<ListItemLinkProps> = props => {
   const classes = useStyles();
-  const selected = useMatch({ path: props.to + '/*' });
+  const selected = useMatch({ path: props.to });
 
   const CustomLink = React.useMemo(
     () =>

--- a/packages/common/src/ui/components/index.ts
+++ b/packages/common/src/ui/components/index.ts
@@ -1,3 +1,4 @@
+import Collapse from '@material-ui/core/Collapse';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -5,4 +6,4 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 export * from './LoadingApp';
 export * from './RemoteComponent';
 export { AppNavLink } from './NavLink';
-export { Typography, CircularProgress, Divider };
+export { Typography, CircularProgress, Divider, Collapse };

--- a/packages/customers/src/CustomerContainer.tsx
+++ b/packages/customers/src/CustomerContainer.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react';
 
-// This is a remote service which is exposed by this package.
-// This component can be imported by another remote who declares
-// this package as a remote in their webpack config and imported through:
-// React.lazy(() => import("template/service"))
+const TransactionService = React.lazy(
+  () => import('transactions/TransactionService')
+);
 
 const CustomerContainer: FC = () => {
-  return <span>This is the customer service!</span>;
+  return <TransactionService />;
 };
 
 export default CustomerContainer;

--- a/packages/customers/src/Nav.tsx
+++ b/packages/customers/src/Nav.tsx
@@ -1,0 +1,42 @@
+import React, { FC, useEffect } from 'react';
+import { useMatch } from 'react-router-dom';
+import {
+  Customers,
+  Collapse,
+  List,
+  useDrawer,
+  AppNavLink,
+} from '@openmsupply-client/common';
+
+const useNestedNav = (path: string) => {
+  const { open } = useDrawer();
+  const match = useMatch(path);
+  const [expanded, setExpanded] = React.useState(false);
+
+  useEffect(() => {
+    setExpanded(!!match);
+  }, [match]);
+
+  return { isActive: open && expanded };
+};
+
+const Nav: FC = () => {
+  const { isActive } = useNestedNav('customer/*');
+
+  return (
+    <>
+      <AppNavLink to="customers" icon={<Customers />} text="Customers" />
+      <Collapse in={isActive}>
+        <List>
+          <AppNavLink
+            to="/customers/customer-invoice"
+            icon={<span style={{ width: 20 }} />}
+            text="Customer Invoices"
+          />
+        </List>
+      </Collapse>
+    </>
+  );
+};
+
+export default Nav;

--- a/packages/customers/src/types.d.ts
+++ b/packages/customers/src/types.d.ts
@@ -1,0 +1,3 @@
+declare module 'transactions/TransactionService' {
+  export default function (): JSX.Element;
+}

--- a/packages/customers/webpack.config.js
+++ b/packages/customers/webpack.config.js
@@ -42,11 +42,12 @@ module.exports = {
       // from other remote packages to refer to this package.
       name: 'customers',
       filename: 'remoteEntry.js',
+      remotes: {
+        transactions: 'transactions@http://localhost:3005/remoteEntry.js',
+      },
       exposes: {
-        // ${UPDATE} : Expose all of this packages components here.
-        // They can be imported from other remotes through the syntax
-        // React.lazy(() => import('${name of this service}/${key of an exposed component}'))
         './CustomerContainer': './src/CustomerContainer',
+        './Nav': './src/Nav',
       },
       // Shared dependencies can be updated, but these defaults should suffice.
       // These defaults will share to all other remotes, all of the dependencies in this packages

--- a/packages/host/src/AppDrawer.tsx
+++ b/packages/host/src/AppDrawer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Customers,
   Dashboard,
   Divider,
   Drawer,
@@ -16,11 +15,11 @@ import {
   Suppliers,
   Tools,
   makeStyles,
-  ReceiptIcon,
   AppNavLink,
 } from '@openmsupply-client/common';
-
 import clsx from 'clsx';
+
+const CustomersNav = React.lazy(() => import('customers/Nav'));
 
 const useStyles = makeStyles(theme => ({
   toolbarIcon: {
@@ -89,62 +88,24 @@ interface MenuProps {
 const Menu: React.FC<MenuProps> = ({ classes }) => (
   <div className={classes['drawerMenu']}>
     <List>
-      <AppNavLink
-        to="dashboard"
-        icon={<Dashboard />}
-        text="Dashboard"
-        classes={classes}
-      />
-      <AppNavLink
-        to="customers"
-        icon={<Customers />}
-        text="Customers"
-        classes={classes}
-      />
-      <AppNavLink
-        to="suppliers"
-        icon={<Suppliers />}
-        text="Suppliers"
-        classes={classes}
-      />
-      <AppNavLink to="stock" icon={<Stock />} text="Stock" classes={classes} />
-      <AppNavLink to="tools" icon={<Tools />} text="Tools" classes={classes} />
-      <AppNavLink
-        to="reports"
-        icon={<Reports />}
-        text="Reports"
-        classes={classes}
-      />
-      <AppNavLink
-        to="messages"
-        icon={<Messages />}
-        text="Messages"
-        classes={classes}
-      />
-      <AppNavLink
-        to="transactions"
-        icon={<ReceiptIcon />}
-        text="Transactions"
-        classes={classes}
-      />
+      <React.Suspense fallback={null}>
+        <CustomersNav />
+      </React.Suspense>
+      <AppNavLink to="dashboard" icon={<Dashboard />} text="Dashboard" />
+
+      <AppNavLink to="suppliers" icon={<Suppliers />} text="Suppliers" />
+      <AppNavLink to="stock" icon={<Stock />} text="Stock" />
+      <AppNavLink to="tools" icon={<Tools />} text="Tools" />
+      <AppNavLink to="reports" icon={<Reports />} text="Reports" />
+      <AppNavLink to="messages" icon={<Messages />} text="Messages" />
     </List>
     <List>
       <Divider
         style={{ backgroundColor: '#555770', marginLeft: 8, width: 152 }}
       />
-      <AppNavLink to="sync" icon={<Radio />} text="Stock" classes={classes} />
-      <AppNavLink
-        to="admin"
-        icon={<Settings />}
-        text="Admin"
-        classes={classes}
-      />
-      <AppNavLink
-        to="logout"
-        icon={<Power />}
-        text="Logout"
-        classes={classes}
-      />
+      <AppNavLink to="sync" icon={<Radio />} text="Stock" />
+      <AppNavLink to="admin" icon={<Settings />} text="Admin" />
+      <AppNavLink to="logout" icon={<Power />} text="Logout" />
     </List>
   </div>
 );

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -7,12 +7,13 @@ import {
   QueryClient,
   ReactQueryDevtools,
   QueryClientProvider,
+  useDrawer,
 } from '@openmsupply-client/common';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import AppDrawer from './AppDrawer';
 import AppBar from './AppBar';
 import Viewport from './Viewport';
-import { useLocalStorageSync } from './useLocalStorageSync';
+
 import { ServiceProvider } from './Service';
 
 const queryClient = new QueryClient();
@@ -21,25 +22,6 @@ const CustomerContainer = React.lazy(
   () => import('customers/CustomerContainer')
 );
 const DashboardService = React.lazy(() => import('dashboard/DashboardService'));
-const TransactionService = React.lazy(
-  () => import('transactions/TransactionService')
-);
-
-const useDrawer = () => {
-  const { value, setItem } = useLocalStorageSync<boolean>(
-    '@openmsupply-client/appdrawer/open'
-  );
-
-  return {
-    open: value,
-    closeDrawer() {
-      setItem(false);
-    },
-    openDrawer() {
-      setItem(true);
-    },
-  };
-};
 
 const Heading: FC = props => (
   <Typography style={{ margin: '100px 50px' }}>[ {props.children} ]</Typography>
@@ -86,10 +68,6 @@ const Host: FC = () => {
                       <Route
                         path="messages/*"
                         element={<Heading>messages</Heading>}
-                      />
-                      <Route
-                        path="transactions/*"
-                        element={<TransactionService />}
                       />
 
                       <Route

--- a/packages/host/src/types.d.ts
+++ b/packages/host/src/types.d.ts
@@ -9,3 +9,7 @@ declare module 'transactions/TransactionService' {
 declare module 'customers/CustomerContainer' {
   export default function (): JSX.Element;
 }
+
+declare module 'customers/Nav' {
+  export default function (): JSX.Element;
+}

--- a/packages/transactions/src/TransactionService.tsx
+++ b/packages/transactions/src/TransactionService.tsx
@@ -116,7 +116,7 @@ const Transactions: FC = () => {
         checkboxSelection
         hideFooterSelectedRowCount
         onRowClick={params => {
-          navigate(`/transactions/${params.id}`);
+          navigate(`/customers/customer-invoice/${params.id}`);
         }}
       />
     </div>
@@ -126,8 +126,8 @@ const Transactions: FC = () => {
 const TransactionService: FC = () => {
   return (
     <Routes>
-      <Route path="*" element={<Transactions />} />
-      <Route path=":id" element={<Transaction />} />
+      <Route path="/customer-invoice" element={<Transactions />} />
+      <Route path="/customer-invoice/:id" element={<Transaction />} />
     </Routes>
   );
 };


### PR DESCRIPTION
Fixes #36

This is adding the customer navigation to the app drawer

![image](https://user-images.githubusercontent.com/35858975/128448775-ca302953-ce1f-4060-8f70-9a9e93c19463.png)


![image](https://user-images.githubusercontent.com/35858975/128448788-69dcdaa4-ac10-438f-92c5-389bfd77dde6.png)

Thought this was enough for the PR for now. Some things in new PRs

- The drawer state is not correctly shared and can get munged. Need to essentially share the state between all `useDrawer` hook usages. Few options here
- Similar to the drawer state, the 'title' needs to be updated better. Can continue using the service context that's in the host package, however that will cause a re-render of the whole app which isn't ideal and I think a solution for both the drawer and title could be used.
- Breadcrumbs - a bit annoying to do this one but likely going to be a similar state that needs to be updated from many different places, same as the above two
- Styling: Not looking correct right now
- 'selected state' - need an update to the `common/AppNavLink` component
- Routes/navigation tidy in general - constants for routes/components to encapsulate more of the code
