### PR TITLE
#81 remote some make styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     ]
   },
   "devDependencies": {
+    "@emotion/styled": "^11.0.0-next.19",
     "@storybook/addon-actions": "^6.3.7",
     "@storybook/addon-essentials": "^6.3.7",
     "@storybook/addon-links": "^6.3.7",
@@ -28,8 +29,10 @@
     "@swc/cli": "^0.1.46",
     "@swc/core": "^1.2.66",
     "@swc/jest": "^0.2.2",
+    "@testing-library/dom": "^8.2.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
+    "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.6.1",
     "@types/react": "^17.0.14",
@@ -43,6 +46,9 @@
     "lerna": "^3.22.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "resolutions": {
+    "**/@emotion/styled": "^11.0.0"
   },
   "lint-staged": {
     "src/**/*.+(js|json|ts|tsx)": [

--- a/packages/common/src/intl/IntlTestProvider.tsx
+++ b/packages/common/src/intl/IntlTestProvider.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { IntlProvider as ReactIntlProvider } from 'react-intl';
 import { LocaleMessages, SupportedLocales } from './intlHelpers';
 import en from './locales/en.json';
 import fr from './locales/fr.json';
 import pt from './locales/pt.json';
 import ar from './locales/ar.json';
+import { useHostContext } from '../hooks';
 
 const locales: Record<SupportedLocales, LocaleMessages> = {
   en,
@@ -21,6 +22,12 @@ export const IntlTestProvider: FC<IntlTestProviderProps> = ({
   children,
   locale,
 }) => {
+  const { locale: currentLocale, setLocale } = useHostContext();
+
+  useEffect(() => {
+    if (currentLocale !== locale) setLocale(locale);
+  }, [locale]);
+
   return (
     <ReactIntlProvider locale="en" messages={locales[locale]}>
       {children}

--- a/packages/common/src/intl/locales/en.json
+++ b/packages/common/src/intl/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app.admin": "Admin",
   "app.customer_invoices": "Customer Invoices",
-  "app.customer-invoice": "Customer Invoices",
+  "app.customer-invoice": "Invoices",
   "app.customer-requisition": "Requisitions",
   "app.customers": "Customers",
   "app.dashboard": "Dashboard",

--- a/packages/common/src/styles/index.ts
+++ b/packages/common/src/styles/index.ts
@@ -2,18 +2,19 @@ import { RTLProvider } from './RTLProvider';
 import { useAppTheme } from './useAppTheme';
 import AppThemeProvider from './ThemeProvider';
 import { styled } from '@material-ui/core/styles';
-import { useTheme } from '@material-ui/core/styles';
+import { Theme, useTheme } from '@material-ui/core/styles';
 import makeStyles from '@material-ui/styles/makeStyles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 export {
   AppThemeProvider,
-  makeStyles,
   CssBaseline,
+  RTLProvider,
+  Theme,
+  makeStyles,
   styled,
+  useAppTheme,
   useMediaQuery,
   useTheme,
-  useAppTheme,
-  RTLProvider,
 };

--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -69,5 +69,7 @@ const theme = createTheme(themeOptions);
 
 theme.shadows[1] =
   '0 4px 8px 0 rgba(96, 97, 112, 0.16), 0 0 2px 0 rgba(40, 41, 61, 0.04)';
+theme.shadows[2] =
+  '0 8px 16px 0 rgba(96, 97, 112, 0.16), 0 2px 4px 0 rgba(40, 41, 61, 0.04)';
 
 export default theme;

--- a/packages/common/src/ui/components/NavLink.tsx
+++ b/packages/common/src/ui/components/NavLink.tsx
@@ -25,9 +25,9 @@ const useSelectedNavMenuItem = (to: string, end: boolean): boolean => {
 };
 
 const getListItemCommonStyles = (isOpen: boolean) => ({
-  height: 32,
-  borderRadius: 16,
-  width: isOpen ? 160 : 32,
+  height: 40,
+  borderRadius: 20,
+  width: isOpen ? 160 : 40,
   justifyContent: 'center',
   alignItems: 'center',
 });
@@ -39,8 +39,8 @@ const StyledListItem = styled<
 })(({ theme, isOpen, isSelected }) => ({
   ...getListItemCommonStyles(isOpen),
   backgroundColor: isSelected ? theme.palette.background.white : 'transparent',
-  boxShadow: isSelected ? theme.shadows[8] : 'none',
-  marginTop: 20,
+  boxShadow: isSelected ? theme.shadows[2] : 'none',
+  marginTop: 5,
   '&:hover': {
     boxShadow: theme.shadows[8],
   },
@@ -79,7 +79,7 @@ export const AppNavLink: FC<ListItemLinkProps> = props => {
           disableGutters
           component={CustomLink}
         >
-          <ListItemIcon sx={{ minWidth: 24 }}>{icon}</ListItemIcon>
+          <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
           {drawer.isOpen && <Box width={10} />}
           {drawer.isOpen && <ListItemText primary={text} />}
         </ListItemButton>

--- a/packages/common/src/ui/components/NavLink.tsx
+++ b/packages/common/src/ui/components/NavLink.tsx
@@ -42,7 +42,6 @@ const StyledListItem = styled<
   boxShadow: isSelected ? theme.shadows[8] : 'none',
   marginTop: 20,
   '&:hover': {
-    backgroundColor: 'none',
     boxShadow: theme.shadows[8],
   },
 }));

--- a/packages/common/src/ui/components/NavLink.tsx
+++ b/packages/common/src/ui/components/NavLink.tsx
@@ -30,27 +30,22 @@ const getListItemCommonStyles = (isOpen: boolean) => ({
   width: isOpen ? 160 : 32,
   justifyContent: 'center',
   alignItems: 'center',
-  // ...(isOpen && {width: 160})
 });
 
 const StyledListItem = styled<
   FC<ListItemProps & { isOpen: boolean; isSelected: boolean; to: string }>
 >(ListItem, {
   shouldForwardProp: prop => prop !== 'isSelected' && prop !== 'isOpen',
-})(({ theme, isOpen, isSelected }) => {
-  return {
-    ...getListItemCommonStyles(isOpen),
-    backgroundColor: isSelected
-      ? theme.palette.background.white
-      : 'transparent',
-    boxShadow: isSelected ? theme.shadows[8] : 'none',
-    marginTop: 20,
-    '&:hover': {
-      backgroundColor: 'none',
-      boxShadow: theme.shadows[8],
-    },
-  };
-});
+})(({ theme, isOpen, isSelected }) => ({
+  ...getListItemCommonStyles(isOpen),
+  backgroundColor: isSelected ? theme.palette.background.white : 'transparent',
+  boxShadow: isSelected ? theme.shadows[8] : 'none',
+  marginTop: 20,
+  '&:hover': {
+    backgroundColor: 'none',
+    boxShadow: theme.shadows[8],
+  },
+}));
 
 interface ListItemLinkProps {
   end?: boolean; // denotes lowest level menu item, using terminology from useMatch

--- a/packages/common/src/ui/components/NavLink.tsx
+++ b/packages/common/src/ui/components/NavLink.tsx
@@ -1,26 +1,56 @@
 import React, { FC } from 'react';
 
-import clsx from 'clsx';
-import { ListItem, ListItemText, Tooltip } from '@material-ui/core';
-import makeStyles from '@material-ui/styles/makeStyles';
+import {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  ListItemButton,
+} from '@material-ui/core';
 import { useMatch, Link } from 'react-router-dom';
 import { useDrawer } from '../../hooks/useDrawer';
+import { styled } from '@material-ui/core/styles';
+import { ListItemProps } from 'material-ui';
+import { Box } from '@material-ui/system';
 
-const useStyles = makeStyles(theme => ({
-  drawerMenuItem: {
-    height: 32,
+const useSelectedNavMenuItem = (to: string, end: boolean): boolean => {
+  // This nav menu item should be selected when lower level elements
+  // are selected. For example, the route /customer-invoices/{id} should
+  // highlight the nav menu item for customer-invoices.
+  const highlightLowerLevels = !end || to.endsWith('*');
+  // If we need to highlight the higher levels append a wildcard to the match path.
+  const path = highlightLowerLevels ? to : `${to}/*`;
+  const selected = useMatch({ path });
+  return !!selected;
+};
+
+const getListItemCommonStyles = (isOpen: boolean) => ({
+  height: 32,
+  borderRadius: 16,
+  width: isOpen ? 160 : 32,
+  justifyContent: 'center',
+  alignItems: 'center',
+  // ...(isOpen && {width: 160})
+});
+
+const StyledListItem = styled<
+  FC<ListItemProps & { isOpen: boolean; isSelected: boolean; to: string }>
+>(ListItem, {
+  shouldForwardProp: prop => prop !== 'isSelected' && prop !== 'isOpen',
+})(({ theme, isOpen, isSelected }) => {
+  return {
+    ...getListItemCommonStyles(isOpen),
+    backgroundColor: isSelected
+      ? theme.palette.background.white
+      : 'transparent',
+    boxShadow: isSelected ? theme.shadows[8] : 'none',
     marginTop: 20,
-    '& svg': { ...theme.mixins.icon.medium },
     '&:hover': {
-      backgroundColor: theme.palette.background.white,
+      backgroundColor: 'none',
       boxShadow: theme.shadows[8],
     },
-  },
-  drawerMenuItemSelected: {
-    backgroundColor: `${theme.palette.background.white}!important`,
-    boxShadow: theme.shadows[4],
-  },
-}));
+  };
+});
 
 interface ListItemLinkProps {
   end?: boolean; // denotes lowest level menu item, using terminology from useMatch
@@ -29,21 +59,7 @@ interface ListItemLinkProps {
   to: string;
 }
 
-const useSelectedNavMenuItem = (to: string, end: boolean): boolean => {
-  // This nav menu item should be selected when lower level elements
-  // are selected. For example, the route /customer-invoices/{id} should
-  // highlight the nav menu item for customer-invoices.
-  const highlightLowerLevels = !end || to.endsWith('*');
-
-  // If we need to highlight the higher levels append a wildcard to the match path.
-  const path = highlightLowerLevels ? to : `${to}/*`;
-
-  const selected = useMatch({ path });
-  return !!selected;
-};
-
 export const AppNavLink: FC<ListItemLinkProps> = props => {
-  const classes = useStyles();
   const { end, icon = <span style={{ width: 2 }} />, text, to } = props;
   const drawer = useDrawer();
   const selected = useSelectedNavMenuItem(to, !!end);
@@ -55,24 +71,25 @@ export const AppNavLink: FC<ListItemLinkProps> = props => {
       )),
     [to]
   );
-  const className = clsx(
-    classes['drawerMenuItem'],
-    !!selected && classes['drawerMenuItemSelected']
-  );
 
   return (
-    <li>
-      <Tooltip disableHoverListener={drawer.isOpen} title={text || ''}>
-        <ListItem
-          selected={selected}
-          button
+    <Tooltip disableHoverListener={drawer.isOpen} title={text || ''}>
+      <StyledListItem isOpen={drawer.isOpen} isSelected={selected} to={to}>
+        <ListItemButton
+          sx={{
+            ...getListItemCommonStyles(drawer.isOpen),
+            '&.MuiListItemButton-root:hover': {
+              backgroundColor: 'transparent',
+            },
+          }}
+          disableGutters
           component={CustomLink}
-          className={className}
         >
-          {icon}
-          <ListItemText primary={text} />
-        </ListItem>
-      </Tooltip>
-    </li>
+          <ListItemIcon sx={{ minWidth: 24 }}>{icon}</ListItemIcon>
+          {drawer.isOpen && <Box width={10} />}
+          {drawer.isOpen && <ListItemText primary={text} />}
+        </ListItemButton>
+      </StyledListItem>
+    </Tooltip>
   );
 };

--- a/packages/common/src/ui/components/buttons/styles.ts
+++ b/packages/common/src/ui/components/buttons/styles.ts
@@ -10,6 +10,8 @@ const defaultStyles = {
   marginLeft: 5,
   marginRight: 5,
   textTransform: 'none' as Property.TextTransform,
+  '&:hover': { color: '#fff' },
+  '&:hover svg': { color: '#fff' },
 };
 
 export const getButtonStyles = ({

--- a/packages/common/src/ui/icons/MSupplyGuy.tsx
+++ b/packages/common/src/ui/icons/MSupplyGuy.tsx
@@ -1,6 +1,17 @@
 import React, { FC } from 'react';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 import { styled } from '@material-ui/core/styles';
+import { keyframes } from '@material-ui/styled-engine';
+
+const spin = keyframes`
+  from {transform:rotate(0deg);}
+  to {transform:rotate(360deg);}
+}`;
+
+const otherSpin = keyframes`
+  from {transform:rotate(360deg);}
+  to {transform:rotate(0deg);}
+}`;
 
 const sizes = {
   large: { height: 60, width: 45 },
@@ -46,6 +57,17 @@ export const UnstyledGuy: FC<MSupplyGuyProps> = (svgProps): JSX.Element => (
   </SvgIcon>
 );
 
-export const MSupplyGuy = styled(UnstyledGuy)(({ size }) => ({
+export const MSupplyGuy = styled(UnstyledGuy)(({ theme, size }) => ({
   ...sizes[size],
+
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  '&:hover': {
+    animation:
+      size === 'large'
+        ? `${spin} 1s infinite ease`
+        : `${otherSpin} 1s infinite ease`,
+  },
 }));

--- a/packages/common/src/ui/icons/MSupplyGuy.tsx
+++ b/packages/common/src/ui/icons/MSupplyGuy.tsx
@@ -1,8 +1,18 @@
-import React from 'react';
+import React, { FC } from 'react';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
+import { styled } from '@material-ui/core/styles';
 
-export const MSupplyGuy = (props: SvgIconProps): JSX.Element => (
-  <SvgIcon {...props} viewBox="3 1 206 310">
+const sizes = {
+  large: { height: 60, width: 45 },
+  medium: { height: 40, width: 30 },
+};
+
+type MSupplyGuyProps = SvgIconProps & {
+  size: 'large' | 'medium';
+};
+
+export const UnstyledGuy: FC<MSupplyGuyProps> = (svgProps): JSX.Element => (
+  <SvgIcon {...svgProps} viewBox="3 1 206 310">
     <g>
       <linearGradient id="6000022348f0" x1="0.5" y1="0" x2="0.5" y2="1">
         <stop offset="0" stopColor="#fa7a0a" />
@@ -35,3 +45,7 @@ export const MSupplyGuy = (props: SvgIconProps): JSX.Element => (
     </g>
   </SvgIcon>
 );
+
+export const MSupplyGuy = styled(UnstyledGuy)(({ size }) => ({
+  ...sizes[size],
+}));

--- a/packages/common/src/utils/testing.tsx
+++ b/packages/common/src/utils/testing.tsx
@@ -1,9 +1,10 @@
 import React, { FC } from 'react';
-import { AppThemeProvider } from '../styles';
+import AppThemeProvider from '../styles/ThemeProvider';
 import { IntlTestProvider } from '../intl/IntlTestProvider';
 import { BrowserRouter } from 'react-router-dom';
 import { SupportedLocales } from '../intl/intlHelpers';
 import mediaQuery from 'css-mediaquery';
+
 interface TestingProviderProps {
   locale?: SupportedLocales;
 }
@@ -11,15 +12,13 @@ interface TestingProviderProps {
 export const TestingProvider: FC<TestingProviderProps> = ({
   children,
   locale = 'en',
-}) => {
-  return (
+}) => (
+  <IntlTestProvider locale={locale}>
     <AppThemeProvider>
-      <IntlTestProvider locale={locale}>
-        <BrowserRouter>{children}</BrowserRouter>
-      </IntlTestProvider>
+      <BrowserRouter>{children}</BrowserRouter>
     </AppThemeProvider>
-  );
-};
+  </IntlTestProvider>
+);
 
 function createMatchMedia(width: number) {
   return (query: any) => ({

--- a/packages/customers/src/Nav.tsx
+++ b/packages/customers/src/Nav.tsx
@@ -5,10 +5,10 @@ import {
   Collapse,
   List,
   useDrawer,
-  AppNavLink,
   useTranslation,
   RouteBuilder,
 } from '@openmsupply-client/common';
+import { AppNavLink } from '@openmsupply-client/common/src/ui/components/NavLink';
 import { AppRoute } from '@openmsupply-client/config';
 
 const useNestedNav = (path: string) => {

--- a/packages/customers/src/Nav.tsx
+++ b/packages/customers/src/Nav.tsx
@@ -33,7 +33,7 @@ const Nav: FC = () => {
       <AppNavLink
         end={!isActive}
         to={AppRoute.Customers}
-        icon={<Customers />}
+        icon={<Customers fontSize="small" />}
         text={t('app.customers')}
       />
       <Collapse in={isActive}>

--- a/packages/host/src/AppDrawer.stories.tsx
+++ b/packages/host/src/AppDrawer.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, ComponentMeta } from '@storybook/react';
 import AppDrawer from './AppDrawer';
-import { Box, TestingProvider } from '@openmsupply-client/common';
+import { TestingProvider } from '@openmsupply-client/common';
 import { SupportedLocales } from '@openmsupply-client/common/src/intl/intlHelpers';
 
 export default {
@@ -14,14 +14,13 @@ interface AppDrawerStoryArgs {
 }
 
 const Template: Story<AppDrawerStoryArgs> = args => (
-  <TestingProvider locale={args.locale}>
-    <Box display="flex" flex={1} height="100vh">
-      <AppDrawer />
-    </Box>
+  <TestingProvider {...args}>
+    <AppDrawer />
   </TestingProvider>
 );
 
 export const English = Template.bind({});
+English.args = 'en';
 
 export const French = Template.bind({});
 French.args = {
@@ -31,4 +30,9 @@ French.args = {
 export const Portuguese = Template.bind({});
 Portuguese.args = {
   locale: 'pt',
+};
+
+export const Arabic = Template.bind({});
+Arabic.args = {
+  locale: 'ar',
 };

--- a/packages/host/src/AppDrawer.test.tsx
+++ b/packages/host/src/AppDrawer.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import AppDrawer from './AppDrawer';
 import {
   setScreenSize_ONLY_FOR_TESTING,
@@ -8,78 +9,83 @@ import {
 import { act } from 'react-dom/test-utils';
 
 describe('AppDrawer', () => {
-  it('Collapses when clicking the drawer open/close button for the first time on a large screen', () => {
-    render(
+  it('Collapses when clicking the drawer open/close button for the first time on a large screen', async () => {
+    const { getByRole, getByTestId } = render(
       <TestingProvider>
         <AppDrawer />
       </TestingProvider>
     );
 
-    const button = screen.getByRole('button', { name: /Open the menu/i });
-    const drawer = screen.getByTestId('drawer');
+    const button = getByRole('button', { name: /Close the menu/i });
+    const drawer = getByTestId('drawer');
 
     act(() => {
-      fireEvent.click(button);
+      userEvent.click(button);
     });
 
-    expect(drawer).toHaveAttribute('aria-expanded', 'false');
+    await waitFor(() => {
+      expect(drawer).toHaveAttribute('aria-expanded', 'false');
+    });
   });
-  it('expands when clicking the drawer open/close button for the first time on a small screen', () => {
+  it('expands when clicking the drawer open/close button for the first time on a small screen', async () => {
     setScreenSize_ONLY_FOR_TESTING(1199);
-    render(
+    const { getByRole, getByTestId } = render(
       <TestingProvider>
         <AppDrawer />
       </TestingProvider>
     );
 
-    const button = screen.getByRole('button', { name: /Open the menu/i });
-    const drawer = screen.getByTestId('drawer');
+    const button = getByRole('button', { name: /Open the menu/i });
+    const drawer = getByTestId('drawer');
 
     act(() => {
-      fireEvent.click(button);
+      userEvent.click(button);
     });
 
-    expect(drawer).toHaveAttribute('aria-expanded', 'true');
+    await waitFor(() => {
+      expect(drawer).toHaveAttribute('aria-expanded', 'true');
+    });
   });
-  it('Text changes visibility when the menu is collapsed/expanded', () => {
-    render(
+  it('Text is visibility when the menu is expanded', async () => {
+    const { getByText } = render(
       <TestingProvider>
         <AppDrawer />
       </TestingProvider>
     );
 
-    const button = screen.getByRole('button', { name: /Open the menu/i });
-
-    let rootNavigationElements = [
-      screen.getByText(/dashboard/i),
-      screen.getByText(/customers/i),
-      screen.getByText(/suppliers/i),
-      screen.getByText(/stock/i),
-      screen.getByText(/tools/i),
-      screen.getByText(/reports/i),
-      screen.getByText(/messages/i),
-    ];
-
-    rootNavigationElements.forEach(element => {
-      expect(element).toBeVisible();
+    await waitFor(() => {
+      expect(getByText(/customers/i)).toBeVisible();
+      expect(getByText(/dashboard/i)).toBeVisible();
+      expect(getByText(/customers/i)).toBeVisible();
+      expect(getByText(/suppliers/i)).toBeVisible();
+      expect(getByText(/stock/i)).toBeVisible();
+      expect(getByText(/tools/i)).toBeVisible();
+      expect(getByText(/reports/i)).toBeVisible();
+      expect(getByText(/messages/i)).toBeVisible();
     });
+  });
+  it('Text is invisible when the menu is collapsed', async () => {
+    const { getByText } = render(
+      <TestingProvider>
+        <AppDrawer />
+      </TestingProvider>
+    );
+
+    const button = screen.getByRole('button', { name: /Close the menu/i });
 
     act(() => {
-      fireEvent.click(button);
+      userEvent.click(button);
     });
 
-    rootNavigationElements = [
-      screen.getByText(/dashboard/i),
-      screen.getByText(/customers/i),
-      screen.getByText(/suppliers/i),
-      screen.getByText(/stock/i),
-      screen.getByText(/tools/i),
-      screen.getByText(/reports/i),
-      screen.getByText(/messages/i),
-    ];
-
-    rootNavigationElements.forEach(element => {
-      expect(element).not.toBeVisible();
+    waitFor(() => {
+      expect(getByText(/customers/i)).not.toBeVisible();
+      expect(getByText(/dashboard/i)).not.toBeVisible();
+      expect(getByText(/customers/i)).not.toBeVisible();
+      expect(getByText(/suppliers/i)).not.toBeVisible();
+      expect(getByText(/stock/i)).not.toBeVisible();
+      expect(getByText(/tools/i)).not.toBeVisible();
+      expect(getByText(/reports/i)).not.toBeVisible();
+      expect(getByText(/messages/i)).not.toBeVisible();
     });
   });
 });

--- a/packages/host/src/AppDrawer.tsx
+++ b/packages/host/src/AppDrawer.tsx
@@ -16,13 +16,15 @@ import {
   Tools,
   makeStyles,
   useTranslation,
-  AppNavLink,
   useDrawer,
   useMediaQuery,
   useTheme,
+  styled,
+  Box,
 } from '@openmsupply-client/common';
-import clsx from 'clsx';
 import { AppRoute } from '@openmsupply-client/config';
+import { AppNavLink } from '@openmsupply-client/common/src/ui/components/NavLink';
+import * as CSS from 'csstype';
 
 const CustomersNav = React.lazy(
   () => import('@openmsupply-client/customers/src/Nav')
@@ -42,118 +44,76 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     height: '100%',
     justifyContent: 'space-between',
-    paddingLeft: 15,
   },
-  drawerMenuItem: {
-    height: 32,
-    margin: '16px 0',
-    '& svg': { ...theme.mixins.icon.medium },
-    '&:hover': {
-      backgroundColor: theme.palette.background.white,
-      boxShadow: theme.shadows[8],
-    },
-  },
-  drawerMenuItemSelected: {
-    backgroundColor: `${theme.palette.background.white}!important`,
-    boxShadow: theme.shadows[4],
-  },
-  drawerPaper: {
-    backgroundColor: theme.palette.background.menu,
-    position: 'relative',
-    whiteSpace: 'nowrap',
-    width: 200,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    borderRadius: 8,
-    boxShadow: theme.shadows[7],
-    '& li': { height: 45, display: 'flex', alignItems: 'center' },
-    '& li > a': { borderRadius: 16, padding: '4px 8px', width: 168 },
-    '& li > a > div': { marginLeft: 8 },
-  },
-  drawerPaperClose: {
-    overflowX: 'hidden',
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    width: theme.spacing(7),
-    [theme.breakpoints.up('sm')]: {
-      width: theme.spacing(9),
-    },
-    '& li > a': { borderRadius: 20, height: 40, padding: 10, width: 40 },
-    '& li > a > div': { display: 'none' },
-    '& ul > hr': { display: 'none' },
-  },
+
   mSupplyGuy: { height: 60, width: 45 },
   mSupplyGuySmall: { height: 40, width: 30 },
 }));
 
-interface MenuProps {
-  classes: Record<string, string>;
-}
-const Menu: React.FC<MenuProps> = ({ classes }) => {
-  const t = useTranslation();
-  return (
-    <div className={classes['drawerMenu']}>
-      <List>
-        <AppNavLink
-          to={AppRoute.Dashboard}
-          icon={<Dashboard />}
-          text={t('app.dashboard')}
-        />
-        <React.Suspense fallback={null}>
-          <CustomersNav />
-        </React.Suspense>
-        <AppNavLink
-          to={AppRoute.Suppliers}
-          icon={<Suppliers />}
-          text={t('app.suppliers')}
-        />
-        <AppNavLink
-          to={AppRoute.Stock}
-          icon={<Stock />}
-          text={t('app.stock')}
-        />
-        <AppNavLink
-          to={AppRoute.Tools}
-          icon={<Tools />}
-          text={t('app.tools')}
-        />
-        <AppNavLink
-          to={AppRoute.Reports}
-          icon={<Reports />}
-          text={t('app.reports')}
-        />
-        <AppNavLink
-          to={AppRoute.Messages}
-          icon={<Messages />}
-          text={t('app.messages')}
-        />
-      </List>
-      <List>
-        <Divider
-          style={{ backgroundColor: '#555770', marginLeft: 8, width: 152 }}
-        />
-        <AppNavLink to={AppRoute.Sync} icon={<Radio />} text={t('app.sync')} />
-        <AppNavLink
-          to={AppRoute.Admin}
-          icon={<Settings />}
-          text={t('app.admin')}
-        />
-        <AppNavLink
-          to={AppRoute.Logout}
-          icon={<Power />}
-          text={t('app.logout')}
-        />
-      </List>
-    </div>
-  );
-};
+const ListContainer = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  justifyContent: 'space-between',
+});
+
+const StyledDivider = styled(Divider)({
+  backgroundColor: '#555770',
+  marginLeft: 8,
+  width: 152,
+});
+
+const drawerWidth = 200;
+
+const openedMixin = theme => ({
+  boxSizing: 'border-box' as CSS.Property.BoxSizing,
+  width: drawerWidth,
+  overflow: 'hidden',
+  paddingLeft: 16,
+  paddingRight: 16,
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.enteringScreen,
+  }),
+});
+
+const closedMixin = theme => ({
+  boxSizing: 'border-box' as CSS.Property.BoxSizing,
+  paddingLeft: 24,
+  paddingRight: 24,
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  overflow: 'hidden',
+  [theme.breakpoints.up('sm')]: {
+    width: theme.spacing(10),
+  },
+});
+
+const StyledDrawer = styled(Drawer)(({ open, theme }) => {
+  return {
+    backgroundColor: theme.palette.background.menu,
+    position: 'relative',
+    whiteSpace: 'nowrap',
+    borderRadius: 8,
+    overflow: 'hidden',
+    boxShadow: theme.shadows[7],
+
+    ...(open && {
+      ...openedMixin(theme),
+      '& .MuiDrawer-paper': openedMixin(theme),
+    }),
+    ...(!open && {
+      ...closedMixin(theme),
+      '& .MuiDrawer-paper': closedMixin(theme),
+    }),
+  };
+});
 
 const AppDrawer: React.FC = () => {
   const theme = useTheme();
+  const t = useTranslation();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'));
   const classes = useStyles();
   const drawer = useDrawer();
@@ -165,16 +125,10 @@ const AppDrawer: React.FC = () => {
   }, [isSmallScreen]);
 
   return (
-    <Drawer
+    <StyledDrawer
       data-testid="drawer"
       variant="permanent"
       aria-expanded={drawer.isOpen}
-      classes={{
-        paper: clsx(
-          classes.drawerPaper,
-          !drawer.isOpen && classes.drawerPaperClose
-        ),
-      }}
       open={drawer.isOpen}
     >
       <div className={classes.toolbarIcon}>
@@ -194,8 +148,62 @@ const AppDrawer: React.FC = () => {
           }
         />
       </div>
-      <Menu classes={classes} />
-    </Drawer>
+      <ListContainer>
+        <List>
+          <AppNavLink
+            to={AppRoute.Dashboard}
+            icon={<Dashboard />}
+            text={t('app.dashboard')}
+          />
+          <React.Suspense fallback={null}>
+            <CustomersNav />
+          </React.Suspense>
+          <AppNavLink
+            to={AppRoute.Suppliers}
+            icon={<Suppliers />}
+            text={t('app.suppliers')}
+          />
+          <AppNavLink
+            to={AppRoute.Stock}
+            icon={<Stock />}
+            text={t('app.stock')}
+          />
+          <AppNavLink
+            to={AppRoute.Tools}
+            icon={<Tools />}
+            text={t('app.tools')}
+          />
+          <AppNavLink
+            to={AppRoute.Reports}
+            icon={<Reports />}
+            text={t('app.reports')}
+          />
+          <AppNavLink
+            to={AppRoute.Messages}
+            icon={<Messages />}
+            text={t('app.messages')}
+          />
+        </List>
+        <List>
+          {drawer.isOpen && <StyledDivider />}
+          <AppNavLink
+            to={AppRoute.Sync}
+            icon={<Radio />}
+            text={t('app.sync')}
+          />
+          <AppNavLink
+            to={AppRoute.Admin}
+            icon={<Settings />}
+            text={t('app.admin')}
+          />
+          <AppNavLink
+            to={AppRoute.Logout}
+            icon={<Power />}
+            text={t('app.logout')}
+          />
+        </List>
+      </ListContainer>
+    </StyledDrawer>
   );
 };
 

--- a/packages/host/src/AppDrawer.tsx
+++ b/packages/host/src/AppDrawer.tsx
@@ -14,7 +14,6 @@ import {
   Stock,
   Suppliers,
   Tools,
-  makeStyles,
   useTranslation,
   useDrawer,
   useMediaQuery,
@@ -30,24 +29,13 @@ const CustomersNav = React.lazy(
   () => import('@openmsupply-client/customers/src/Nav')
 );
 
-const useStyles = makeStyles(theme => ({
-  toolbarIcon: {
-    display: 'flex',
-    height: 90,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-  },
-  drawerMenu: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-    justifyContent: 'space-between',
-  },
-
-  mSupplyGuy: { height: 60, width: 45 },
-  mSupplyGuySmall: { height: 40, width: 30 },
+const ToolbarIconContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  height: 90,
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '0 8px',
+  ...theme.mixins.toolbar,
 }));
 
 const ListContainer = styled(Box)({
@@ -64,13 +52,14 @@ const StyledDivider = styled(Divider)({
 });
 
 const drawerWidth = 200;
+const gutterSize = 24;
 
 const openedMixin = theme => ({
   boxSizing: 'border-box' as CSS.Property.BoxSizing,
   width: drawerWidth,
   overflow: 'hidden',
-  paddingLeft: 16,
-  paddingRight: 16,
+  paddingLeft: gutterSize,
+  paddingRight: gutterSize,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.enteringScreen,
@@ -79,8 +68,8 @@ const openedMixin = theme => ({
 
 const closedMixin = theme => ({
   boxSizing: 'border-box' as CSS.Property.BoxSizing,
-  paddingLeft: 24,
-  paddingRight: 24,
+  paddingLeft: gutterSize,
+  paddingRight: gutterSize,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
@@ -115,7 +104,6 @@ const AppDrawer: React.FC = () => {
   const theme = useTheme();
   const t = useTranslation();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'));
-  const classes = useStyles();
   const drawer = useDrawer();
 
   React.useEffect(() => {
@@ -131,23 +119,15 @@ const AppDrawer: React.FC = () => {
       aria-expanded={drawer.isOpen}
       open={drawer.isOpen}
     >
-      <div className={classes.toolbarIcon}>
+      <ToolbarIconContainer>
         <UnstyledIconButton
           titleKey={
             drawer.isOpen ? 'button.close-the-menu' : 'button.open-the-menu'
           }
           onClick={drawer.toggle}
-          icon={
-            <MSupplyGuy
-              classes={{
-                root: drawer.isOpen
-                  ? classes.mSupplyGuy
-                  : classes.mSupplyGuySmall,
-              }}
-            />
-          }
+          icon={<MSupplyGuy size={drawer.isOpen ? 'large' : 'medium'} />}
         />
-      </div>
+      </ToolbarIconContainer>
       <ListContainer>
         <List>
           <AppNavLink

--- a/packages/host/src/AppDrawer.tsx
+++ b/packages/host/src/AppDrawer.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
+  Box,
   Dashboard,
   Divider,
   Drawer,
-  UnstyledIconButton,
   List,
   MSupplyGuy,
   Messages,
@@ -13,13 +13,14 @@ import {
   Settings,
   Stock,
   Suppliers,
+  Theme,
   Tools,
-  useTranslation,
+  UnstyledIconButton,
+  styled,
   useDrawer,
   useMediaQuery,
   useTheme,
-  styled,
-  Box,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { AppNavLink } from '@openmsupply-client/common/src/ui/components/NavLink';
@@ -54,10 +55,15 @@ const StyledDivider = styled(Divider)({
 const drawerWidth = 200;
 const gutterSize = 24;
 
-const openedMixin = theme => ({
+const getDrawerCommonStyles = (theme: Theme) => ({
+  backgroundColor: theme.palette.background.menu,
   boxSizing: 'border-box' as CSS.Property.BoxSizing,
-  width: drawerWidth,
   overflow: 'hidden',
+});
+
+const openedMixin = (theme: Theme) => ({
+  ...getDrawerCommonStyles(theme),
+  width: drawerWidth,
   paddingLeft: gutterSize,
   paddingRight: gutterSize,
   transition: theme.transitions.create('width', {
@@ -66,15 +72,14 @@ const openedMixin = theme => ({
   }),
 });
 
-const closedMixin = theme => ({
-  boxSizing: 'border-box' as CSS.Property.BoxSizing,
+const closedMixin = (theme: Theme) => ({
+  ...getDrawerCommonStyles(theme),
   paddingLeft: gutterSize,
   paddingRight: gutterSize,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
   }),
-  overflow: 'hidden',
   [theme.breakpoints.up('sm')]: {
     width: theme.spacing(10),
   },
@@ -82,7 +87,6 @@ const closedMixin = theme => ({
 
 const StyledDrawer = styled(Drawer)(({ open, theme }) => {
   return {
-    backgroundColor: theme.palette.background.menu,
     position: 'relative',
     whiteSpace: 'nowrap',
     borderRadius: 8,
@@ -132,7 +136,7 @@ const AppDrawer: React.FC = () => {
         <List>
           <AppNavLink
             to={AppRoute.Dashboard}
-            icon={<Dashboard />}
+            icon={<Dashboard fontSize="small" />}
             text={t('app.dashboard')}
           />
           <React.Suspense fallback={null}>
@@ -140,27 +144,27 @@ const AppDrawer: React.FC = () => {
           </React.Suspense>
           <AppNavLink
             to={AppRoute.Suppliers}
-            icon={<Suppliers />}
+            icon={<Suppliers fontSize="small" />}
             text={t('app.suppliers')}
           />
           <AppNavLink
             to={AppRoute.Stock}
-            icon={<Stock />}
+            icon={<Stock fontSize="small" />}
             text={t('app.stock')}
           />
           <AppNavLink
             to={AppRoute.Tools}
-            icon={<Tools />}
+            icon={<Tools fontSize="small" />}
             text={t('app.tools')}
           />
           <AppNavLink
             to={AppRoute.Reports}
-            icon={<Reports />}
+            icon={<Reports fontSize="small" />}
             text={t('app.reports')}
           />
           <AppNavLink
             to={AppRoute.Messages}
-            icon={<Messages />}
+            icon={<Messages fontSize="small" />}
             text={t('app.messages')}
           />
         </List>

--- a/packages/host/src/Viewport.tsx
+++ b/packages/host/src/Viewport.tsx
@@ -16,7 +16,7 @@ const globalStyles = {
     height: '100%',
     width: '100%',
   },
-};
+} as const;
 
 const Viewport: React.FC = props => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,7 +1299,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6":
+"@emotion/is-prop-valid@^0.8.6":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1368,25 +1368,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.2.tgz#1d9ffde531714ba28e62dac6a996a8b1089719d0"
   integrity sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw==
 
-"@emotion/styled-base@^10.0.27":
-  version "10.0.31"
-  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.31.tgz#940957ee0aa15c6974adc7d494ff19765a2f742a"
-  integrity sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/is-prop-valid" "0.8.8"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/utils" "0.11.3"
-
-"@emotion/styled@^10.0.27":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
-  integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
-  dependencies:
-    "@emotion/styled-base" "^10.0.27"
-    babel-plugin-emotion "^10.0.27"
-
-"@emotion/styled@^11.3.0":
+"@emotion/styled@^10.0.27", "@emotion/styled@^11.0.0", "@emotion/styled@^11.0.0-next.19", "@emotion/styled@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
   integrity sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==
@@ -3847,7 +3829,7 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/dom@^8.0.0":
+"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.2.0":
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.2.0.tgz#ac46a1b9d7c81f0d341ae38fb5424b64c27d151e"
   integrity sha512-U8cTWENQPHO3QHvxBdfltJ+wC78ytMdg69ASvIdkGdQ/XRg4M9H2vvM3mHddxl+w/fM6NNqzGMwpQoh82v9VIA==
@@ -3883,6 +3865,13 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
+
+"@testing-library/user-event@^13.2.1":
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.2.1.tgz#7a71a39e50b4a733afbe2916fa2b99966e941f98"
+  integrity sha512-cczlgVl+krjOb3j1625usarNEibI0IFRJrSWX9UsJ1HKYFgCQv9Nb7QAipUDXl3Xdz8NDTsiS78eAkPSxlzTlw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
Partial fixes #81 

- Fixes the storybook problem, which was that when I upgraded to v5 mui, the dependency of `emotion` that storybook and mui were out of sync, causing issues which made me very angry and sad and happy. This is why there are deps added for `emotion` and the resolution to a specific version. This was to my main goal which I originally thought was because of the `makeStyle` uses which I was hoping I was going to kill 3 birds with one stone (storybook/rtl/extra package). Nope
- Removed use of `makeStyle` in `AppDrawer` and `NavLink`. I ran in to a few learning curves
    - We can't pass arbitrary props to dom elements like a `div` or `a`, so when using `Styled`, you sometimes have to use `shouldForwardProps` to stop the propagation of that prop.
    - Overriding mui classes ends up being kinda nice (IMO, after figuring it out...) : https://next.material-ui.com/customization/how-to-customize/#overriding-nested-component-styles