### PR TITLE
#149 color column

### DIFF
--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
@@ -36,7 +36,7 @@ const Template: ComponentStory<typeof ColorMenu> = ({ onClick }) => {
             sx={{
               width: '12px',
               margin: 'margin: 0 9px 0 10px',
-              overflow: 'visible',
+
               cursor: 'pointer',
             }}
           />

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { ColorMenu } from './ColorMenu';
+import { TestingProvider } from '../../../../utils';
+import { UnstyledIconButton } from '../../buttons';
+import { Circle } from '../../../icons';
+
+export default {
+  title: 'Menus/ColorMenu',
+  component: ColorMenu,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} as ComponentMeta<typeof ColorMenu>;
+
+const Template: ComponentStory<typeof ColorMenu> = ({ onClick }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <TestingProvider>
+      <ColorMenu onClose={handleClose} anchorEl={anchorEl} onClick={onClick} />
+      <UnstyledIconButton
+        titleKey="app.admin"
+        icon={
+          <Circle
+            htmlColor="red"
+            sx={{
+              width: '12px',
+              margin: 'margin: 0 9px 0 10px',
+              overflow: 'visible',
+              cursor: 'pointer',
+            }}
+          />
+        }
+        onClick={handleClick}
+      />
+    </TestingProvider>
+  );
+};
+
+export const Primary = Template.bind({});
+Primary.args = {
+  onClick: () => {},
+};

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { render } from '@testing-library/react';
+import { Color, ColorMenu } from './ColorMenu';
+import { UnstyledIconButton } from '../../buttons';
+import { TestingProvider } from '../../../../utils';
+import { act } from 'react-dom/test-utils';
+import userEvent from '@testing-library/user-event';
+import { Circle } from '../../../icons';
+
+describe('ColorMenu', () => {
+  const TestColorMenu = ({ onClick }: { onClick: (color: Color) => void }) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+      setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+      setAnchorEl(null);
+    };
+
+    return (
+      <TestingProvider>
+        <ColorMenu
+          onClose={handleClose}
+          anchorEl={anchorEl}
+          onClick={onClick}
+        />
+        <UnstyledIconButton
+          titleKey="app.admin"
+          icon={
+            <Circle
+              htmlColor="red"
+              sx={{
+                width: '12px',
+                margin: 'margin: 0 9px 0 10px',
+                overflow: 'visible',
+                cursor: 'pointer',
+              }}
+            />
+          }
+          onClick={handleClick}
+        />
+      </TestingProvider>
+    );
+  };
+
+  it('Renders all the colors after clicking to open the menu', async () => {
+    const fn = jest.fn();
+
+    const { getByRole, getByLabelText } = render(
+      <TestColorMenu onClick={fn} />
+    );
+
+    const button = getByRole('button');
+
+    await act(async () => {
+      userEvent.click(button);
+    });
+
+    const red = getByLabelText('red');
+    const blue = getByLabelText('blue');
+    const green = getByLabelText('green');
+    const yellow = getByLabelText('yellow');
+    const grey = getByLabelText('grey');
+    const aqua = getByLabelText('aqua');
+
+    expect(red).toBeInTheDocument();
+    expect(blue).toBeInTheDocument();
+    expect(green).toBeInTheDocument();
+    expect(yellow).toBeInTheDocument();
+    expect(grey).toBeInTheDocument();
+    expect(aqua).toBeInTheDocument();
+  });
+
+  it('Triggers the callback provided when clicking on a color', async () => {
+    const fn = jest.fn();
+
+    const { getByRole, getByLabelText } = render(
+      <TestColorMenu onClick={fn} />
+    );
+
+    const button = getByRole('button');
+
+    await act(async () => {
+      userEvent.click(button);
+    });
+
+    const red = getByLabelText('red');
+
+    await act(async () => {
+      userEvent.click(red);
+    });
+
+    expect(fn).toBeCalledTimes(1);
+    expect(fn).toBeCalledWith({ name: 'red', hex: '#ff3b3b' });
+  });
+});

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
@@ -34,7 +34,6 @@ describe('ColorMenu', () => {
               sx={{
                 width: '12px',
                 margin: 'margin: 0 9px 0 10px',
-                overflow: 'visible',
                 cursor: 'pointer',
               }}
             />

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
@@ -67,7 +67,7 @@ export const ColorMenu: FC<ColorMenuProps> = ({
             onClose();
           }}
           htmlColor={hex}
-          sx={{ width: '20px', overflow: 'visible', cursor: 'pointer' }}
+          sx={{ width: '20px', cursor: 'pointer' }}
         />
       ))}
     </Paper>

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
@@ -39,7 +39,7 @@ export const ColorMenu: FC<ColorMenuProps> = ({
     }}
     anchorOrigin={{
       vertical: 'center',
-      horizontal: 'right',
+      horizontal: 'left',
     }}
     transformOrigin={{
       vertical: 'center',

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
@@ -1,0 +1,75 @@
+import { Paper, Popover } from '@material-ui/core';
+import React, { FC } from 'react';
+import { Circle } from '../../../icons';
+
+export interface Color {
+  hex: string;
+  name: string;
+}
+
+interface ColorMenuProps {
+  colors?: Color[];
+  anchorEl: HTMLButtonElement | null;
+  onClick: (color: Color) => void;
+  onClose: () => void;
+}
+
+const defaultColors = [
+  { hex: '#004fc4', name: 'blue' },
+  { hex: '#05a660', name: 'green' },
+  { hex: '#ff3b3b', name: 'red' },
+  { hex: '#fc0', name: 'yellow' },
+  { hex: '#00b7c4', name: 'aqua' },
+  { hex: '#8f90a6', name: 'grey' },
+];
+
+export const ColorMenu: FC<ColorMenuProps> = ({
+  colors = defaultColors,
+  anchorEl,
+  onClose,
+  onClick,
+}) => (
+  <Popover
+    anchorEl={anchorEl}
+    onClose={onClose}
+    sx={{
+      '& .MuiPaper-root': {
+        borderRadius: '24px',
+      },
+    }}
+    anchorOrigin={{
+      vertical: 'center',
+      horizontal: 'right',
+    }}
+    transformOrigin={{
+      vertical: 'center',
+      horizontal: 'left',
+    }}
+    open={Boolean(anchorEl)}
+  >
+    <Paper
+      sx={{
+        width: 33.3 * colors.length,
+        height: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '15px 16px 17px 15px',
+      }}
+    >
+      {colors.map(({ hex, name }) => (
+        <Circle
+          role="button"
+          aria-label={name}
+          key={hex}
+          onClick={() => {
+            onClick({ hex, name });
+            onClose();
+          }}
+          htmlColor={hex}
+          sx={{ width: '20px', overflow: 'visible', cursor: 'pointer' }}
+        />
+      ))}
+    </Paper>
+  </Popover>
+);

--- a/packages/common/src/ui/components/menus/ColorMenu/index.ts
+++ b/packages/common/src/ui/components/menus/ColorMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './ColorMenu';

--- a/packages/common/src/ui/components/menus/index.ts
+++ b/packages/common/src/ui/components/menus/index.ts
@@ -1,0 +1,1 @@
+export * from './ColorMenu';

--- a/packages/common/src/ui/icons/Circle.tsx
+++ b/packages/common/src/ui/icons/Circle.tsx
@@ -3,12 +3,7 @@ import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
 export const Circle = (props: SvgIconProps): JSX.Element => {
   return (
-    <SvgIcon
-      sx={{ overflow: 'visible' }}
-      color="primary"
-      viewBox="0 0 21 20"
-      {...props}
-    >
+    <SvgIcon sx={{ overflow: 'visible' }} viewBox="0 0 21 20" {...props}>
       <circle cx="12" cy="12" r="10" />
     </SvgIcon>
   );

--- a/packages/common/src/ui/icons/Circle.tsx
+++ b/packages/common/src/ui/icons/Circle.tsx
@@ -3,8 +3,13 @@ import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
 export const Circle = (props: SvgIconProps): JSX.Element => {
   return (
-    <SvgIcon {...props} viewBox="0 0 21 20">
-      <circle cx="12" cy="12" r="10"></circle>
+    <SvgIcon
+      sx={{ overflow: 'visible' }}
+      color="primary"
+      viewBox="0 0 21 20"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
     </SvgIcon>
   );
 };

--- a/packages/common/src/ui/icons/Circle.tsx
+++ b/packages/common/src/ui/icons/Circle.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
+
+export const Circle = (props: SvgIconProps): JSX.Element => {
+  return (
+    <SvgIcon {...props} viewBox="0 0 21 20">
+      <circle cx="12" cy="12" r="10"></circle>
+    </SvgIcon>
+  );
+};

--- a/packages/common/src/ui/icons/Circle.tsx
+++ b/packages/common/src/ui/icons/Circle.tsx
@@ -3,8 +3,8 @@ import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
 export const Circle = (props: SvgIconProps): JSX.Element => {
   return (
-    <SvgIcon sx={{ overflow: 'visible' }} viewBox="0 0 21 20" {...props}>
-      <circle cx="12" cy="12" r="10" />
+    <SvgIcon viewBox="0 0 20 20" {...props}>
+      <circle cx="10" cy="10" r="10" />
     </SvgIcon>
   );
 };

--- a/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/packages/common/src/ui/icons/Icon.stories.tsx
@@ -26,7 +26,7 @@ import { Stock } from './Stock';
 import { Suppliers } from './Suppliers';
 import { Tools } from './Tools';
 import { Translate } from './Translate';
-
+import { Circle } from './Circle';
 import {
   Box,
   Grid,
@@ -62,7 +62,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <CheckboxChecked {...args} />, name: 'CheckboxChecked' },
     {
       icon: <CheckboxIndeterminate {...args} />,
-      name: 'CheckboxIndeterminate',
+      name: 'Checkbox Indeterminate',
     },
     { icon: <CheckboxEmpty {...args} />, name: 'CheckboxEmpty' },
     { icon: <ChevronDown {...args} />, name: 'ChevronDown' },
@@ -85,6 +85,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <Suppliers {...args} />, name: 'Suppliers' },
     { icon: <Tools {...args} />, name: 'Tools' },
     { icon: <Translate {...args} />, name: 'Translate' },
+    { icon: <Circle {...args} />, name: 'Circle' },
   ];
   const [filteredIcons, setFilteredIcons] = useState(icons);
   const filterIcons = (event: ChangeEvent<HTMLInputElement>) => {
@@ -103,7 +104,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
       <Grid item>
         <Grid container spacing={1}>
           {filteredIcons.map(i => (
-            <Grid item key={i.name}>
+            <Grid item xs key={i.name}>
               <StyledPaper>
                 {i.icon}
                 <Typography>{i.name}</Typography>

--- a/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/packages/common/src/ui/icons/Icon.stories.tsx
@@ -85,7 +85,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <Suppliers {...args} />, name: 'Suppliers' },
     { icon: <Tools {...args} />, name: 'Tools' },
     { icon: <Translate {...args} />, name: 'Translate' },
-    { icon: <Circle {...args} />, name: 'Circle' },
+    { icon: <Circle htmlColor="#e95c30" {...args} />, name: 'Circle' },
   ];
   const [filteredIcons, setFilteredIcons] = useState(icons);
   const filterIcons = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/packages/common/src/ui/icons/Icon.stories.tsx
@@ -66,6 +66,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     },
     { icon: <CheckboxEmpty {...args} />, name: 'CheckboxEmpty' },
     { icon: <ChevronDown {...args} />, name: 'ChevronDown' },
+    { icon: <Circle htmlColor="#e95c30" {...args} />, name: 'Circle' },
     { icon: <Customers {...args} />, name: 'Customers' },
     { icon: <Dashboard {...args} />, name: 'Dashboard' },
     { icon: <Download {...args} />, name: 'Download' },
@@ -85,7 +86,6 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     { icon: <Suppliers {...args} />, name: 'Suppliers' },
     { icon: <Tools {...args} />, name: 'Tools' },
     { icon: <Translate {...args} />, name: 'Translate' },
-    { icon: <Circle htmlColor="#e95c30" {...args} />, name: 'Circle' },
   ];
   const [filteredIcons, setFilteredIcons] = useState(icons);
   const filterIcons = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/common/src/ui/icons/index.ts
+++ b/packages/common/src/ui/icons/index.ts
@@ -24,3 +24,4 @@ export { Suppliers } from './Suppliers';
 export { Tools } from './Tools';
 export { Translate } from './Translate';
 export { UnhappyMan } from './UnhappyMan';
+export { Circle } from './Circle';


### PR DESCRIPTION
Partial #149 

- Adding just the color menu component and a circle svg (I used american spelling - thought `<ColourMenu color="x"/>` was a bit weird 
![image](https://user-images.githubusercontent.com/35858975/132961621-6efb5a09-128e-4d4d-b4bf-b3806d0ecf2b.png)
- although this features seems lower in priority, I thought doing this would give me some insight into doing mutations with the data table
- I think it did! 
- Need to pass a callback from `ListView`, down to the `Cell` level - i.e. `changeTransactionColor`.
- On mobile, we do this by passing a `getCallback` function to `DataTableRow`, which the `Row` calls and passes to the `Cell`, depending on the `CellKey`.
- With our current setup, we can pass into the `column` object passed into `useColumns` the callback for that column which does seem simpler