### PR TITLE
#119 placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 # Compiled release
 **/build/*
 **/dist/*
+**/storybook-static/*
 
 # Dependency directories
 node_modules/

--- a/packages/common/src/ui/components/buttons/NavigationButton.tsx
+++ b/packages/common/src/ui/components/buttons/NavigationButton.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button as MuiButton } from '@material-ui/core';
+import { styled } from '@material-ui/core/styles';
+import { LocaleKey, useTranslation } from '../../../intl/intlHelpers';
+import { DefaultButtonStyles } from './styles';
+
+interface NavigationButtonProps {
+  icon: React.ReactNode;
+  labelKey: LocaleKey;
+  to: string;
+}
+
+const StyledButton = styled(MuiButton)(({ theme }) => ({
+  ...DefaultButtonStyles,
+  boxShadow: theme.shadows[1],
+  color: theme.palette.primary.main,
+  minWidth: 115,
+}));
+
+const NavigationButton: FC<NavigationButtonProps> = props => {
+  const { icon, labelKey, to } = props;
+  const t = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <StyledButton
+      onClick={() => navigate(to)}
+      startIcon={icon}
+      variant="contained"
+    >
+      {t(labelKey)}
+    </StyledButton>
+  );
+};
+export default NavigationButton;

--- a/packages/common/src/ui/components/buttons/index.ts
+++ b/packages/common/src/ui/components/buttons/index.ts
@@ -1,6 +1,7 @@
 import Button from './Button';
 import IconButton from './IconButton';
+import NavigationButton from './NavigationButton';
 import TextButton from './TextButton';
 import UnstyledIconButton from './UnstyledIconButton';
 
-export { Button, IconButton, TextButton, UnstyledIconButton };
+export { Button, IconButton, NavigationButton, TextButton, UnstyledIconButton };

--- a/packages/common/src/ui/icons/Invoice.tsx
+++ b/packages/common/src/ui/icons/Invoice.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
+
+export const Invoice = (props: SvgIconProps): JSX.Element => {
+  const combinedProps: SvgIconProps = {
+    color: 'primary',
+    style: {
+      fill: 'none',
+    },
+    stroke: 'currentColor',
+    ...props,
+  };
+  return (
+    <SvgIcon {...combinedProps} viewBox="0 0 24 24">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8"></polyline>
+      <line x1="16" y1="13" x2="8" y2="13"></line>
+      <line x1="16" y1="17" x2="8" y2="17"></line>
+      <polyline points="10 9 9 9 8 9"></polyline>
+    </SvgIcon>
+  );
+};

--- a/packages/common/src/ui/icons/index.ts
+++ b/packages/common/src/ui/icons/index.ts
@@ -3,6 +3,7 @@ export { Book } from './Book';
 export { Customers } from './Customers';
 export { Dashboard } from './Dashboard';
 export { Download } from './Download';
+export { Invoice } from './Invoice';
 export { MenuDots } from './MenuDots';
 export { Messages } from './Messages';
 export { MSupplyGuy } from './MSupplyGuy';

--- a/packages/customers/src/CustomerContainer.tsx
+++ b/packages/customers/src/CustomerContainer.tsx
@@ -1,6 +1,12 @@
 import React, { FC } from 'react';
 import { useMatch } from 'react-router-dom';
-import { RouteBuilder, Typography } from '@openmsupply-client/common';
+import {
+  Grid,
+  Invoice,
+  NavigationButton,
+  RouteBuilder,
+  Typography,
+} from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 
 const TransactionService = React.lazy(
@@ -29,7 +35,35 @@ const CustomerContainer: FC = () => {
     return <RequisitionService />;
   }
 
-  return <></>;
+  return (
+    <Grid container>
+      <Grid container sx={{ padding: 10 }} flexDirection="column">
+        <Grid flex={1} item sx={{ margin: 1 }}>
+          <NavigationButton
+            to={RouteBuilder.create(AppRoute.Customers)
+              .addPart(AppRoute.CustomerInvoice)
+              .build()}
+            labelKey="app.customer-invoice"
+            icon={<Invoice />}
+          />
+        </Grid>
+        <Grid flex={1} item sx={{ margin: 1 }}>
+          <NavigationButton
+            to={RouteBuilder.create(AppRoute.Customers)
+              .addPart(AppRoute.CustomerRequisition)
+              .build()}
+            labelKey="app.customer-requisition"
+            icon={<Invoice />}
+          />
+        </Grid>
+      </Grid>
+      <Grid container justifyContent="center">
+        <Typography sx={{ marginTop: 10 }}>
+          Note: no design provided yet. The buttons are for convenience.
+        </Typography>
+      </Grid>
+    </Grid>
+  );
 };
 
 export default CustomerContainer;

--- a/packages/dashboard/src/DashboardService.tsx
+++ b/packages/dashboard/src/DashboardService.tsx
@@ -5,19 +5,19 @@ import { styled } from '@material-ui/core/styles';
 
 const RecentInvoiceWidget = () => (
   <Widget height="500px">
-    <Typography>RecentInvoices</Typography>
+    <Typography variant="h6">Recent Invoices</Typography>
   </Widget>
 );
 
 const SalesDepositsWidget = () => (
   <Widget height="240px">
-    <Typography>SalesDeposits</Typography>
+    <Typography variant="h6">Alerts</Typography>
   </Widget>
 );
 
 const SalesTodayWidget = () => (
   <Widget height="240px">
-    <Typography>SalesToday</Typography>
+    <Typography variant="h6">Purchase Orders</Typography>
   </Widget>
 );
 

--- a/packages/host/src/AppDrawer.tsx
+++ b/packages/host/src/AppDrawer.tsx
@@ -24,6 +24,7 @@ import {
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { AppNavLink } from '@openmsupply-client/common/src/ui/components/NavLink';
+import { Property } from 'csstype';
 
 const CustomersNav = React.lazy(
   () => import('@openmsupply-client/customers/src/Nav')
@@ -38,11 +39,30 @@ const ToolbarIconContainer = styled(Box)(({ theme }) => ({
   ...theme.mixins.toolbar,
 }));
 
-const ListContainer = styled(Box)({
+const commonListContainerStyles = {
   display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
+  flexDirection: 'column' as Property.FlexDirection,
   justifyContent: 'space-between',
+  alignItems: 'center',
+};
+
+const LowerListContainer = styled(Box)({
+  ...commonListContainerStyles,
+  height: 151,
+  position: 'static',
+  bottom: 0,
+});
+
+const UpperListContainer = styled(Box)({
+  ...commonListContainerStyles,
+  flex: 1,
+  height: '100%',
+  msOverflowStyle: 'none',
+  overflow: 'scroll',
+  scrollbarWidth: 'none',
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
 });
 
 const StyledDivider = styled(Divider)({
@@ -52,7 +72,6 @@ const StyledDivider = styled(Divider)({
 });
 
 const drawerWidth = 200;
-const gutterSize = 24;
 
 const getDrawerCommonStyles = (theme: Theme) => ({
   backgroundColor: theme.palette.background.menu,
@@ -62,8 +81,7 @@ const getDrawerCommonStyles = (theme: Theme) => ({
 const openedMixin = (theme: Theme) => ({
   ...getDrawerCommonStyles(theme),
   width: drawerWidth,
-  paddingLeft: gutterSize,
-  paddingRight: gutterSize,
+
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.enteringScreen,
@@ -72,8 +90,7 @@ const openedMixin = (theme: Theme) => ({
 
 const closedMixin = (theme: Theme) => ({
   ...getDrawerCommonStyles(theme),
-  paddingLeft: gutterSize,
-  paddingRight: gutterSize,
+
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
@@ -129,7 +146,7 @@ const AppDrawer: React.FC = () => {
           icon={<MSupplyGuy size={drawer.isOpen ? 'large' : 'medium'} />}
         />
       </ToolbarIconContainer>
-      <ListContainer>
+      <UpperListContainer>
         <List>
           <AppNavLink
             to={AppRoute.Dashboard}
@@ -165,6 +182,8 @@ const AppDrawer: React.FC = () => {
             text={t('app.messages')}
           />
         </List>
+      </UpperListContainer>
+      <LowerListContainer>
         <List>
           {drawer.isOpen && <StyledDivider />}
           <AppNavLink
@@ -183,7 +202,7 @@ const AppDrawer: React.FC = () => {
             text={t('app.logout')}
           />
         </List>
-      </ListContainer>
+      </LowerListContainer>
     </StyledDrawer>
   );
 };

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -9,9 +9,7 @@ import {
   IntlProvider,
   SnackbarProvider,
   styled,
-  useFormatDate,
   useHostContext,
-  useTranslation,
   RouteBuilder,
   ErrorBoundary,
   GenericErrorFallback,
@@ -36,113 +34,90 @@ const DashboardService = React.lazy(
   () => import('@openmsupply-client/dashboard/src/DashboardService')
 );
 
-const Heading: FC<{ locale: string }> = props => {
-  const t = useTranslation();
-  const formatDate = useFormatDate();
-  const date = new Date();
-
-  return (
-    <div style={{ margin: '100px 50px' }}>
-      <span>
-        <Typography>Current locale: {props.locale}</Typography>
-        <Typography>
-          {t('app.welcome', { name: '<your name here>' })}
-        </Typography>
-        <Typography>
-          Today is{' '}
-          {formatDate(date, {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            weekday: 'long',
-          })}
-        </Typography>
-      </span>
-      <Typography>[ {props.children} ]</Typography>
-    </div>
-  );
-};
+const Heading: FC<{ locale: string }> = props => (
+  <div style={{ margin: 50 }}>
+    <Typography>[ Placeholder page: {props.children} ]</Typography>
+  </div>
+);
 
 const Host: FC = () => {
   const { locale } = useHostContext();
 
   return (
     <ErrorBoundary Fallback={GenericErrorFallback}>
-        <QueryClientProvider client={queryClient}>
-          <IntlProvider locale={locale}>
-            <AppThemeProvider>
-              <BrowserRouter>
-                <SnackbarProvider maxSnack={3}>
-                  <Viewport>
-                    <AppBar />
-                    <Box display="flex" flex={1}>
-                      <AppDrawer />
-                      <Content flex={1}>
-                        <React.Suspense fallback={'Loading'}>
-                          <Routes>
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Dashboard)
-                                .addWildCard()
-                                .build()}
-                              element={<DashboardService />}
-                            />
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Customers)
-                                .addWildCard()
-                                .build()}
-                              element={<CustomerContainer />}
-                            />
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Suppliers)
-                                .addWildCard()
-                                .build()}
-                              element={
-                                <Heading locale={locale}>suppliers</Heading>
-                              }
-                            />
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Stock)
-                                .addWildCard()
-                                .build()}
-                              element={<Heading locale={locale}>stock</Heading>}
-                            />
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Tools)
-                                .addWildCard()
-                                .build()}
-                              element={<Heading locale={locale}>tools</Heading>}
-                            />
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Reports)
-                                .addWildCard()
-                                .build()}
-                              element={
-                                <Heading locale={locale}>reports</Heading>
-                              }
-                            />
-                            <Route
-                              path={RouteBuilder.create(AppRoute.Messages)
-                                .addWildCard()
-                                .build()}
-                              element={
-                                <Heading locale={locale}>messages</Heading>
-                              }
-                            />
-                            <Route
-                              path="*"
-                              element={<Navigate to="/dashboard" replace />}
-                            />
-                          </Routes>
-                        </React.Suspense>
-                      </Content>
-                    </Box>
-                  </Viewport>
-                </SnackbarProvider>
-              </BrowserRouter>
-            </AppThemeProvider>
-            <ReactQueryDevtools initialIsOpen />
-          </IntlProvider>
-        </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale={locale}>
+          <AppThemeProvider>
+            <BrowserRouter>
+              <SnackbarProvider maxSnack={3}>
+                <Viewport>
+                  <AppBar />
+                  <Box display="flex" flex={1}>
+                    <AppDrawer />
+                    <Content flex={1}>
+                      <React.Suspense fallback={'Loading'}>
+                        <Routes>
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Dashboard)
+                              .addWildCard()
+                              .build()}
+                            element={<DashboardService />}
+                          />
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Customers)
+                              .addWildCard()
+                              .build()}
+                            element={<CustomerContainer />}
+                          />
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Suppliers)
+                              .addWildCard()
+                              .build()}
+                            element={
+                              <Heading locale={locale}>suppliers</Heading>
+                            }
+                          />
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Stock)
+                              .addWildCard()
+                              .build()}
+                            element={<Heading locale={locale}>stock</Heading>}
+                          />
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Tools)
+                              .addWildCard()
+                              .build()}
+                            element={<Heading locale={locale}>tools</Heading>}
+                          />
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Reports)
+                              .addWildCard()
+                              .build()}
+                            element={<Heading locale={locale}>reports</Heading>}
+                          />
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Messages)
+                              .addWildCard()
+                              .build()}
+                            element={
+                              <Heading locale={locale}>messages</Heading>
+                            }
+                          />
+                          <Route
+                            path="*"
+                            element={<Navigate to="/dashboard" replace />}
+                          />
+                        </Routes>
+                      </React.Suspense>
+                    </Content>
+                  </Box>
+                </Viewport>
+              </SnackbarProvider>
+            </BrowserRouter>
+          </AppThemeProvider>
+          <ReactQueryDevtools initialIsOpen />
+        </IntlProvider>
+      </QueryClientProvider>
     </ErrorBoundary>
   );
 };

--- a/packages/mock-server/src/schema/Transaction.js
+++ b/packages/mock-server/src/schema/Transaction.js
@@ -46,15 +46,15 @@ const getDataSorter = (sortKey, desc) => (a, b) => {
   return 0;
 };
 
-const delay = async ms =>
-  new Promise(resolve =>
-    setTimeout(() => {
-      resolve('');
-    }, ms)
-  );
+// const delay = async ms =>
+//   new Promise(resolve =>
+//     setTimeout(() => {
+//       resolve('');
+//     }, ms)
+//   );
 
 const getTransactionData = async (first, offset, sort, desc) => {
-  await delay(1000 * Math.random() + 200);
+  // await delay(1000 * Math.random() + 200);
   const data = TransactionData.slice();
   if (sort) {
     const sortData = getDataSorter(sort, desc);


### PR DESCRIPTION
Fixes #119 

Few small tidies and helpers:
 - changed the page placeholder text to simply say `[ Placeholder page: xxxxx ]`
 - fixed an issue with the left nav: if the screen size is small then the bottom options disappear. The upper section now is scrollable with the bottom section always shown, and always at the bottom
 - Added some buttons to the customers page, when the drawer is collapsed you couldn't get to the list page
 - removed the delay on the mock server response 🤷‍♂️ 