### PR TITLE
#128 add row select mechanism

### DIFF
--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -44,6 +44,8 @@ const themeOptions = {
   palette: {
     darkGrey: '#555770',
     primary: { 500: '#e95c30' },
+    secondary: { main: '#555770' },
+
     background: {
       menu: '#f2f2f5',
       white: '#fff',

--- a/packages/common/src/ui/components/inputs/Checkbox/Checkbox.stories.tsx
+++ b/packages/common/src/ui/components/inputs/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Checkbox } from './Checkbox';
+
+export default {
+  title: 'Inputs/Checkbox',
+  component: Checkbox,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} as ComponentMeta<typeof Checkbox>;
+
+const Template: ComponentStory<typeof Checkbox> = args => (
+  <Checkbox {...args} />
+);
+
+export const Primary = Template.bind({});

--- a/packages/common/src/ui/components/inputs/Checkbox/Checkbox.tsx
+++ b/packages/common/src/ui/components/inputs/Checkbox/Checkbox.tsx
@@ -1,0 +1,7 @@
+import React, { FC } from 'react';
+import MuiCheckbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+
+// TODO: Change icons to be consistent with Zeplin designs
+export const Checkbox: FC<CheckboxProps> = props => {
+  return <MuiCheckbox size="small" color="secondary" {...props} />;
+};

--- a/packages/common/src/ui/components/inputs/Checkbox/index.ts
+++ b/packages/common/src/ui/components/inputs/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox';

--- a/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Checkbox } from '../../../components/inputs/Checkbox';
+import { Column } from 'react-table';
+
+export const getCheckboxSelectionColumn = (): Column => ({
+  id: 'selection',
+  Header: ({ getToggleAllRowsSelectedProps }) => (
+    <Checkbox
+      size="small"
+      color="secondary"
+      {...getToggleAllRowsSelectedProps()}
+    />
+  ),
+  Cell: ({ row }) => {
+    return (
+      <Checkbox
+        color="secondary"
+        size="small"
+        onClick={event => {
+          event.stopPropagation();
+        }}
+        {...row.getToggleRowSelectedProps()}
+      />
+    );
+  },
+});

--- a/packages/common/src/ui/layout/tables/columns/index.ts
+++ b/packages/common/src/ui/layout/tables/columns/index.ts
@@ -1,0 +1,1 @@
+export { getCheckboxSelectionColumn } from './CheckboxSelectionColumn';

--- a/packages/common/src/ui/layout/tables/hooks/index.ts
+++ b/packages/common/src/ui/layout/tables/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useColumns';
+export * from './useDataTableApi';

--- a/packages/common/src/ui/layout/tables/hooks/useColumns.ts
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns.ts
@@ -1,36 +1,30 @@
-import { getCheckboxSelectionColumn } from './../columns/CheckboxSelectionColumn';
 import { Column, IdType } from 'react-table';
-
+import {
+  GenericColumnType,
+  ColumnDefinition,
+  GenericColumnDef,
+  ColumnFormat,
+} from '../types';
+import { getCheckboxSelectionColumn } from './../columns/CheckboxSelectionColumn';
 import { useFormatDate, useTranslation } from '../../../../intl';
-import { LocaleKey } from '../../../../intl/intlHelpers';
 
-export enum ColumnFormat {
-  date,
-  integer,
-  real,
-  text,
-}
-
-export interface ColumnDefinition<T> {
-  label: LocaleKey;
-  format?: ColumnFormat;
-  key: keyof T;
-  sortable?: boolean; // defaults to true
-}
-
-interface ColumnOptions {
-  useSelectionColumn: boolean;
-}
+const columnLookup = (column: GenericColumnDef) => {
+  if (column === GenericColumnType.Selection) {
+    return getCheckboxSelectionColumn();
+  }
+};
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const useColumns = <T extends object>(
-  columnsToMap: ColumnDefinition<T>[],
-  options: ColumnOptions = { useSelectionColumn: false }
+  columnsToMap: (ColumnDefinition<T> | GenericColumnDef)[]
 ): Column<T>[] => {
   const t = useTranslation();
   const formatDate = useFormatDate();
 
-  let columns = columnsToMap.map(column => {
+  return columnsToMap.map(column => {
+    if (typeof column === 'string') {
+      return columnLookup(column);
+    }
     const { key, label, sortable = true } = column;
     const Header = t(label);
     const accessor = getAccessor<T>(column, formatDate);
@@ -50,12 +44,6 @@ export const useColumns = <T extends object>(
       // TODO: Fix react-type column typings here
     } as any;
   });
-
-  if (options.useSelectionColumn) {
-    columns = [...columns, getCheckboxSelectionColumn()];
-  }
-
-  return columns;
 };
 
 const getSortType = <T>(column: ColumnDefinition<T>) => {

--- a/packages/common/src/ui/layout/tables/hooks/useColumns.ts
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns.ts
@@ -1,14 +1,9 @@
 import { Column, IdType } from 'react-table';
-import {
-  GenericColumnType,
-  ColumnDefinition,
-  GenericColumnDef,
-  ColumnFormat,
-} from '../types';
+import { GenericColumnType, ColumnDefinition, ColumnFormat } from '../types';
 import { getCheckboxSelectionColumn } from './../columns/CheckboxSelectionColumn';
 import { useFormatDate, useTranslation } from '../../../../intl';
 
-const columnLookup = (column: GenericColumnDef) => {
+const columnLookup = (column: GenericColumnType) => {
   if (column === GenericColumnType.Selection) {
     return getCheckboxSelectionColumn();
   }
@@ -16,7 +11,7 @@ const columnLookup = (column: GenericColumnDef) => {
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const useColumns = <T extends object>(
-  columnsToMap: (ColumnDefinition<T> | GenericColumnDef)[]
+  columnsToMap: (ColumnDefinition<T> | GenericColumnType)[]
 ): Column<T>[] => {
   const t = useTranslation();
   const formatDate = useFormatDate();
@@ -25,6 +20,7 @@ export const useColumns = <T extends object>(
     if (typeof column === 'string') {
       return columnLookup(column);
     }
+
     const { key, label, sortable = true } = column;
     const Header = t(label);
     const accessor = getAccessor<T>(column, formatDate);

--- a/packages/common/src/ui/layout/tables/hooks/useDataTableApi.ts
+++ b/packages/common/src/ui/layout/tables/hooks/useDataTableApi.ts
@@ -1,0 +1,33 @@
+import { TableInstance } from 'react-table';
+import { DataTableApi } from './../types';
+import { useImperativeHandle, useRef, RefObject } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const useSetupDataTableApi = <DataTableRowType extends object>(
+  ref: RefObject<DataTableApi<DataTableRowType>>,
+  tableInstance: TableInstance<DataTableRowType>
+): RefObject<DataTableApi<DataTableRowType>> => {
+  const { selectedFlatRows, toggleAllRowsSelected } = tableInstance;
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      // Mapping into a plain row object rather than a react-table row object
+      // which contains a bunch of irrelevant data.
+      selectedRows: selectedFlatRows.map(
+        ({ values }) => values
+      ) as DataTableRowType[],
+      selectAllRows: toggleAllRowsSelected,
+    }),
+    [selectedFlatRows]
+  );
+
+  return ref;
+};
+
+export const useDataTableApi = <DataTableRowType>(): RefObject<
+  DataTableApi<DataTableRowType>
+> => {
+  const tableApi = useRef<DataTableApi<DataTableRowType>>(null);
+  return tableApi;
+};

--- a/packages/common/src/ui/layout/tables/index.ts
+++ b/packages/common/src/ui/layout/tables/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks';
 export * from './RemoteDataTable';
+export * from './types';
 
 export const DEFAULT_PAGE_SIZE = 25;

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,0 +1,30 @@
+import { ReactNode, RefObject } from 'react';
+import { Column, Row, SortingRule } from 'react-table';
+
+export interface QueryProps<D> {
+  first: number;
+  offset: number;
+  sortBy?: SortingRule<D>[];
+}
+
+export interface QueryResponse<T> {
+  data: T[];
+  totalLength: number;
+}
+
+export interface DataTableApi<T> {
+  selectAllRows: () => void;
+  selectedRows: T[];
+}
+
+export interface TableProps<T extends Record<string, unknown>> {
+  columns: Column<T>[];
+  data?: T[];
+  initialSortBy?: SortingRule<T>[];
+  isLoading?: boolean;
+  onFetchData: (props: QueryProps<T>) => void;
+  onRowClick?: <T extends Record<string, unknown>>(row: Row<T>) => void;
+  totalLength?: number;
+  tableApi: RefObject<DataTableApi<T>>;
+  children?: ReactNode;
+}

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -16,8 +16,6 @@ export interface ColumnDefinition<T> {
   sortable?: boolean; // defaults to true
 }
 
-export type GenericColumnDef = GenericColumnType.Selection;
-
 export enum GenericColumnType {
   Selection = 'selection',
 }

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,5 +1,26 @@
+import { LocaleKey } from '@openmsupply-client/common/src/intl/intlHelpers';
 import { ReactNode, RefObject } from 'react';
 import { Column, Row, SortingRule } from 'react-table';
+
+export enum ColumnFormat {
+  date,
+  integer,
+  real,
+  text,
+}
+
+export interface ColumnDefinition<T> {
+  label: LocaleKey;
+  format?: ColumnFormat;
+  key: keyof T;
+  sortable?: boolean; // defaults to true
+}
+
+export type GenericColumnDef = GenericColumnType.Selection;
+
+export enum GenericColumnType {
+  Selection = 'selection',
+}
 
 export interface QueryProps<D> {
   first: number;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,4 +10,4 @@ declare global {
   }
 }
 
-export const Environment: EnvironmentConfig = window.env;
+export const Environment: EnvironmentConfig = window.env ?? {};

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -25,7 +25,14 @@ const Content = styled(Box)({
   overflowY: 'scroll',
   height: '100vh',
 });
-const queryClient = new QueryClient();
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 const CustomerContainer = React.lazy(
   () => import('@openmsupply-client/customers/src/CustomerContainer')

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -10,7 +10,6 @@ import {
   MenuDots,
   PlusCircle,
   Printer,
-  QueryProps,
   useQuery,
   RemoteDataTable,
   useColumns,
@@ -18,9 +17,10 @@ import {
   useNotification,
   SortingRule,
   Transaction,
+  QueryProps,
+  useDataTableApi,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
-
 import { getListQuery } from '../../api';
 
 const queryFn = async (queryParams: QueryProps<Transaction>) => {
@@ -50,17 +50,22 @@ export const OutboundShipmentListView: FC = () => {
   );
 
   const navigate = useNavigate();
-  const getColumns = useColumns();
-  const columns = getColumns<Transaction>([
-    { label: 'label.id', key: 'id', sortable: false },
-    { label: 'label.date', key: 'date', format: ColumnFormat.date },
-    { label: 'label.customer', key: 'customer' },
-    { label: 'label.supplier', key: 'supplier' },
-    { label: 'label.total', key: 'total' },
-  ]);
+  const columns = useColumns<Transaction>(
+    [
+      { label: 'label.id', key: 'id', sortable: false },
+      { label: 'label.date', key: 'date', format: ColumnFormat.date },
+      { label: 'label.customer', key: 'customer' },
+      { label: 'label.supplier', key: 'supplier' },
+      { label: 'label.total', key: 'total' },
+    ],
+    { useSelectionColumn: true }
+  );
+
   const initialSortBy: SortingRule<Transaction>[] = [
     { id: 'date', desc: true },
   ];
+
+  const tableApi = useDataTableApi<Transaction>();
 
   return (
     <>
@@ -89,6 +94,7 @@ export const OutboundShipmentListView: FC = () => {
         </>
       </Portal>
       <RemoteDataTable<Transaction>
+        tableApi={tableApi}
         columns={columns}
         data={response?.data || []}
         initialSortBy={initialSortBy}

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -19,6 +19,7 @@ import {
   Transaction,
   QueryProps,
   useDataTableApi,
+  GenericColumnType,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { getListQuery } from '../../api';
@@ -50,16 +51,14 @@ export const OutboundShipmentListView: FC = () => {
   );
 
   const navigate = useNavigate();
-  const columns = useColumns<Transaction>(
-    [
-      { label: 'label.id', key: 'id', sortable: false },
-      { label: 'label.date', key: 'date', format: ColumnFormat.date },
-      { label: 'label.customer', key: 'customer' },
-      { label: 'label.supplier', key: 'supplier' },
-      { label: 'label.total', key: 'total' },
-    ],
-    { useSelectionColumn: true }
-  );
+  const columns = useColumns<Transaction>([
+    { label: 'label.id', key: 'id', sortable: false },
+    { label: 'label.date', key: 'date', format: ColumnFormat.date },
+    { label: 'label.customer', key: 'customer' },
+    { label: 'label.supplier', key: 'supplier' },
+    { label: 'label.total', key: 'total' },
+    GenericColumnType.Selection,
+  ]);
 
   const initialSortBy: SortingRule<Transaction>[] = [
     { id: 'date', desc: true },

--- a/types/react-table-config.d.ts
+++ b/types/react-table-config.d.ts
@@ -1,49 +1,49 @@
 import {
-  // UseColumnOrderInstanceProps,
-  // UseColumnOrderState,
-  // UseExpandedHooks,
-  // UseExpandedInstanceProps,
+  UseColumnOrderInstanceProps,
+  UseColumnOrderState,
+  UseExpandedHooks,
+  UseExpandedInstanceProps,
   UseExpandedOptions,
-  // UseExpandedRowProps,
+  UseExpandedRowProps,
   UseExpandedState,
-  // UseFiltersColumnOptions,
+  UseFiltersColumnOptions,
   UseFiltersColumnProps,
-  // UseFiltersInstanceProps,
+  UseFiltersInstanceProps,
   UseFiltersOptions,
   UseFiltersState,
-  // UseGlobalFiltersColumnOptions,
-  // UseGlobalFiltersInstanceProps,
+  UseGlobalFiltersColumnOptions,
+  UseGlobalFiltersInstanceProps,
   UseGlobalFiltersOptions,
   UseGlobalFiltersState,
-  // UseGroupByCellProps,
-  // UseGroupByColumnOptions,
+  UseGroupByCellProps,
+  UseGroupByColumnOptions,
   UseGroupByColumnProps,
-  // UseGroupByHooks,
-  // UseGroupByInstanceProps,
+  UseGroupByHooks,
+  UseGroupByInstanceProps,
   UseGroupByOptions,
-  // UseGroupByRowProps,
+  UseGroupByRowProps,
   UseGroupByState,
-  // UsePaginationInstanceProps,
+  UsePaginationInstanceProps,
   UsePaginationOptions,
   UsePaginationState,
-  // UseResizeColumnsColumnOptions,
+  UseResizeColumnsColumnOptions,
   UseResizeColumnsColumnProps,
   UseResizeColumnsOptions,
   UseResizeColumnsState,
-  // UseRowSelectHooks,
-  // UseRowSelectInstanceProps,
+  UseRowSelectHooks,
+  UseRowSelectInstanceProps,
   UseRowSelectOptions,
-  // UseRowSelectRowProps,
+  UseRowSelectRowProps,
   UseRowSelectState,
-  // UseRowStateCellProps,
-  // UseRowStateInstanceProps,
+  UseRowStateCellProps,
+  UseRowStateInstanceProps,
   UseRowStateOptions,
-  // UseRowStateRowProps,
+  UseRowStateRowProps,
   UseRowStateState,
-  // UseSortByColumnOptions,
+  UseSortByColumnOptions,
   UseSortByColumnProps,
-  // UseSortByHooks,
-  // UseSortByInstanceProps,
+  UseSortByHooks,
+  UseSortByInstanceProps,
   UseSortByOptions,
   UseSortByState,
 } from 'react-table';
@@ -67,24 +67,24 @@ declare module 'react-table' {
       UseRowStateOptions<D>,
       UseSortByOptions<D> {}
 
-  // export interface Hooks<
-  //   D extends Record<string, unknown> = Record<string, unknown>
-  // > extends UseExpandedHooks<D>,
-  //     UseGroupByHooks<D>,
-  //     UseRowSelectHooks<D>,
-  //     UseSortByHooks<D> {}
+  export interface Hooks<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseExpandedHooks<D>,
+      UseGroupByHooks<D>,
+      UseRowSelectHooks<D>,
+      UseSortByHooks<D> {}
 
-  // export interface TableInstance<
-  //   D extends Record<string, unknown> = Record<string, unknown>
-  // > extends UseColumnOrderInstanceProps<D>,
-  //     UseExpandedInstanceProps<D>,
-  //     UseFiltersInstanceProps<D>,
-  //     UseGlobalFiltersInstanceProps<D>,
-  //     UseGroupByInstanceProps<D>,
-  //     UsePaginationInstanceProps<D>,
-  //     UseRowSelectInstanceProps<D>,
-  //     UseRowStateInstanceProps<D>,
-  //     UseSortByInstanceProps<D> {}
+  export interface TableInstance<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseColumnOrderInstanceProps<D>,
+      UseExpandedInstanceProps<D>,
+      UseFiltersInstanceProps<D>,
+      UseGlobalFiltersInstanceProps<D>,
+      UseGroupByInstanceProps<D>,
+      UsePaginationInstanceProps<D>,
+      UseRowSelectInstanceProps<D>,
+      UseRowStateInstanceProps<D>,
+      UseSortByInstanceProps<D> {}
 
   export interface TableState<
     D extends Record<string, unknown> = Record<string, unknown>
@@ -99,24 +99,23 @@ declare module 'react-table' {
       UseRowStateState<D>,
       UseSortByState<D> {}
 
-  // export interface ColumnInterface<
-  //   D extends Record<string, unknown> = Record<string, unknown>
-  // > extends UseFiltersColumnOptions<D>,
-  //     UseGlobalFiltersColumnOptions<D>,
-  //     UseGroupByColumnOptions<D>,
-  //     UseResizeColumnsColumnOptions<D>,
-  //     UseSortByColumnOptions<D> {}
+  export interface ColumnInterface<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseFiltersColumnOptions<D>,
+      UseGlobalFiltersColumnOptions<D>,
+      UseGroupByColumnOptions<D>,
+      UseResizeColumnsColumnOptions<D>,
+      UseSortByColumnOptions<D> {}
 
-  // export interface Cell<
-  //   D extends Record<string, unknown> = Record<string, unknown>,
-  //   V = any
-  // > extends UseGroupByCellProps<D>,
-  //     UseRowStateCellProps<D> {}
+  export interface Cell<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseGroupByCellProps<D>,
+      UseRowStateCellProps<D> {}
 
-  // export interface Row<
-  //   D extends Record<string, unknown> = Record<string, unknown>
-  // > extends UseExpandedRowProps<D>,
-  //     UseGroupByRowProps<D>,
-  //     UseRowSelectRowProps<D>,
-  //     UseRowStateRowProps<D> {}
+  export interface Row<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseExpandedRowProps<D>,
+      UseGroupByRowProps<D>,
+      UseRowSelectRowProps<D>,
+      UseRowStateRowProps<D> {}
 }


### PR DESCRIPTION
#128 partly - enough for now

- I went with a quick implementation with the `useImperativeHandle` hook to see if we like it. It's against the 'react grain' (passing props down, rather than passing a thing down to access the child) so I can see it not being liked. I am still undecided
- couple offroads
- Think best to change the icons of the checkbox for the nice border radius (which I played with and cant get to work) and color. Probably better to be using the blue as the secondary, I guess


![image](https://user-images.githubusercontent.com/35858975/132331380-ef0f0f9c-310e-4d39-a393-0dfe30742c60.png)
![image](https://user-images.githubusercontent.com/35858975/132331399-cd698406-5108-4894-b239-6ae52bbdc4fd.png)

