### PR TITLE
#144 row selection and delete

### DIFF
--- a/packages/common/src/intl/locales/ar.json
+++ b/packages/common/src/intl/locales/ar.json
@@ -28,6 +28,7 @@
     "button.go-back": "Go back",
     "error.something-wrong": "Oops! Somethings gone wrong.",
     "button.delete-lines": "Delete selected lines",
+    "button.export-to-csv": "Export to CSV",
     "label.customer": "Customer",
     "label.date": "Date",
     "label.id": "ID",

--- a/packages/common/src/intl/locales/ar.json
+++ b/packages/common/src/intl/locales/ar.json
@@ -27,6 +27,7 @@
     "button.try-again": "Try again",
     "button.go-back": "Go back",
     "error.something-wrong": "Oops! Somethings gone wrong.",
+    "button.delete-lines": "Delete selected lines",
     "label.customer": "Customer",
     "label.date": "Date",
     "label.id": "ID",

--- a/packages/common/src/intl/locales/en.json
+++ b/packages/common/src/intl/locales/en.json
@@ -26,6 +26,7 @@
   "button.print": "Print",
   "button.go-back": "Go back",
   "button.try-again": "Try again",
+  "button.delete-lines": "Delete selected lines",
   "error.something-wrong": "Oops! Somethings gone wrong.",
   "label.customer": "Customer",
   "label.date": "Date",

--- a/packages/common/src/intl/locales/en.json
+++ b/packages/common/src/intl/locales/en.json
@@ -27,6 +27,7 @@
   "button.go-back": "Go back",
   "button.try-again": "Try again",
   "button.delete-lines": "Delete selected lines",
+  "button.export-to-csv": "Export to CSV",
   "error.something-wrong": "Oops! Somethings gone wrong.",
   "label.customer": "Customer",
   "label.date": "Date",

--- a/packages/common/src/intl/locales/fr.json
+++ b/packages/common/src/intl/locales/fr.json
@@ -26,6 +26,7 @@
   "button.open-the-menu": "Ouvrir le menu",
   "button.try-again": "Try again",
   "button.go-back": "Go back",
+  "button.delete-lines": "Delete selected lines",
   "error.something-wrong": "Oops! Somethings gone wrong.",
   "label.customer": "Client",
   "label.date": "Date",

--- a/packages/common/src/intl/locales/fr.json
+++ b/packages/common/src/intl/locales/fr.json
@@ -27,6 +27,7 @@
   "button.try-again": "Try again",
   "button.go-back": "Go back",
   "button.delete-lines": "Delete selected lines",
+  "button.export-to-csv": "Export to CSV",
   "error.something-wrong": "Oops! Somethings gone wrong.",
   "label.customer": "Client",
   "label.date": "Date",

--- a/packages/common/src/intl/locales/pt.json
+++ b/packages/common/src/intl/locales/pt.json
@@ -27,6 +27,7 @@
   "button.try-again": "Try again",
   "button.go-back": "Go back",
   "button.delete-lines": "Delete selected lines",
+  "button.export-to-csv": "Export to CSV",
   "error.something-wrong": "Oops! Somethings gone wrong.",
   "label.customer": "Customer",
   "label.date": "Date",

--- a/packages/common/src/intl/locales/pt.json
+++ b/packages/common/src/intl/locales/pt.json
@@ -26,6 +26,7 @@
   "button.open-the-menu": "Abra o menu",
   "button.try-again": "Try again",
   "button.go-back": "Go back",
+  "button.delete-lines": "Delete selected lines",
   "error.something-wrong": "Oops! Somethings gone wrong.",
   "label.customer": "Customer",
   "label.date": "Date",

--- a/packages/common/src/ui/components/index.ts
+++ b/packages/common/src/ui/components/index.ts
@@ -14,6 +14,7 @@ export * from './buttons';
 export * from './errors';
 export * from './LoadingSpinner';
 export * from './RemoteComponent';
