### PR TITLE
production build

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,1 +1,13 @@
 export * from './routes';
+
+interface EnvironmentConfig {
+  API_URL: string;
+}
+
+declare global {
+  interface Window {
+    env: EnvironmentConfig;
+  }
+}
+
+export const Environment: EnvironmentConfig = window.env;

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "webpack-cli serve",
-    "build": "webpack --mode production",
+    "build": "webpack --env production",
     "serve": "serve dist -p 3003",
     "clean": "rm -rf dist",
     "tsc": "tsc --build"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-rc.6",
+    "copy-webpack-plugin": "^9.0.1",
     "eslint-config-prettier": "^8.3.0",
     "find-up": "5.0.0",
     "html-webpack-plugin": "5.3.1",

--- a/packages/host/public/config.js
+++ b/packages/host/public/config.js
@@ -1,0 +1,3 @@
+window.env = {
+  API_URL: 'http://localhost:4000',
+};

--- a/packages/host/public/index.html
+++ b/packages/host/public/index.html
@@ -4,6 +4,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Inter"
     />
+    <script type="text/javascript" src="/config.js"></script>
   </head>
 
   <body>

--- a/packages/host/webpack.config.js
+++ b/packages/host/webpack.config.js
@@ -1,4 +1,5 @@
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 const HotModuleReplacementPlugin = webpack.HotModuleReplacementPlugin;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -35,6 +36,7 @@ module.exports = env => {
     output: {
       publicPath: isProduction ? '/' : 'http://localhost:3003/',
       chunkFilename: '[id].[contenthash].js',
+      clean: true,
     },
     optimization: {
       splitChunks: {
@@ -78,7 +80,9 @@ module.exports = env => {
         favicon: './public/favicon.ico',
         template: './public/index.html',
       }),
-
+      new CopyPlugin({
+        patterns: [{ from: './public/config.js', to: 'config.js' }],
+      }),
       // new ModuleFederationPlugin({
       //   name: 'host',
       //   filename: 'remoteEntry.js',

--- a/packages/host/webpack.config.js
+++ b/packages/host/webpack.config.js
@@ -8,104 +8,107 @@ const path = require('path');
 const BundleAnalyzerPlugin =
   require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
-const isDevelopment = process.env.NODE_ENV !== 'production';
+module.exports = env => {
+  const isProduction = !!env.production;
 
-module.exports = {
-  entry: './src/index',
-  mode: isDevelopment ? 'development' : 'production',
-  devServer: {
-    hot: true,
-    static: path.join(__dirname, 'dist'),
+  return {
+    entry: './src/index',
+    mode: isProduction ? 'production' : 'development',
+    devServer: {
+      hot: true,
+      static: path.join(__dirname, 'dist'),
 
-    port: 3003,
-    historyApiFallback: true,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
-      'Access-Control-Allow-Headers':
-        'X-Requested-With, content-type, Authorization',
+      port: 3003,
+      historyApiFallback: true,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods':
+          'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+        'Access-Control-Allow-Headers':
+          'X-Requested-With, content-type, Authorization',
+      },
+      open: true,
     },
-    open: true,
-  },
-  resolve: {
-    extensions: ['.js', '.css', '.ts', '.tsx'],
-  },
-  output: {
-    publicPath: 'http://localhost:3003/',
-    chunkFilename: '[id].[contenthash].js',
-  },
-  optimization: {
-    splitChunks: {
-      chunks: 'all',
+    resolve: {
+      extensions: ['.js', '.css', '.ts', '.tsx'],
     },
-  },
-  module: {
-    rules: [
-      {
-        test: /\.[t|j]sx?$/,
-        loader: 'swc-loader',
-        exclude: /node_modules/,
-        options: {
-          jsc: {
-            parser: {
-              dynamicImport: true,
-              syntax: 'typescript',
-              tsx: true,
+    output: {
+      publicPath: isProduction ? '/' : 'http://localhost:3003/',
+      chunkFilename: '[id].[contenthash].js',
+    },
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+      },
+    },
+    module: {
+      rules: [
+        {
+          test: /\.[t|j]sx?$/,
+          loader: 'swc-loader',
+          exclude: /node_modules/,
+          options: {
+            jsc: {
+              parser: {
+                dynamicImport: true,
+                syntax: 'typescript',
+                tsx: true,
+              },
+              target: 'es2015',
             },
-            target: 'es2015',
           },
         },
-      },
+      ],
+    },
+    plugins: [
+      new HotModuleReplacementPlugin(),
+
+      new ReactRefreshWebpackPlugin(),
+
+      new BundleAnalyzerPlugin({
+        /**
+         * In "server" mode analyzer will start HTTP server to show bundle report.
+         * In "static" mode single HTML file with bundle report will be generated.
+         * In "json" mode single JSON file with bundle report will be generated
+         */
+        analyzerMode: 'disabled',
+      }),
+
+      new HtmlWebpackPlugin({
+        favicon: './public/favicon.ico',
+        template: './public/index.html',
+      }),
+
+      // new ModuleFederationPlugin({
+      //   name: 'host',
+      //   filename: 'remoteEntry.js',
+      //   remotes: {
+      //     customers: 'customers@http://localhost:3007/remoteEntry.js',
+      //     dashboard: 'dashboard@http://localhost:3004/remoteEntry.js',
+      //     transactions: 'transactions@http://localhost:3005/remoteEntry.js',
+      //   },
+      //   exposes: {
+      //     './Host': './src/Host',
+      //   },
+      //   shared: [
+      //     {
+      //       ...deps,
+      //       react: {
+      //         singleton: true,
+      //         requiredVersion: deps.react,
+      //       },
+      //       'react-dom': {
+      //         singleton: true,
+      //         requiredVersion: deps['react-dom'],
+      //       },
+      //     },
+      //     {
+      //       '@openmsupply-client/common': {
+      //         requiredVersion: require('../common/package.json').version,
+      //       },
+      //     },
+      //   ],
+      // }),
     ],
-  },
-  plugins: [
-    new HotModuleReplacementPlugin(),
-
-    new ReactRefreshWebpackPlugin(),
-
-    new BundleAnalyzerPlugin({
-      /**
-       * In "server" mode analyzer will start HTTP server to show bundle report.
-       * In "static" mode single HTML file with bundle report will be generated.
-       * In "json" mode single JSON file with bundle report will be generated
-       */
-      analyzerMode: 'disabled',
-    }),
-
-    new HtmlWebpackPlugin({
-      favicon: './public/favicon.ico',
-      template: './public/index.html',
-    }),
-
-    // new ModuleFederationPlugin({
-    //   name: 'host',
-    //   filename: 'remoteEntry.js',
-    //   remotes: {
-    //     customers: 'customers@http://localhost:3007/remoteEntry.js',
-    //     dashboard: 'dashboard@http://localhost:3004/remoteEntry.js',
-    //     transactions: 'transactions@http://localhost:3005/remoteEntry.js',
-    //   },
-    //   exposes: {
-    //     './Host': './src/Host',
-    //   },
-    //   shared: [
-    //     {
-    //       ...deps,
-    //       react: {
-    //         singleton: true,
-    //         requiredVersion: deps.react,
-    //       },
-    //       'react-dom': {
-    //         singleton: true,
-    //         requiredVersion: deps['react-dom'],
-    //       },
-    //     },
-    //     {
-    //       '@openmsupply-client/common': {
-    //         requiredVersion: require('../common/package.json').version,
-    //       },
-    //     },
-    //   ],
-    // }),
-  ],
+  };
 };

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@openmsupply-client/mock-server",
-    "version": "0.0.0",
-    "private": true,
-    "main": "./src/index.ts",
-    "scripts": {
-        "start": "nodemon --exec babel-node -- ./src/index.js"
-    },
-    "devDependencies": {
-        "@babel/cli": "^7.14.8",
-        "@babel/core": "^7.14.8",
-        "@babel/preset-env": "^7.14.9",
-        "nodemon": "^2.0.12"
-    },
-    "dependencies": {
-        "@babel/node": "^7.14.9",
-        "@openmsupply-client/common": "^0.0.1",
-        "@openmsupply-client/config": "^0.0.0",
-        "apollo-server": "^3.1.1",
-        "faker": "^5.5.3",
-        "graphql": "^15.5.1"
-    }
+  "name": "@openmsupply-client/mock-server",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "start": "nodemon --exec babel-node -- ./src/index.js"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.14.8",
+    "@babel/core": "^7.14.8",
+    "@babel/preset-env": "^7.14.9",
+    "nodemon": "^2.0.12"
+  },
+  "dependencies": {
+    "@babel/node": "^7.14.9",
+    "@openmsupply-client/common": "^0.0.1",
+    "@openmsupply-client/config": "^0.0.0",
+    "apollo-server": "^3.1.1",
+    "faker": "^5.5.3",
+    "graphql": "^15.5.1"
+  }
 }

--- a/packages/transactions/src/OutboundShipment/DetailView.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView.tsx
@@ -4,9 +4,10 @@ import { useNavigate, useParams } from 'react-router';
 import { request, Transaction } from '@openmsupply-client/common';
 import { getMutation, getDetailQuery } from '../api';
 import { createDraftStore, useDraftDocument } from '../useDraftDocument';
+import { Environment } from '@openmsupply-client/config';
 
 const queryFn = (id: string) => async (): Promise<Transaction> => {
-  const result = await request('http://localhost:4000', getDetailQuery(), {
+  const result = await request(Environment.API_URL, getDetailQuery(), {
     id,
   });
   const { transaction } = result;
@@ -15,7 +16,7 @@ const queryFn = (id: string) => async (): Promise<Transaction> => {
 
 const mutationFn = async (updated: Transaction): Promise<Transaction> => {
   const patch = { transactionPatch: updated };
-  const result = await request('http://localhost:4000', getMutation(), patch);
+  const result = await request(Environment.API_URL, getMutation(), patch);
   const { upsertTransaction } = result;
   return upsertTransaction;
 };

--- a/packages/transactions/src/OutboundShipment/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView.tsx
@@ -19,20 +19,17 @@ import {
   Transaction,
 } from '@openmsupply-client/common';
 import { getListQuery } from '../api';
+import { Environment } from '@openmsupply-client/config';
 
 const queryFn = async (queryParams: QueryProps<Transaction>) => {
   const { first, offset, sortBy } = queryParams;
 
-  const { transactions } = await request(
-    'http://localhost:4000',
-    getListQuery(),
-    {
-      first,
-      offset,
-      sort: sortBy?.[0]?.id,
-      desc: !!sortBy?.[0]?.desc,
-    }
-  );
+  const { transactions } = await request(Environment.API_URL, getListQuery(), {
+    first,
+    offset,
+    sort: sortBy?.[0]?.id,
+    desc: !!sortBy?.[0]?.desc,
+  });
 
   return transactions;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,7 +1299,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@^0.8.6":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.6":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1368,7 +1368,25 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.2.tgz#1d9ffde531714ba28e62dac6a996a8b1089719d0"
   integrity sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw==
 
-"@emotion/styled@^10.0.27", "@emotion/styled@^11.0.0", "@emotion/styled@^11.0.0-next.19", "@emotion/styled@^11.3.0":
+"@emotion/styled-base@^10.0.27":
+  version "10.0.31"
+  resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.31.tgz#940957ee0aa15c6974adc7d494ff19765a2f742a"
+  integrity sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/is-prop-valid" "0.8.8"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/styled@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
+  integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
+  dependencies:
+    "@emotion/styled-base" "^10.0.27"
+    babel-plugin-emotion "^10.0.27"
+
+"@emotion/styled@^11.0.0-next.19", "@emotion/styled@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.3.0.tgz#d63ee00537dfb6ff612e31b0e915c5cf9925a207"
   integrity sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==
@@ -6782,6 +6800,19 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
+copy-webpack-plugin@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz#b71d21991599f61a4ee00ba79087b8ba279bbb59"
+  integrity sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==
+  dependencies:
+    fast-glob "^3.2.5"
+    glob-parent "^6.0.0"
+    globby "^11.0.3"
+    normalize-path "^3.0.0"
+    p-limit "^3.1.0"
+    schema-utils "^3.0.0"
+    serialize-javascript "^6.0.0"
+
 core-js-compat@^3.14.0, core-js-compat@^3.16.0, core-js-compat@^3.8.1:
   version "3.16.4"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.16.4.tgz#cf28abe0e45a43645b04b2c1a073efa03d0b3b26"
@@ -8972,6 +9003,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.1.tgz#42054f685eb6a44e7a7d189a96efa40a54971aa7"
+  integrity sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==
   dependencies:
     is-glob "^4.0.1"
 


### PR DESCRIPTION
Fixes #122 

Adds the option to override environment based settings at runtime. Possibly the API url will just be on the same url with a specific port and we won't need this for production, instead a version which overrides for local dev. Not sure at this stage - this option allows the same code to run in different environments, so meets my need.

Also tidied the 'production' mode which wasn't being set when a build was run.