+export * from './menus';
 
 export {
   CircularProgress,

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.stories.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { SvgIconProps } from '@material-ui/core';
 import { ComponentMeta, Story } from '@storybook/react';
 import { Dropdown, DropdownItem } from './Dropdown';
+import { Customers, Download, Suppliers, Tools } from '../../../icons';
 
 export default {
   title: 'Inputs/Dropdown',
@@ -47,13 +49,39 @@ const clickOptions = [
   { label: 'Three', onClick: () => console.log('three') },
 ];
 
+const iconOptions = [
+  { label: 'Customers', icon: Customers },
+  { label: 'Suppliers', icon: Suppliers },
+  { label: 'Download', icon: Download },
+  { label: 'Tools', icon: Tools },
+];
+
+const someWithIconsOptions = [
+  { label: 'Customers', icon: Customers },
+  { label: 'Suppliers' },
+  { label: 'Download', icon: Download },
+  { label: 'Tools', inset: true },
+];
+
 const Template: Story<{
-  options: { label: string; value?: string; onClick?: () => void }[];
+  options: {
+    label: string;
+    value?: string;
+    onClick?: () => void;
+    icon?: React.JSXElementConstructor<SvgIconProps>;
+    inset?: boolean;
+  }[];
   placeholder: string;
 }> = args => (
   <Dropdown label={args.placeholder}>
-    {args.options.map(({ label, value, onClick }) => (
-      <DropdownItem key={label} value={value} onClick={onClick}>
+    {args.options.map(({ label, value, onClick, icon, inset }) => (
+      <DropdownItem
+        key={label}
+        value={value}
+        onClick={onClick}
+        IconComponent={icon}
+        inset={inset}
+      >
         {label}
       </DropdownItem>
     ))}
@@ -76,4 +104,16 @@ export const OnClick = Template.bind({});
 OnClick.args = {
   options: clickOptions,
   placeholder: 'Select a country!',
+};
+
+export const WithIcons = Template.bind({});
+WithIcons.args = {
+  options: iconOptions,
+  placeholder: 'Select a .. thing!',
+};
+
+export const SomeWithIcons = Template.bind({});
+SomeWithIcons.args = {
+  options: someWithIconsOptions,
+  placeholder: 'Select a different thing!',
 };

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.stories.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta, Story } from '@storybook/react';
+
+import { Dropdown, DropdownItem } from './Dropdown';
+import { Box, styled } from '@material-ui/system';
+
+export default {
+  title: 'Inputs/Dropdown',
+  component: Dropdown,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} as ComponentMeta<typeof Dropdown>;
+
+const options = [
+  { value: 'cooks', label: 'Cook islands.' },
+  { value: 'tonga', label: 'Tonga' },
+  { value: 'tokelau', label: 'Tokelau' },
+  { value: 'marshallIsland', label: 'Marshall Island' },
+  { value: 'micronesia', label: 'Micronesia' },
+  { value: 'nauru', label: 'Nauru' },
+  { value: 'kiribati', label: 'Kiribati' },
+  { value: 'png', label: 'Papa New Guinea' },
+  { value: 'solomons', label: 'Solomon Islands' },
+  { value: 'vanuatu', label: 'Vanuatu' },
+  { value: 'eastTimor', label: 'East Timor' },
+  { value: 'cambodia', label: 'Cambodia' },
+  { value: 'fiji', label: 'Fiji' },
+  { value: 'laos', label: 'Laos' },
+  { value: 'india', label: 'India' },
+  { value: 'myanmar', label: 'Myanmar' },
+  { value: 'afghanistan', label: 'Afghanistan' },
+  { value: 'nepal', label: 'Nepal' },
+  { value: 'southSudan', label: 'South Sudan' },
+  { value: 'uganda', label: 'Uganda' },
+  { value: 'tanzania', label: 'Tanzania' },
+  { value: 'zambia', label: 'Zambia' },
+  { value: 'cdi', label: "Cote d'Ivoire" },
+  { value: 'nigeria', label: 'Nigeria' },
+  { value: 'ghana', label: 'Ghana' },
+  { value: 'drCongo', label: 'Democratic Republic of the Congo' },
+  { value: 'liberia', label: 'Liberia' },
+  { value: 'sierraLeone', label: 'Sierra Leone' },
+  { value: 'gambia', label: 'Gambia' },
+  { value: 'uk', label: 'United Kingdom' },
+  { value: 'usa', label: 'United States of America' },
+];
+
+const Container = styled('div')({
+  display: 'flex',
+  flex: 1,
+  justifyContent: 'flex-end',
+});
+
+const Template: Story<{
+  options: { label: string; value: string }[];
+  placeholder: string;
+}> = args => (
+  <Container>
+    <Dropdown label={args.placeholder} value="">
+      {args.options.map(({ label, value }) => (
+        <DropdownItem key={label} value={value}>
+          {label}
+        </DropdownItem>
+      ))}
+    </Dropdown>
+  </Container>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  options: options.slice(0, 5),
+  placeholder: 'Select a country!',
+};

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.stories.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.stories.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta, Story } from '@storybook/react';
-
+import { ComponentMeta, Story } from '@storybook/react';
 import { Dropdown, DropdownItem } from './Dropdown';
-import { Box, styled } from '@material-ui/system';
 
 export default {
   title: 'Inputs/Dropdown',
   component: Dropdown,
-  argTypes: {
-    backgroundColor: { control: 'color' },
-  },
 } as ComponentMeta<typeof Dropdown>;
 
 const options = [
@@ -46,29 +41,39 @@ const options = [
   { value: 'usa', label: 'United States of America' },
 ];
 
-const Container = styled('div')({
-  display: 'flex',
-  flex: 1,
-  justifyContent: 'flex-end',
-});
+const clickOptions = [
+  { label: 'One', onClick: () => console.log('one') },
+  { label: 'Two', onClick: () => console.log('two') },
+  { label: 'Three', onClick: () => console.log('three') },
+];
 
 const Template: Story<{
-  options: { label: string; value: string }[];
+  options: { label: string; value?: string; onClick?: () => void }[];
   placeholder: string;
 }> = args => (
-  <Container>
-    <Dropdown label={args.placeholder} value="">
-      {args.options.map(({ label, value }) => (
-        <DropdownItem key={label} value={value}>
-          {label}
-        </DropdownItem>
-      ))}
-    </Dropdown>
-  </Container>
+  <Dropdown label={args.placeholder}>
+    {args.options.map(({ label, value, onClick }) => (
+      <DropdownItem key={label} value={value} onClick={onClick}>
+        {label}
+      </DropdownItem>
+    ))}
+  </Dropdown>
 );
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const Simple = Template.bind({});
+Simple.args = {
   options: options.slice(0, 5),
+  placeholder: 'Select a country!',
+};
+
+export const LargeList = Template.bind({});
+LargeList.args = {
+  options: options,
+  placeholder: 'Select a country!',
+};
+
+export const OnClick = Template.bind({});
+OnClick.args = {
+  options: clickOptions,
   placeholder: 'Select a country!',
 };

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.test.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { Dropdown, DropdownItem } from '.';
+import { TestingProvider } from '../../../../utils';
+
+describe('Dropdown', () => {
+  it('Renders the dropdown item children when the dropdown is clicked', () => {
+    const { getByRole, getByText } = render(
+      <TestingProvider>
+        <Dropdown label="dropdown">
+          <DropdownItem>One</DropdownItem>
+        </Dropdown>
+      </TestingProvider>
+    );
+
+    const button = getByRole('button');
+
+    act(() => {
+      userEvent.click(button);
+    });
+
+    const node = getByText(/one/i);
+
+    expect(node).toBeInTheDocument();
+  });
+
+  it('Renders the dropdown item children when the dropdown is clicked', () => {
+    const TestDropdown = () => {
+      const [text, setText] = React.useState('one');
+
+      return (
+        <TestingProvider>
+          <Dropdown label="dropdown">
+            <DropdownItem onClick={() => setText('two')}>{text}</DropdownItem>
+          </Dropdown>
+        </TestingProvider>
+      );
+    };
+
+    const { getByRole, getByText } = render(<TestDropdown />);
+
+    const button = getByRole('button');
+
+    act(() => {
+      userEvent.click(button);
+    });
+
+    let node = getByText(/one/i);
+
+    act(() => {
+      userEvent.click(node);
+    });
+
+    node = getByText(/two/i);
+
+    expect(node).toBeInTheDocument();
+  });
+});

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.test.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -53,7 +53,7 @@ describe('Dropdown', () => {
       userEvent.click(node);
     });
 
-    node = getByText(/two/i);
+    node = screen.getByText(/two/i);
 
     expect(node).toBeInTheDocument();
   });

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.test.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -53,7 +53,7 @@ describe('Dropdown', () => {
       userEvent.click(node);
     });
 
-    node = screen.getByText(/two/i);
+    node = getByText(/two/i);
 
     expect(node).toBeInTheDocument();
   });

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -1,15 +1,14 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import {
   MenuItem,
   MenuItemProps,
   FormControl,
   Select,
-  ListItemText,
-  Menu,
+  InputLabel,
+  outlinedInputClasses,
 } from '@material-ui/core';
-import { outlinedInputClasses } from '@material-ui/core/OutlinedInput';
-import InputLabel from '@material-ui/core/InputLabel';
 import { styled } from '@material-ui/system';
+
 import { ChevronDown } from '../../../icons';
 
 export const DropdownItem: FC<MenuItemProps> = props => {
@@ -18,7 +17,7 @@ export const DropdownItem: FC<MenuItemProps> = props => {
 
 const StyledSelect = styled(Select)(({ theme }) => ({
   borderRadius: '8px',
-  minWidth: 160,
+  width: 160,
   backgroundColor: 'white',
   '& .MuiSelect-icon': {
     // If left is not explicitly defined, sometimes the icon floats to the left
@@ -39,30 +38,15 @@ const StyledSelect = styled(Select)(({ theme }) => ({
     },
 }));
 
-interface Action {
-  label: string;
-  callback: () => void;
-}
-interface ActionDropdownProps {
-  actions: Action[];
+interface DropdownProps {
   label: string;
 }
 
 // Styled doesn't like `sx` prop being passed to it.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const ActionDropdown: FC<ActionDropdownProps> = ({ label, actions }) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
+export const Dropdown: FC<DropdownProps> = ({ label, children }) => {
   return (
-    <FormControl margin="dense" size="small">
+    <FormControl size="small">
       <InputLabel
         shrink={false}
         sx={{ color: '#8f90a6', '&.Mui-focused': { color: '#8f90a6' } }}
@@ -72,41 +56,14 @@ export const ActionDropdown: FC<ActionDropdownProps> = ({ label, actions }) => {
         {label}
       </InputLabel>
       <StyledSelect
-        open={false}
         value=""
-        onOpen={event =>
-          setAnchorEl(
-            (event as React.KeyboardEvent<HTMLDivElement>).currentTarget
-          )
-        }
         size="small"
         labelId={`action-drop-down-label-${label}`}
-        onClick={handleClick}
         variant="outlined"
         IconComponent={ChevronDown}
-      />
-      <Menu
-        sx={{
-          '& .MuiPaper-root': { borderRadius: '8px' },
-        }}
-        open={Boolean(anchorEl)}
-        anchorEl={anchorEl}
-        onClose={handleClose}
       >
-        {actions.map(({ callback, label }) => (
-          <DropdownItem
-            key={label}
-            onClick={() => {
-              callback();
-              handleClose();
-            }}
-          >
-            <ListItemText>{label}</ListItemText>
-          </DropdownItem>
-        ))}
-      </Menu>
+        {children}
+      </StyledSelect>
     </FormControl>
   );
 };
-
-export const Dropdown = ActionDropdown;

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -9,8 +9,9 @@ import {
   Box,
   SvgIconProps,
   ListItemText,
+  styled,
 } from '@material-ui/core';
-import { styled } from '@material-ui/system';
+// import { styled } from '@material-ui/system';
 
 import { ChevronDown } from '../../../icons';
 
@@ -45,7 +46,8 @@ const StyledSelect = styled(Select)(({ theme }) => ({
   '& .MuiSelect-icon': {
     // If left is not explicitly defined, sometimes the icon floats to the left
     left: 'calc(100% - 30px)',
-    color: theme.palette['primary']['500'],
+    // color: theme.palette['primary']['500'],
+    color: theme.palette.primary.main,
   },
 
   [`& .${outlinedInputClasses.notchedOutline}`]: {

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -21,7 +21,7 @@ interface DropdownItemProps extends MenuItemProps {
 
 export const DropdownItem: FC<DropdownItemProps> = props => {
   return (
-    <MenuItem sx={{ fontSize: '10' }}>
+    <MenuItem sx={{ fontSize: '10' }} {...props}>
       {props.IconComponent ? (
         <Box mr={1}>
           <props.IconComponent fontSize="inherit" />

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -6,13 +6,36 @@ import {
   Select,
   InputLabel,
   outlinedInputClasses,
+  Box,
+  SvgIconProps,
+  ListItemText,
 } from '@material-ui/core';
 import { styled } from '@material-ui/system';
 
 import { ChevronDown } from '../../../icons';
 
-export const DropdownItem: FC<MenuItemProps> = props => {
-  return <MenuItem {...props} />;
+interface DropdownItemProps extends MenuItemProps {
+  IconComponent?: React.JSXElementConstructor<SvgIconProps>;
+  inset?: boolean;
+}
+
+export const DropdownItem: FC<DropdownItemProps> = props => {
+  return (
+    <MenuItem sx={{ fontSize: '10' }}>
+      {props.IconComponent ? (
+        <Box mr={1}>
+          <props.IconComponent fontSize="inherit" />
+        </Box>
+      ) : null}
+      <ListItemText
+        inset={props.inset}
+        primaryTypographyProps={{ sx: { fontSize: 'inherit' } }}
+        sx={{ '&.MuiListItemText-inset': { paddingLeft: '22px' } }}
+      >
+        {props.children}
+      </ListItemText>
+    </MenuItem>
+  );
 };
 
 const StyledSelect = styled(Select)(({ theme }) => ({

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -11,7 +11,6 @@ import {
   ListItemText,
   styled,
 } from '@material-ui/core';
-// import { styled } from '@material-ui/system';
 
 import { ChevronDown } from '../../../icons';
 
@@ -46,7 +45,6 @@ const StyledSelect = styled(Select)(({ theme }) => ({
   '& .MuiSelect-icon': {
     // If left is not explicitly defined, sometimes the icon floats to the left
     left: 'calc(100% - 30px)',
-    // color: theme.palette['primary']['500'],
     color: theme.palette.primary.main,
   },
 

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -74,7 +74,6 @@ export const Dropdown: FC<DropdownProps> = ({ label, children }) => {
         shrink={false}
         sx={{ color: '#8f90a6', '&.Mui-focused': { color: '#8f90a6' } }}
         id={`action-drop-down-label-${label}`}
-        aria-label="Select an action to perform on selected rows"
       >
         {label}
       </InputLabel>

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -19,12 +19,15 @@ interface DropdownItemProps extends MenuItemProps {
   inset?: boolean;
 }
 
-export const DropdownItem: FC<DropdownItemProps> = props => {
+export const DropdownItem: FC<DropdownItemProps> = ({
+  IconComponent,
+  ...props
+}) => {
   return (
     <MenuItem sx={{ fontSize: '10' }} {...props}>
-      {props.IconComponent ? (
+      {IconComponent ? (
         <Box mr={1}>
-          <props.IconComponent fontSize="inherit" />
+          <IconComponent fontSize="inherit" />
         </Box>
       ) : null}
       <ListItemText

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -1,16 +1,112 @@
-import React, { FC } from 'react';
-import Select, { SelectProps } from '@material-ui/core/Select';
-import MenuItem, { MenuItemProps } from '@material-ui/core/MenuItem';
+import React, { FC, useState } from 'react';
+import {
+  MenuItem,
+  MenuItemProps,
+  FormControl,
+  Select,
+  ListItemText,
+  Menu,
+} from '@material-ui/core';
+import { outlinedInputClasses } from '@material-ui/core/OutlinedInput';
+import InputLabel from '@material-ui/core/InputLabel';
 import { styled } from '@material-ui/system';
+import { ChevronDown } from '../../../icons';
 
 export const DropdownItem: FC<MenuItemProps> = props => {
   return <MenuItem {...props} />;
 };
 
-const StyledSelect = styled(Select)({});
+const StyledSelect = styled(Select)(({ theme }) => ({
+  borderRadius: '8px',
+  minWidth: 160,
+  backgroundColor: 'white',
+  '& .MuiSelect-icon': {
+    // If left is not explicitly defined, sometimes the icon floats to the left
+    left: 'calc(100% - 30px)',
+    color: theme.palette['primary']['500'],
+  },
+
+  [`& .${outlinedInputClasses.notchedOutline}`]: {
+    borderColor: '#e4e4eb',
+  },
+  [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
+    borderColor: '#e4e4eb',
+  },
+
+  [`&.${outlinedInputClasses.focused} .${outlinedInputClasses.notchedOutline}`]:
+    {
+      borderColor: theme.palette['darkGrey'],
+    },
+}));
+
+interface Action {
+  label: string;
+  callback: () => void;
+}
+interface ActionDropdownProps {
+  actions: Action[];
+  label: string;
+}
 
 // Styled doesn't like `sx` prop being passed to it.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Dropdown: FC<SelectProps> = ({ sx, ...props }) => {
-  return <StyledSelect {...props} />;
+export const ActionDropdown: FC<ActionDropdownProps> = ({ label, actions }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <FormControl margin="dense" size="small">
+      <InputLabel
+        shrink={false}
+        sx={{ color: '#8f90a6', '&.Mui-focused': { color: '#8f90a6' } }}
+        id={`action-drop-down-label-${label}`}
+        aria-label="Select an action to perform on selected rows"
+      >
+        {label}
+      </InputLabel>
+      <StyledSelect
+        open={false}
+        value=""
+        onOpen={event =>
+          setAnchorEl(
+            (event as React.KeyboardEvent<HTMLDivElement>).currentTarget
+          )
+        }
+        size="small"
+        labelId={`action-drop-down-label-${label}`}
+        onClick={handleClick}
+        variant="outlined"
+        IconComponent={ChevronDown}
+      />
+      <Menu
+        sx={{
+          '& .MuiPaper-root': { borderRadius: '8px' },
+        }}
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+      >
+        {actions.map(({ callback, label }) => (
+          <DropdownItem
+            key={label}
+            onClick={() => {
+              callback();
+              handleClose();
+            }}
+          >
+            <ListItemText>{label}</ListItemText>
+          </DropdownItem>
+        ))}
+      </Menu>
+    </FormControl>
+  );
 };
+
+export const Dropdown = ActionDropdown;

--- a/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
+++ b/packages/common/src/ui/components/inputs/Dropdown/Dropdown.tsx
@@ -57,7 +57,7 @@ const StyledSelect = styled(Select)(({ theme }) => ({
 
   [`&.${outlinedInputClasses.focused} .${outlinedInputClasses.notchedOutline}`]:
     {
-      borderColor: theme.palette['darkGrey'],
+      borderColor: theme.palette.darkGrey,
     },
 }));
 

--- a/packages/common/src/ui/components/inputs/Dropdown/index.ts
+++ b/packages/common/src/ui/components/inputs/Dropdown/index.ts
@@ -1,1 +1,0 @@
-export { Dropdown, DropdownItem } from './Dropdown';

--- a/packages/common/src/ui/components/inputs/index.ts
+++ b/packages/common/src/ui/components/inputs/index.ts
@@ -1,2 +1,1 @@
 export * from './Checkbox';
-export * from './Dropdown';

--- a/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { SvgIconProps } from '@material-ui/core';
 import { ComponentMeta, Story } from '@storybook/react';
-import { Dropdown, DropdownItem } from './Dropdown';
+import { DropdownMenu, DropdownMenuItem } from './DropdownMenu';
 import { Customers, Download, Suppliers, Tools } from '../../../icons';
 
 export default {
-  title: 'Inputs/Dropdown',
-  component: Dropdown,
-} as ComponentMeta<typeof Dropdown>;
+  title: 'Menus/DropdownMenu',
+  component: DropdownMenu,
+} as ComponentMeta<typeof DropdownMenu>;
 
 const options = [
   { value: 'cooks', label: 'Cook islands.' },
@@ -73,9 +73,9 @@ const Template: Story<{
   }[];
   placeholder: string;
 }> = args => (
-  <Dropdown label={args.placeholder}>
+  <DropdownMenu label={args.placeholder}>
     {args.options.map(({ label, value, onClick, icon, inset }) => (
-      <DropdownItem
+      <DropdownMenuItem
         key={label}
         value={value}
         onClick={onClick}
@@ -83,9 +83,9 @@ const Template: Story<{
         inset={inset}
       >
         {label}
-      </DropdownItem>
+      </DropdownMenuItem>
     ))}
-  </Dropdown>
+  </DropdownMenu>
 );
 
 export const Simple = Template.bind({});

--- a/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.test.tsx
@@ -2,16 +2,16 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { Dropdown, DropdownItem } from '.';
+import { DropdownMenu, DropdownMenuItem } from './DropdownMenu';
 import { TestingProvider } from '../../../../utils';
 
 describe('Dropdown', () => {
   it('Renders the dropdown item children when the dropdown is clicked', () => {
     const { getByRole, getByText } = render(
       <TestingProvider>
-        <Dropdown label="dropdown">
-          <DropdownItem>One</DropdownItem>
-        </Dropdown>
+        <DropdownMenu label="dropdown">
+          <DropdownMenuItem>One</DropdownMenuItem>
+        </DropdownMenu>
       </TestingProvider>
     );
 
@@ -32,9 +32,11 @@ describe('Dropdown', () => {
 
       return (
         <TestingProvider>
-          <Dropdown label="dropdown">
-            <DropdownItem onClick={() => setText('two')}>{text}</DropdownItem>
-          </Dropdown>
+          <DropdownMenu label="dropdown">
+            <DropdownMenuItem onClick={() => setText('two')}>
+              {text}
+            </DropdownMenuItem>
+          </DropdownMenu>
         </TestingProvider>
       );
     };

--- a/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.test.tsx
@@ -26,7 +26,7 @@ describe('Dropdown', () => {
     expect(node).toBeInTheDocument();
   });
 
-  it('Renders the dropdown item children when the dropdown is clicked', () => {
+  it('Renders the dropdown item children when the dropdown is clicked and triggers the callback when an item is selected', () => {
     const TestDropdown = () => {
       const [text, setText] = React.useState('one');
 

--- a/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.tsx
+++ b/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.tsx
@@ -14,12 +14,12 @@ import {
 
 import { ChevronDown } from '../../../icons';
 
-interface DropdownItemProps extends MenuItemProps {
+interface DropdownMenuItemProps extends MenuItemProps {
   IconComponent?: React.JSXElementConstructor<SvgIconProps>;
   inset?: boolean;
 }
 
-export const DropdownItem: FC<DropdownItemProps> = ({
+export const DropdownMenuItem: FC<DropdownMenuItemProps> = ({
   IconComponent,
   ...props
 }) => {
@@ -64,13 +64,13 @@ const StyledSelect = styled(Select)(({ theme }) => ({
     },
 }));
 
-interface DropdownProps {
+interface DropdownMenuProps {
   label: string;
 }
 
 // Styled doesn't like `sx` prop being passed to it.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Dropdown: FC<DropdownProps> = ({ label, children }) => {
+export const DropdownMenu: FC<DropdownMenuProps> = ({ label, children }) => {
   return (
     <FormControl size="small">
       <InputLabel

--- a/packages/common/src/ui/components/menus/DropdownMenu/index.ts
+++ b/packages/common/src/ui/components/menus/DropdownMenu/index.ts
@@ -1,0 +1,1 @@
+export { DropdownMenu, DropdownMenuItem } from './DropdownMenu';

--- a/packages/common/src/ui/components/menus/index.ts
+++ b/packages/common/src/ui/components/menus/index.ts
@@ -1,0 +1,1 @@
+export * from './DropdownMenu';

--- a/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
+++ b/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
@@ -118,6 +118,7 @@ export const RemoteDataTable = <T extends Record<string, unknown>>({
                     sx={{
                       backgroundColor: 'transparent',
                     }}
+                    aria-label={column.id}
                     sortDirection={
                       column.isSorted
                         ? column.isSortedDesc

--- a/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
+++ b/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react';
 
 import {
-  ColumnInstance,
   SortingRule,
   usePagination,
   useRowSelect,
@@ -14,32 +13,23 @@ import {
 import {
   Box,
   CircularProgress,
-  Grid,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
   TableContainer,
   TablePagination,
+  TableSortLabel,
   Table as MuiTable,
 } from '@material-ui/core';
 
-import { useTheme } from '@material-ui/core/styles';
-
-import { SortAsc, SortDesc } from '../../icons';
+import { SortDesc } from '../../icons';
 import { DEFAULT_PAGE_SIZE } from '.';
 import { TableProps } from './types';
 import { useSetupDataTableApi } from './hooks/useDataTableApi';
 import { DataRow } from './components/DataRow/DataRow';
 
 export { SortingRule };
-
-const renderSortIcon = <D extends Record<string, unknown>>(
-  column: ColumnInstance<D>
-) => {
-  if (!column.isSorted) return null;
-  return !!column.isSortedDesc ? <SortDesc /> : <SortAsc />;
-};
 
 export const RemoteDataTable = <T extends Record<string, unknown>>({
   columns,
@@ -51,7 +41,6 @@ export const RemoteDataTable = <T extends Record<string, unknown>>({
   totalLength = 0,
   tableApi,
 }: TableProps<T>): JSX.Element => {
-  const theme = useTheme();
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [pageIndex, setPageIndex] = useState(0);
   const pageCount = Math.ceil(totalLength / pageSize);
@@ -105,7 +94,6 @@ export const RemoteDataTable = <T extends Record<string, unknown>>({
     <Box
       sx={{
         display: 'flex',
-        marginTop: 50,
       }}
     >
       <CircularProgress
@@ -116,25 +104,39 @@ export const RemoteDataTable = <T extends Record<string, unknown>>({
       />
     </Box>
   ) : (
-    <TableContainer sx={{ marginBottom: 100 }}>
+    <TableContainer>
       <MuiTable stickyHeader {...getTableProps()}>
         <TableHead>
           {headerGroups.map(({ getHeaderGroupProps, headers }) => (
             <TableRow {...getHeaderGroupProps()}>
-              {headers.map(column => (
-                <TableCell
-                  {...column.getHeaderProps(column.getSortByToggleProps())}
-                  sx={{
-                    backgroundColor: 'transparent',
-                    ...theme.typography.th,
-                  }}
-                >
-                  <Grid container>
-                    {column.render('Header')}
-                    {renderSortIcon(column)}
-                  </Grid>
-                </TableCell>
-              ))}
+              {headers.map(column => {
+                return (
+                  <TableCell
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    align={column.align}
+                    padding={column.id === 'selection' ? 'checkbox' : 'normal'}
+                    sx={{
+                      backgroundColor: 'transparent',
+                    }}
+                    sortDirection={
+                      column.isSorted
+                        ? column.isSortedDesc
+                          ? 'desc'
+                          : 'asc'
+                        : false
+                    }
+                  >
+                    <TableSortLabel
+                      hideSortIcon={column.id === 'selection'}
+                      active={column.isSorted}
+                      direction={column.isSortedDesc ? 'desc' : 'asc'}
+                      IconComponent={SortDesc}
+                    >
+                      {column.render('Header')}
+                    </TableSortLabel>
+                  </TableCell>
+                );
+              })}
             </TableRow>
           ))}
         </TableHead>

--- a/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
+++ b/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
@@ -8,6 +8,7 @@ import {
   useRowSelect,
   useSortBy,
   useTable,
+  Row,
 } from 'react-table';
 
 import {
@@ -29,6 +30,7 @@ import { SortAsc, SortDesc } from '../../icons';
 import { DEFAULT_PAGE_SIZE } from '.';
 import { TableProps } from './types';
 import { useSetupDataTableApi } from './hooks/useDataTableApi';
+import { DataRow } from './components/DataRow/DataRow';
 
 export { SortingRule };
 
@@ -53,7 +55,6 @@ export const RemoteDataTable = <T extends Record<string, unknown>>({
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [pageIndex, setPageIndex] = useState(0);
   const pageCount = Math.ceil(totalLength / pageSize);
-  const hasRowClick = !!onRowClick;
   const tableInstance = useTable(
     {
       columns,
@@ -138,31 +139,22 @@ export const RemoteDataTable = <T extends Record<string, unknown>>({
           ))}
         </TableHead>
         <TableBody {...getTableBodyProps()}>
-          {rows.map(row => {
+          {rows.map((row: Row<T>) => {
             prepareRow(row);
+
+            const { cells, values } = row;
+            const { key } = row.getRowProps();
+
             return (
-              <TableRow
-                {...row.getRowProps()}
-                onClick={() => onRowClick && onRowClick(row)}
-                hover={hasRowClick}
-              >
-                {row.cells.map(cell => {
-                  return (
-                    <TableCell
-                      {...cell.getCellProps()}
-                      sx={{
-                        padding: 0,
-                        paddingLeft: '16px',
-                        ...(hasRowClick && { cursor: 'pointer' }),
-                      }}
-                    >
-                      {cell.render('Cell')}
-                    </TableCell>
-                  );
-                })}
-              </TableRow>
+              <DataRow<T>
+                cells={cells}
+                values={values as T}
+                key={key}
+                onClick={onRowClick}
+              />
             );
           })}
+
           <TableRow>
             <TablePagination
               page={pageIndex}

--- a/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { Checkbox } from '../../../components/inputs/Checkbox';
 import { Column } from 'react-table';
 
-export const getCheckboxSelectionColumn = (): Column => ({
+export const getCheckboxSelectionColumn = (): Column & { align: string } => ({
   id: 'selection',
+  align: 'right',
+  disableSortBy: true,
   Header: ({ getToggleAllRowsSelectedProps }) => (
     <Checkbox
       size="small"

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
@@ -15,26 +15,32 @@ const cells = [
   {
     render: () => <span>11</span>,
     getCellProps: () => ({ key: Math.random() * 20 }),
+    column: { align: 'right' },
   },
   {
     render: () => <span>General Warehouse</span>,
     getCellProps: () => ({ key: Math.random() * 20 }),
+    column: { align: 'right' },
   },
   {
     render: () => <span>All items: General warehouse</span>,
     getCellProps: () => ({ key: Math.random() * 20 }),
+    column: { align: 'right' },
   },
   {
     render: () => <span>52</span>,
     getCellProps: () => ({ key: Math.random() * 20 }),
+    column: { align: 'right' },
   },
   {
     render: () => <span>25 Nov 2020</span>,
     getCellProps: () => ({ key: Math.random() * 20 }),
+    column: { align: 'right' },
   },
   {
     render: () => <span>In Progress</span>,
     getCellProps: () => ({ key: Math.random() * 20 }),
+    column: { align: 'right' },
   },
 ] as any;
 

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
@@ -4,7 +4,7 @@ import { TableBody, Table } from '@material-ui/core';
 import { DataRow } from './DataRow';
 
 export default {
-  title: 'Components/Table/DataRow',
+  title: 'Table/DataRow',
   component: DataRow,
   argTypes: {
     backgroundColor: { control: 'color' },
@@ -47,6 +47,9 @@ const Template: Story = ({ onClick }) => (
 );
 
 export const Basic = Template.bind({});
+Basic.args = {
+  onClick: null,
+};
 
 export const WithRowClick = Template.bind({});
 WithRowClick.args = {

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ComponentMeta, Story } from '@storybook/react';
+import { TableBody, Table } from '@material-ui/core';
+import { DataRow } from './DataRow';
+
+export default {
+  title: 'Components/Table/DataRow',
+  component: DataRow,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} as ComponentMeta<typeof DataRow>;
+
+const cells = [
+  {
+    render: () => <span>11</span>,
+    getCellProps: () => ({ key: Math.random() * 20 }),
+  },
+  {
+    render: () => <span>General Warehouse</span>,
+    getCellProps: () => ({ key: Math.random() * 20 }),
+  },
+  {
+    render: () => <span>All items: General warehouse</span>,
+    getCellProps: () => ({ key: Math.random() * 20 }),
+  },
+  {
+    render: () => <span>52</span>,
+    getCellProps: () => ({ key: Math.random() * 20 }),
+  },
+  {
+    render: () => <span>25 Nov 2020</span>,
+    getCellProps: () => ({ key: Math.random() * 20 }),
+  },
+  {
+    render: () => <span>In Progress</span>,
+    getCellProps: () => ({ key: Math.random() * 20 }),
+  },
+] as any;
+
+const Template: Story = ({ onClick }) => (
+  <Table>
+    <TableBody>
+      <DataRow cells={cells} values={{ id: 'josh' }} onClick={onClick} />
+    </TableBody>
+  </Table>
+);
+
+export const Basic = Template.bind({});
+
+export const WithRowClick = Template.bind({});
+WithRowClick.args = {
+  onClick: () => {},
+};

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { TableBody, Table } from '@material-ui/core';
+
+import { DataRow } from './DataRow';
+
+describe('DataRow', () => {
+  const cells = [
+    {
+      render: () => <span>josh</span>,
+      getCellProps: () => ({ key: Math.random() * 20 }),
+    },
+  ] as any;
+
+  it('Renders a cell passed', () => {
+    const { getByText } = render(
+      <Table>
+        <TableBody>
+          <DataRow cells={cells} values={{ id: 'josh' }} />
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByText(/josh/)).toBeInTheDocument();
+  });
+});

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
@@ -10,6 +10,7 @@ describe('DataRow', () => {
     {
       render: () => <span>josh</span>,
       getCellProps: () => ({ key: Math.random() * 20 }),
+      column: { align: 'right' },
     },
   ] as any;
 

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -27,7 +27,9 @@ export const DataRow = <T extends Record<string, unknown>>({
         return (
           <TableCell
             key={cellKey}
+            align={cell.column.align}
             sx={{
+              justifyContent: 'flex-end',
               padding: 0,
               paddingLeft: '16px',
               ...(hasOnClick && { cursor: 'pointer' }),

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -1,0 +1,42 @@
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import React from 'react';
+import { Cell } from 'react-table';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+interface DataRowProps<T extends object> {
+  cells: Cell<T, any>[];
+  onClick?: (rowValues: T) => void;
+  values: T;
+}
+
+export const DataRow = <T extends Record<string, unknown>>({
+  cells,
+  onClick,
+  values,
+}: DataRowProps<T>): JSX.Element => {
+  const hasOnClick = !!onClick;
+  const onRowClick = () => onClick && onClick(values);
+
+  return (
+    <TableRow onClick={onRowClick} hover={hasOnClick}>
+      {cells.map(cell => {
+        const cellProps = cell.getCellProps();
+        const { key: cellKey } = cellProps;
+
+        return (
+          <TableCell
+            key={cellKey}
+            sx={{
+              padding: 0,
+              paddingLeft: '16px',
+              ...(hasOnClick && { cursor: 'pointer' }),
+            }}
+          >
+            {cell.render('Cell')}
+          </TableCell>
+        );
+      })}
+    </TableRow>
+  );
+};

--- a/packages/common/src/ui/layout/tables/components/DataRow/index.ts
+++ b/packages/common/src/ui/layout/tables/components/DataRow/index.ts
@@ -1,0 +1,1 @@
+export { DataRow } from './DataRow';

--- a/packages/common/src/ui/layout/tables/hooks/useColumns.ts
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns.ts
@@ -7,6 +7,7 @@ const columnLookup = (column: GenericColumnType) => {
   if (column === GenericColumnType.Selection) {
     return getCheckboxSelectionColumn();
   }
+  return null;
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -30,6 +31,7 @@ export const useColumns = <T extends object>(
     const sortDescFirst = column.format === ColumnFormat.date;
 
     return {
+      align: column.align || 'left',
       accessor,
       disableSortBy,
       Header,

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,6 +1,6 @@
 import { LocaleKey } from '@openmsupply-client/common/src/intl/intlHelpers';
 import { ReactNode, RefObject } from 'react';
-import { Column, Row, SortingRule } from 'react-table';
+import { Column, SortingRule } from 'react-table';
 
 export enum ColumnFormat {
   date,
@@ -44,7 +44,7 @@ export interface TableProps<T extends Record<string, unknown>> {
   initialSortBy?: SortingRule<T>[];
   isLoading?: boolean;
   onFetchData: (props: QueryProps<T>) => void;
-  onRowClick?: <T extends Record<string, unknown>>(row: Row<T>) => void;
+  onRowClick?: (row: T) => void;
   totalLength?: number;
   tableApi: RefObject<DataTableApi<T>>;
   children?: ReactNode;

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -14,6 +14,7 @@ export interface ColumnDefinition<T> {
   format?: ColumnFormat;
   key: keyof T;
   sortable?: boolean; // defaults to true
+  align?: 'left' | 'right' | 'center';
 }
 
 export enum GenericColumnType {

--- a/packages/host/src/AppBar.tsx
+++ b/packages/host/src/AppBar.tsx
@@ -28,6 +28,9 @@ const StyledContainer = styled(Box, {
   marginLeft: 80,
   marginRight: 0,
   minHeight: 90,
+  paddingLeft: '16px',
+  paddingRight: '16px',
+  paddingBottom: '16px',
   zIndex: theme.zIndex.drawer - 1,
   boxShadow: theme.shadows[1],
   ...theme.mixins.header,
@@ -48,12 +51,12 @@ const StyledContainer = styled(Box, {
 
 const AppBar: React.FC = () => {
   const { isOpen } = useDrawer();
-  const { appBarButtonsRef, appBarContentRef } = useHostContext();
+  const { appBarButtonsRef } = useHostContext();
   const navigate = useNavigate();
 
   return (
     <StyledContainer isOpen={isOpen}>
-      <Toolbar disableGutters sx={{ paddingLeft: '24px' }}>
+      <Toolbar disableGutters>
         <UnstyledIconButton
           icon={<ArrowLeft />}
           titleKey="button.go-back"

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -21,7 +21,6 @@ import AppBar from './AppBar';
 import Viewport from './Viewport';
 
 const Content = styled(Box)({
-  marginTop: 90,
   overflowY: 'scroll',
   height: '100vh',
 });

--- a/packages/mock-server/src/schema/Transaction.js
+++ b/packages/mock-server/src/schema/Transaction.js
@@ -71,6 +71,15 @@ const TransactionQueryResolvers = {
 };
 
 const TransactionMutationResolvers = {
+  deleteTransactions: (_, { transactions }) => {
+    transactions.forEach(({ id: deleteId }) => {
+      const idx = TransactionData.findIndex(({ id }) => deleteId === id);
+      TransactionData.splice(idx, 1);
+    });
+
+    return transactions;
+  },
+
   upsertTransaction: (_, { transaction: { id: filterId, ...patch } }) => {
     if (!filterId) {
       const newId = String(TransactionData.length);
@@ -105,6 +114,7 @@ const TransactionMutations = `
     upsertTransaction(transaction: TransactionPatch): Transaction
     addTransaction(transaction: TransactionPatch): Transaction
     deleteTransaction(transaction: TransactionPatch): Transaction
+    deleteTransactions(transactions: [TransactionPatch]): [Transaction]
 `;
 
 const TransactionInput = `

--- a/packages/mocks/src/handlers.ts
+++ b/packages/mocks/src/handlers.ts
@@ -2,7 +2,7 @@ import { graphql } from 'msw';
 
 import faker from 'faker';
 
-const TransactionData = Array.from({ length: 500 }).map((_, i) => ({
+const TransactionData = Array.from({ length: 10 }).map((_, i) => ({
   id: `${i}`,
   customer: `${faker.name.firstName()} ${faker.name.lastName()}`,
   supplier: `${faker.name.firstName()} ${faker.name.lastName()}`,
@@ -52,6 +52,21 @@ const upsertTransaction = graphql.mutation(
   }
 );
 
+const deleteTransactions = graphql.mutation(
+  'deleteTransactions',
+  (request, response, context) => {
+    const { variables } = request;
+    const { transactions } = variables;
+
+    transactions.forEach(({ id: deleteId }: { id: string }) => {
+      const idx = TransactionData.findIndex(({ id }) => deleteId === id);
+      TransactionData.splice(idx, 1);
+    });
+
+    return response(context.data({ transactions }));
+  }
+);
+
 export const transactionList = graphql.query(
   'transactions',
   (request, response, context) => {
@@ -83,4 +98,9 @@ export const transactionDetail = graphql.query(
   }
 );
 
-export const handlers = [transactionList, transactionDetail, upsertTransaction];
+export const handlers = [
+  transactionList,
+  transactionDetail,
+  upsertTransaction,
+  deleteTransactions,
+];

--- a/packages/mocks/src/handlers.ts
+++ b/packages/mocks/src/handlers.ts
@@ -2,7 +2,7 @@ import { graphql } from 'msw';
 
 import faker from 'faker';
 
-const TransactionData = Array.from({ length: 10 }).map((_, i) => ({
+const TransactionData = Array.from({ length: 500 }).map((_, i) => ({
   id: `${i}`,
   customer: `${faker.name.firstName()} ${faker.name.lastName()}`,
   supplier: `${faker.name.firstName()} ${faker.name.lastName()}`,

--- a/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
@@ -3,6 +3,8 @@ import React, { FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 import {
+  Dropdown,
+  DropdownItem,
   request,
   Transaction,
   useQueryClient,
@@ -75,6 +77,11 @@ export const OutboundShipmentDetailView: FC = () => {
 
   return draft ? (
     <>
+      <Dropdown label="Select" value="">
+        <DropdownItem onClick={() => console.log('ten!')}>Ten</DropdownItem>
+        <DropdownItem value={() => console.log('twenty!')}>Twenty</DropdownItem>
+      </Dropdown>
+
       <div>
         <input
           value={draft?.customer}

--- a/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
@@ -3,8 +3,6 @@ import React, { FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 import {
-  Dropdown,
-  DropdownItem,
   request,
   Transaction,
   useQueryClient,
@@ -77,11 +75,6 @@ export const OutboundShipmentDetailView: FC = () => {
 
   return draft ? (
     <>
-      <Dropdown label="Select" value="">
-        <DropdownItem onClick={() => console.log('ten!')}>Ten</DropdownItem>
-        <DropdownItem value={() => console.log('twenty!')}>Twenty</DropdownItem>
-      </Dropdown>
-
       <div>
         <input
           value={draft?.customer}

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.test.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.test.tsx
@@ -27,7 +27,7 @@ describe('OutboundShipmentListView', () => {
     });
   });
 
-  it('Selects all rows when the select all checkbox is checked', async () => {
+  it('Selects all rows when the select all checkbox is checked and deletes them after clicking delete all selected rows', async () => {
     const { getAllByRole, getByRole, getByText, queryAllByRole } = render(
       <TestingProvider>
         <TestingRouter initialEntries={['/customers/customer-invoice']}>

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.test.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Route } from 'react-router';
 
 import { TestingProvider, TestingRouter } from '@openmsupply-client/common';
+import AppBar from '@openmsupply-client/host/src/AppBar';
 
 import { OutboundShipmentListView } from './ListView';
 
@@ -22,6 +24,53 @@ describe('OutboundShipmentListView', () => {
       expect(getByText(/customer/i)).toBeInTheDocument();
       expect(getByText(/supplier/i)).toBeInTheDocument();
       expect(getByText(/total/i)).toBeInTheDocument();
+    });
+  });
+
+  it('Selects all rows when the select all checkbox is checked', async () => {
+    const { getAllByRole, getByRole, getByText, queryAllByRole } = render(
+      <TestingProvider>
+        <TestingRouter initialEntries={['/customers/customer-invoice']}>
+          <Route
+            path="*"
+            element={
+              <>
+                <AppBar />
+                <OutboundShipmentListView />
+              </>
+            }
+          />
+        </TestingRouter>
+      </TestingProvider>
+    );
+
+    await waitFor(async () => {
+      const selectAllRowsButton = getByRole('columnheader', {
+        name: /selection/i,
+      });
+
+      const dropdown = getByRole('button', {
+        name: /select/i,
+        expanded: false,
+      });
+
+      let rows = getAllByRole('row');
+
+      await act(async () => {
+        userEvent.click(selectAllRowsButton);
+        userEvent.click(dropdown);
+      });
+
+      const dropdownOption = getByText(/delete/i);
+
+      await act(async () => {
+        userEvent.click(dropdownOption);
+        rows = await queryAllByRole('row');
+      });
+
+      await waitFor(async () => {
+        expect(rows.length).toBe(0);
+      });
     });
   });
 });

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -26,6 +26,8 @@ import {
   AppBarContentPortal,
   useTranslation,
   useMutation,
+  ChevronDown,
+  Tools,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { getDeleteMutation, getListQuery } from '../../api';
@@ -92,12 +94,30 @@ export const OutboundShipmentListView: FC = () => {
       <AppBarContentPortal>
         <Dropdown label="Select">
           <DropdownItem
-            onClick={() =>
-              tableApi?.current?.selectedRows &&
-              mutateAsync(tableApi?.current?.selectedRows)
-            }
+            IconComponent={ChevronDown}
+            onClick={() => {
+              const linesToDelete = tableApi?.current?.selectedRows;
+              if (linesToDelete && linesToDelete?.length > 0) {
+                mutateAsync(linesToDelete);
+                success(`Deleted ${linesToDelete?.length} invoices`)();
+              } else {
+                info('Select rows to delete them')();
+              }
+            }}
           >
             {t('button.delete-lines')}
+          </DropdownItem>
+          <DropdownItem
+            IconComponent={Tools}
+            onClick={warning('Whats this do?')}
+          >
+            Edit
+          </DropdownItem>
+          <DropdownItem
+            IconComponent={Download}
+            onClick={success('Successfully exported to CSV!')}
+          >
+            {t('button.export-to-csv')}
           </DropdownItem>
         </Dropdown>
       </AppBarContentPortal>

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -29,7 +29,9 @@ import { Environment } from '@openmsupply-client/config';
 import { getListQuery } from '../../api';
 import { Checkbox } from '@material-ui/core';
 
-const queryFn = async (queryParams: QueryProps<Transaction>) => {
+const queryFn = async (
+  queryParams: QueryProps<Transaction>
+): Promise<{ data: Transaction[]; totalLength: number }> => {
   const { first, offset, sortBy } = queryParams;
 
   const { transactions } = await request(Environment.API_URL, getListQuery(), {

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -20,13 +20,13 @@ import {
   QueryProps,
   useDataTableApi,
   GenericColumnType,
+  Dropdown,
   DropdownItem,
   AppBarContentPortal,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { getListQuery } from '../../api';
 import { Checkbox } from '@material-ui/core';
-import { ActionDropdown } from '@openmsupply-client/common/src/ui/components/inputs/Dropdown/Dropdown';
 
 const queryFn = async (
   queryParams: QueryProps<Transaction>
@@ -75,17 +75,13 @@ export const OutboundShipmentListView: FC = () => {
   return (
     <>
       <AppBarContentPortal>
-        <ActionDropdown
-          label="Select"
-          actions={[
-            {
-              label: 'oneoneoneoneoneoneoneone',
-              callback: () => console.log('one'),
-            },
-            { label: 'two', callback: () => console.log('two') },
-            { label: 'three', callback: () => console.log('three') },
-          ]}
-        />
+        <Dropdown label="Select">
+          <DropdownItem onClick={() => console.log('one')}>one</DropdownItem>
+          <DropdownItem onClick={() => console.log('two')}>two</DropdownItem>
+          <DropdownItem onClick={() => console.log('three')}>
+            three
+          </DropdownItem>
+        </Dropdown>
         <Checkbox
           size="small"
           color="secondary"

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -20,14 +20,13 @@ import {
   QueryProps,
   useDataTableApi,
   GenericColumnType,
-  Dropdown,
   DropdownItem,
   AppBarContentPortal,
-  Customers,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { getListQuery } from '../../api';
 import { Checkbox } from '@material-ui/core';
+import { ActionDropdown } from '@openmsupply-client/common/src/ui/components/inputs/Dropdown/Dropdown';
 
 const queryFn = async (
   queryParams: QueryProps<Transaction>
@@ -76,10 +75,17 @@ export const OutboundShipmentListView: FC = () => {
   return (
     <>
       <AppBarContentPortal>
-        <Dropdown label="Select" value={10} IconComponent={Customers}>
-          <DropdownItem value={10}>Ten</DropdownItem>
-          <DropdownItem value={20}>Twenty</DropdownItem>
-        </Dropdown>
+        <ActionDropdown
+          label="Select"
+          actions={[
+            {
+              label: 'oneoneoneoneoneoneoneone',
+              callback: () => console.log('one'),
+            },
+            { label: 'two', callback: () => console.log('two') },
+            { label: 'three', callback: () => console.log('three') },
+          ]}
+        />
         <Checkbox
           size="small"
           color="secondary"

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -21,8 +21,8 @@ import {
   QueryProps,
   useDataTableApi,
   GenericColumnType,
-  Dropdown,
-  DropdownItem,
+  DropdownMenu,
+  DropdownMenuItem,
   AppBarContentPortal,
   useTranslation,
   useMutation,
@@ -92,8 +92,8 @@ export const OutboundShipmentListView: FC = () => {
   return (
     <>
       <AppBarContentPortal>
-        <Dropdown label="Select">
-          <DropdownItem
+        <DropdownMenu label="Select">
+          <DropdownMenuItem
             IconComponent={ChevronDown}
             onClick={() => {
               const linesToDelete = tableApi?.current?.selectedRows;
@@ -106,20 +106,20 @@ export const OutboundShipmentListView: FC = () => {
             }}
           >
             {t('button.delete-lines')}
-          </DropdownItem>
-          <DropdownItem
+          </DropdownMenuItem>
+          <DropdownMenuItem
             IconComponent={Tools}
             onClick={warning('Whats this do?')}
           >
             Edit
-          </DropdownItem>
-          <DropdownItem
+          </DropdownMenuItem>
+          <DropdownMenuItem
             IconComponent={Download}
             onClick={success('Successfully exported to CSV!')}
           >
             {t('button.export-to-csv')}
-          </DropdownItem>
-        </Dropdown>
+          </DropdownMenuItem>
+        </DropdownMenu>
       </AppBarContentPortal>
 
       <Portal container={appBarButtonsRef?.current}>

--- a/packages/transactions/src/api.ts
+++ b/packages/transactions/src/api.ts
@@ -24,6 +24,14 @@ export const getMutation = (): string => gql`
   }
 `;
 
+export const getDeleteMutation = (): string => gql`
+  mutation deleteTransactions($transactions: [TransactionPatch]) {
+    deleteTransactions(transactions: $transactions) {
+      id
+    }
+  }
+`;
+
 export const getListQuery = (): string => gql`
   query transactions($first: Int, $offset: Int, $sort: String, $desc: Boolean) {
     transactions(first: $first, offset: $offset, sort: $sort, desc: $desc) {

--- a/types/react-table-config.d.ts
+++ b/types/react-table-config.d.ts
@@ -49,11 +49,13 @@ import {
 } from 'react-table';
 
 declare module 'react-table' {
+  type Align = { align?: 'left' | 'center' | 'right' };
   export interface ColumnInstance<
     D extends Record<string, unknown> = Record<string, unknown>
   > extends UseFiltersColumnProps<D>,
       UseGroupByColumnProps<D>,
       UseResizeColumnsColumnProps<D>,
+      Align,
       UseSortByColumnProps<D> {}
 
   export interface TableOptions<D extends Record<string, unknown>>
@@ -105,6 +107,7 @@ declare module 'react-table' {
       UseGlobalFiltersColumnOptions<D>,
       UseGroupByColumnOptions<D>,
       UseResizeColumnsColumnOptions<D>,
+      Align,
       UseSortByColumnOptions<D> {}
 
   export interface Cell<


### PR DESCRIPTION
Fixes #144 

- Adds a dropdown which does some things
![image](https://user-images.githubusercontent.com/35858975/132933444-f70addbb-809e-4eab-bd2e-19870c4583d5.png)
![image](https://user-images.githubusercontent.com/35858975/132933447-192425d7-97b6-456b-8926-fd5ecf3dcbf3.png)
- Wanted to align the checkbox to the right, so made some changes around that area. Extracted the row to `DataRow` (bad name?) and add an `align` into the `column` definition.

Some issues to make from here:
- Create a hook `useListData` (?) - This can encapsulate the query for some list data and mutations/actions performed on the data to tidy things up a bit.
- Extract out `HeaderRow` component
- Made me think about what is the behaviour when a row is finalised. We want to be able to select it, but we don't want to be able to delete it. Also if there's a mix of finalised/not finalised in the list of selected things. Possibly showing on the dropdown "disabled as you have finalised things and we can't delete them" 🤷 
