### PR TITLE
#225 reducer to handle sorting

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,7 @@
     "graphql": "^15.5.1",
     "graphql-request": "^3.4.0",
     "history": "^5.0.0",
+    "immer": "^9.0.6",
     "kbar": "^0.1.0-beta.5",
     "notistack": "^1.0.6-next.3",
     "react-query": "^3.24.3",
@@ -26,6 +27,7 @@
     "react-table": "^7.7.0",
     "stylis": "^4.0.10",
     "stylis-plugin-rtl": "^2.1.0",
+    "use-immer": "^0.6.0",
     "zustand": "^3.5.7"
   },
   "devDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,6 @@
     "react-table": "^7.7.0",
     "stylis": "^4.0.10",
     "stylis-plugin-rtl": "^2.1.0",
-    "use-immer": "^0.6.0",
     "zustand": "^3.5.7"
   },
   "devDependencies": {

--- a/packages/common/src/hooks/useDraftDocument/types.ts
+++ b/packages/common/src/hooks/useDraftDocument/types.ts
@@ -1,5 +1,4 @@
 import { Dispatch } from 'react';
-
 export interface Api<ReadType, UpdateType> {
   onRead: () => Promise<ReadType>;
   onUpdate: (val: UpdateType) => Promise<ReadType>;
@@ -11,8 +10,8 @@ export type ReducerCreator<ServerDataType, StateType, ActionType> = (
 ) => (state: StateType | undefined, action: ActionType) => StateType;
 
 export interface DraftState<DraftType, StateType, ReadType, ActionType> {
-  draft: Readonly<DraftType>;
-  state: Readonly<StateType>;
+  draft: DraftType;
+  state: StateType;
   dispatch: Dispatch<DraftActionSet<ActionType>>;
   save: (draft: DraftType) => Promise<ReadType>;
 }

--- a/packages/common/src/hooks/useDraftDocument/types.ts
+++ b/packages/common/src/hooks/useDraftDocument/types.ts
@@ -11,8 +11,8 @@ export type ReducerCreator<ServerDataType, StateType, ActionType> = (
 ) => (state: StateType | undefined, action: ActionType) => StateType;
 
 export interface DraftState<DraftType, StateType, ReadType, ActionType> {
-  draft: DraftType;
-  state: StateType;
+  draft: Readonly<DraftType>;
+  state: Readonly<StateType>;
   dispatch: Dispatch<DraftActionSet<ActionType>>;
   save: (draft: DraftType) => Promise<ReadType>;
 }

--- a/packages/common/src/hooks/useDraftDocument/types.ts
+++ b/packages/common/src/hooks/useDraftDocument/types.ts
@@ -10,9 +10,11 @@ export type ReducerCreator<ServerDataType, StateType, ActionType> = (
   dispatch: Dispatch<DraftActionSet<ActionType>> | null
 ) => (state: StateType | undefined, action: ActionType) => StateType;
 
-export interface DraftState<StateType, ReadType> {
-  draft: StateType;
-  save: (draft: StateType) => Promise<ReadType>;
+export interface DraftState<DraftType, StateType, ReadType, ActionType> {
+  draft: DraftType;
+  state: StateType;
+  dispatch: Dispatch<DraftActionSet<ActionType>>;
+  save: (draft: DraftType) => Promise<ReadType>;
 }
 
 export enum DraftActionType {

--- a/packages/common/src/hooks/useDraftDocument/useDraftDocument.ts
+++ b/packages/common/src/hooks/useDraftDocument/useDraftDocument.ts
@@ -20,14 +20,15 @@ export const mergeDraft = (): DefaultDraftAction => ({
 });
 
 export const useDraftDocument = <
+  DraftType extends { id: string },
   ReadType extends { id: string },
-  StateType extends { id: string },
+  StateType extends { draft: DraftType },
   ActionType
 >(
   queryKey: unknown[],
   reducer: ReducerCreator<ReadType, StateType, DraftActionSet<ActionType>>,
-  api: Api<ReadType, StateType>
-): DraftState<StateType, ReadType> => {
+  api: Api<ReadType, DraftType>
+): DraftState<DraftType, StateType, ReadType, ActionType> => {
   const isNew = queryKey.includes('new');
 
   const navigate = useNavigate();
@@ -49,7 +50,7 @@ export const useDraftDocument = <
 
   const [state, dispatch] = useReducer(
     reducer(data, dispatchRef.current),
-    null,
+    undefined,
     () => reducer(data, dispatchRef.current)(undefined, initDraft())
   );
 
@@ -61,5 +62,7 @@ export const useDraftDocument = <
     }
   }, [data]);
 
-  return { draft: state, save: mutateAsync };
+  const { draft } = state;
+
+  return { state, draft, save: mutateAsync, dispatch };
 };

--- a/packages/common/src/hooks/useDraftDocument/useDraftDocument.ts
+++ b/packages/common/src/hooks/useDraftDocument/useDraftDocument.ts
@@ -10,6 +10,7 @@ import {
   DraftActionType,
   DraftActionSet,
 } from './types';
+import { DomainObject } from '../../types';
 
 export const initDraft = (): DefaultDraftAction => ({
   type: DraftActionType.Init,
@@ -19,10 +20,16 @@ export const mergeDraft = (): DefaultDraftAction => ({
   type: DraftActionType.Merge,
 });
 
+/**
+ * Hook which handles side effects for fetching and updating server data and aids in merging
+ * the server data with a client side copy.
+ *
+ */
+
 export const useDraftDocument = <
-  DraftType extends { id: string },
-  ReadType extends { id: string },
   StateType extends { draft: DraftType },
+  DraftType extends DomainObject,
+  ReadType extends DomainObject,
   ActionType
 >(
   queryKey: unknown[],

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,7 +13,7 @@ export {
 export * from 'graphql-request';
 export * from 'react-query';
 export * from 'react-query/devtools';
-export * from 'use-immer';
+export * from 'immer';
 
 export * from './utils';
 export * from './ui';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,6 +13,7 @@ export {
 export * from 'graphql-request';
 export * from 'react-query';
 export * from 'react-query/devtools';
+export * from 'use-immer';
 
 export * from './utils';
 export * from './ui';

--- a/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
+++ b/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
@@ -71,7 +71,11 @@ export const RemoteDataTable = <T extends DomainObject>({
         <TableHead sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <HeaderRow>
             {columns.map(column => (
-              <HeaderCell sortBy={sortBy} column={column}>
+              <HeaderCell
+                sortBy={sortBy}
+                column={column}
+                key={String(column.key)}
+              >
                 <column.Header column={column} />
               </HeaderCell>
             ))}

--- a/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
+++ b/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
@@ -24,7 +24,6 @@ export const RemoteDataTable = <T extends DomainObject>({
   sortBy,
   data = [],
   isLoading = false,
-  onSortBy,
   onRowClick,
   pagination,
   onChangePage,
@@ -72,17 +71,7 @@ export const RemoteDataTable = <T extends DomainObject>({
         <TableHead sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <HeaderRow>
             {columns.map(column => (
-              <HeaderCell
-                minWidth={column.minWidth}
-                width={Number(column.width)}
-                onSortBy={onSortBy}
-                key={String(column.key)}
-                isSortable={!!column.sortable}
-                isSorted={column.key === sortBy.key}
-                align={column.align}
-                columnKey={column.key}
-                direction={sortBy.direction}
-              >
+              <HeaderCell sortBy={sortBy} column={column}>
                 <column.Header column={column} />
               </HeaderCell>
             ))}

--- a/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
+++ b/packages/common/src/ui/layout/tables/RemoteDataTable.tsx
@@ -21,7 +21,6 @@ import { useTableStore } from './context';
 
 export const RemoteDataTable = <T extends DomainObject>({
   columns,
-  sortBy,
   data = [],
   isLoading = false,
   onRowClick,
@@ -71,13 +70,7 @@ export const RemoteDataTable = <T extends DomainObject>({
         <TableHead sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <HeaderRow>
             {columns.map(column => (
-              <HeaderCell
-                sortBy={sortBy}
-                column={column}
-                key={String(column.key)}
-              >
-                <column.Header column={column} />
-              </HeaderCell>
+              <HeaderCell column={column} key={String(column.key)} />
             ))}
           </HeaderRow>
         </TableHead>

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -45,6 +45,7 @@ export interface Column<T extends DomainObject> {
   sortDescFirst: boolean;
   sortType: 'datetime' | 'numeric' | 'alphanumeric';
   sortInverted: boolean;
+  onChangeSortBy?: (column: Column<T>) => void;
 
   width: number;
   minWidth: number;

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -1,4 +1,5 @@
 import { JSXElementConstructor } from 'react';
+import { SortBy } from '../../../../hooks';
 import { LocaleKey } from './../../../../intl/intlHelpers';
 import { DomainObject } from './../../../../types';
 
@@ -46,6 +47,7 @@ export interface Column<T extends DomainObject> {
   sortType: 'datetime' | 'numeric' | 'alphanumeric';
   sortInverted: boolean;
   onChangeSortBy?: (column: Column<T>) => void;
+  sortBy?: SortBy<T>;
 
   width: number;
   minWidth: number;

--- a/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -13,14 +13,14 @@ export default {
 } as ComponentMeta<typeof HeaderRow>;
 
 const Template: Story = () => {
-  const { sortBy, onChangeSortBy } = useSortBy<Item>({ key: 'name' });
+  const { onChangeSortBy, sortBy } = useSortBy<Item>({ key: 'name' });
 
   const [column1, column2] = useColumns(
     new ColumnSetBuilder<Item>()
       .addColumn('name')
       .addColumn('packSize')
       .build(),
-    { onChangeSortBy }
+    { onChangeSortBy, sortBy }
   );
 
   if (!column1 || !column2) return <></>;
@@ -35,12 +35,8 @@ const Template: Story = () => {
     >
       <TableHead>
         <HeaderRow>
-          <HeaderCell sortBy={sortBy} column={column1}>
-            Header1
-          </HeaderCell>
-          <HeaderCell sortBy={sortBy} column={column1}>
-            Header2
-          </HeaderCell>
+          <HeaderCell column={column1} />
+          <HeaderCell column={column1} />
         </HeaderRow>
       </TableHead>
     </Table>

--- a/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentMeta, Story } from '@storybook/react';
 import { Table, TableHead } from '@mui/material';
 import { HeaderCell, HeaderRow } from './Header';
 import { useSortBy } from '../../../../../hooks/useSortBy';
+import { ColumnSetBuilder, useColumns } from '../..';
+import { Item } from '../../../../..';
 
 export default {
   title: 'Table/HeaderRow',
@@ -10,7 +12,18 @@ export default {
 } as ComponentMeta<typeof HeaderRow>;
 
 const Template: Story = () => {
-  const { sortBy, onChangeSortBy } = useSortBy({ key: 'id' });
+  const { sortBy, onChangeSortBy } = useSortBy<Item>({ key: 'name' });
+
+  const [column1, column2] = useColumns(
+    new ColumnSetBuilder<Item>()
+      .addColumn('name')
+      .addColumn('packSize')
+      .build(),
+    { onChangeSortBy }
+  );
+
+  if (!column1 || !column2) return <></>;
+
   return (
     <Table
       sx={{
@@ -21,23 +34,10 @@ const Template: Story = () => {
     >
       <TableHead>
         <HeaderRow>
-          <HeaderCell
-            width={100}
-            minWidth={100}
-            onSortBy={onChangeSortBy}
-            isSortable
-            isSorted={sortBy.key === 'id'}
-            columnKey="id"
-            direction={sortBy.direction}
-          >
+          <HeaderCell sortBy={sortBy} column={column1}>
             Header1
           </HeaderCell>
-          <HeaderCell
-            width={100}
-            minWidth={100}
-            isSortable={false}
-            columnKey="quantity"
-          >
+          <HeaderCell sortBy={sortBy} column={column1}>
             Header2
           </HeaderCell>
         </HeaderRow>

--- a/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -3,8 +3,9 @@ import { ComponentMeta, Story } from '@storybook/react';
 import { Table, TableHead } from '@mui/material';
 import { HeaderCell, HeaderRow } from './Header';
 import { useSortBy } from '../../../../../hooks/useSortBy';
-import { ColumnSetBuilder, useColumns } from '../..';
-import { Item } from '../../../../..';
+import { useColumns } from '../../hooks';
+import { ColumnSetBuilder } from '../../utils';
+import { Item } from '../../../../../types';
 
 export default {
   title: 'Table/HeaderRow',

--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -4,7 +4,7 @@ import { HeaderCell, HeaderRow } from './Header';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 import { ColumnSetBuilder, useColumns } from '../..';
-import { Item } from '../../../../..';
+import { Item, TestingProvider } from '../../../../..';
 
 describe('HeaderRow', () => {
   const Example: FC<{
@@ -22,18 +22,20 @@ describe('HeaderRow', () => {
     if (!column1 || !column2) return null;
 
     return (
-      <table>
-        <thead>
-          <HeaderRow>
-            <HeaderCell column={column1} sortBy={sortBy}>
-              Header1
-            </HeaderCell>
-            <HeaderCell column={column2} sortBy={sortBy}>
-              Header2
-            </HeaderCell>
-          </HeaderRow>
-        </thead>
-      </table>
+      <TestingProvider>
+        <table>
+          <thead>
+            <HeaderRow>
+              <HeaderCell column={column1} sortBy={sortBy}>
+                Header1
+              </HeaderCell>
+              <HeaderCell column={column2} sortBy={sortBy}>
+                Header2
+              </HeaderCell>
+            </HeaderRow>
+          </thead>
+        </table>
+      </TestingProvider>
     );
   };
 

--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -3,43 +3,47 @@ import { render } from '@testing-library/react';
 import { HeaderCell, HeaderRow } from './Header';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
+import { ColumnSetBuilder, useColumns } from '../..';
+import { Item } from '../../../../..';
 
 describe('HeaderRow', () => {
-  const Example: FC<{ onSortBy: () => void }> = ({ onSortBy }) => (
-    <table>
-      <thead>
-        <HeaderRow>
-          <HeaderCell
-            width={100}
-            minWidth={100}
-            onSortBy={onSortBy}
-            isSortable
-            isSorted
-            columnKey="id"
-            direction="asc"
-          >
-            Header1
-          </HeaderCell>
-          <HeaderCell
-            width={100}
-            minWidth={100}
-            onSortBy={onSortBy}
-            isSortable={false}
-            isSorted={false}
-            columnKey="quantity"
-            direction="asc"
-          >
-            Header2
-          </HeaderCell>
-        </HeaderRow>
-      </thead>
-    </table>
-  );
+  const Example: FC<{
+    onChangeSortBy: () => void;
+    sortBy: { key: keyof Item; direction: 'asc' | 'desc' };
+  }> = ({ onChangeSortBy, sortBy }) => {
+    const [column1, column2] = useColumns(
+      new ColumnSetBuilder<Item>()
+        .addColumn('name')
+        .addColumn('packSize')
+        .build(),
+      { onChangeSortBy }
+    );
+
+    if (!column1 || !column2) return null;
+
+    return (
+      <table>
+        <thead>
+          <HeaderRow>
+            <HeaderCell column={column1} sortBy={sortBy}>
+              Header1
+            </HeaderCell>
+            <HeaderCell column={column2} sortBy={sortBy}>
+              Header2
+            </HeaderCell>
+          </HeaderRow>
+        </thead>
+      </table>
+    );
+  };
 
   it('renders the cells passed', () => {
     const onSortBy = jest.fn();
+    const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
-    const { getByRole } = render(<Example onSortBy={onSortBy} />);
+    const { getByRole } = render(
+      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+    );
 
     const idHeader = getByRole('columnheader', { name: /id/i });
     const quantityHeader = getByRole('columnheader', { name: /quantity/i });
@@ -50,8 +54,11 @@ describe('HeaderRow', () => {
 
   it('renders a button when the header is sortable, and no button otherwise', () => {
     const onSortBy = jest.fn();
+    const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
-    const { getByRole, queryByRole } = render(<Example onSortBy={onSortBy} />);
+    const { getByRole, queryByRole } = render(
+      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+    );
 
     const idHeader = getByRole('button', { name: /header1/i });
     const quantityHeader = queryByRole('button', { name: /header2/i });
@@ -62,8 +69,11 @@ describe('HeaderRow', () => {
 
   it('calls the provided sortBy function when the sort button is pressed', () => {
     const onSortBy = jest.fn();
+    const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
-    const { getByRole } = render(<Example onSortBy={onSortBy} />);
+    const { getByRole } = render(
+      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+    );
 
     const idHeader = getByRole('button', { name: /header1/i });
 
@@ -74,8 +84,11 @@ describe('HeaderRow', () => {
 
   it('calls the provided sortBy function with the values of the column', () => {
     const onSortBy = jest.fn();
+    const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
-    const { getByRole } = render(<Example onSortBy={onSortBy} />);
+    const { getByRole } = render(
+      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+    );
 
     const idHeader = getByRole('button', { name: /header1/i });
 

--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -14,7 +14,7 @@ describe('HeaderRow', () => {
     const [column1, column2] = useColumns(
       new ColumnSetBuilder<Item>()
         .addColumn('name')
-        .addColumn('packSize')
+        .addColumn('packSize', { sortable: false })
         .build(),
       { onChangeSortBy }
     );
@@ -22,20 +22,18 @@ describe('HeaderRow', () => {
     if (!column1 || !column2) return null;
 
     return (
-      <TestingProvider>
-        <table>
-          <thead>
-            <HeaderRow>
-              <HeaderCell column={column1} sortBy={sortBy}>
-                Header1
-              </HeaderCell>
-              <HeaderCell column={column2} sortBy={sortBy}>
-                Header2
-              </HeaderCell>
-            </HeaderRow>
-          </thead>
-        </table>
-      </TestingProvider>
+      <table>
+        <thead>
+          <HeaderRow>
+            <HeaderCell column={column1} sortBy={sortBy}>
+              Header1
+            </HeaderCell>
+            <HeaderCell column={column2} sortBy={sortBy}>
+              Header2
+            </HeaderCell>
+          </HeaderRow>
+        </thead>
+      </table>
     );
   };
 
@@ -44,14 +42,16 @@ describe('HeaderRow', () => {
     const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
     const { getByRole } = render(
-      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      <TestingProvider>
+        <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      </TestingProvider>
     );
 
-    const idHeader = getByRole('columnheader', { name: /id/i });
-    const quantityHeader = getByRole('columnheader', { name: /quantity/i });
+    const nameHeader = getByRole('columnheader', { name: /name/i });
+    const packSizeHeader = getByRole('columnheader', { name: /packSize/i });
 
-    expect(idHeader).toBeInTheDocument();
-    expect(quantityHeader).toBeInTheDocument();
+    expect(nameHeader).toBeInTheDocument();
+    expect(packSizeHeader).toBeInTheDocument();
   });
 
   it('renders a button when the header is sortable, and no button otherwise', () => {
@@ -59,14 +59,16 @@ describe('HeaderRow', () => {
     const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
     const { getByRole, queryByRole } = render(
-      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      <TestingProvider>
+        <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      </TestingProvider>
     );
 
-    const idHeader = getByRole('button', { name: /header1/i });
-    const quantityHeader = queryByRole('button', { name: /header2/i });
+    const nameHeader = getByRole('button', { name: /header1/i });
+    const packSizeHeader = queryByRole('button', { name: /header2/i });
 
-    expect(idHeader).toBeInTheDocument();
-    expect(quantityHeader).not.toBeInTheDocument();
+    expect(nameHeader).toBeInTheDocument();
+    expect(packSizeHeader).not.toBeInTheDocument();
   });
 
   it('calls the provided sortBy function when the sort button is pressed', () => {
@@ -74,12 +76,14 @@ describe('HeaderRow', () => {
     const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
     const { getByRole } = render(
-      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      <TestingProvider>
+        <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      </TestingProvider>
     );
 
-    const idHeader = getByRole('button', { name: /header1/i });
+    const nameHeader = getByRole('button', { name: /header1/i });
 
-    act(() => userEvent.click(idHeader));
+    act(() => userEvent.click(nameHeader));
 
     expect(onSortBy).toBeCalledTimes(1);
   });
@@ -89,13 +93,15 @@ describe('HeaderRow', () => {
     const sortBy = { key: 'packSize', direction: 'asc' as 'asc' | 'desc' };
 
     const { getByRole } = render(
-      <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      <TestingProvider>
+        <Example onChangeSortBy={onSortBy} sortBy={sortBy} />
+      </TestingProvider>
     );
 
     const idHeader = getByRole('button', { name: /header1/i });
 
     act(() => userEvent.click(idHeader));
 
-    expect(onSortBy).toBeCalledWith({ key: 'id' });
+    expect(onSortBy).toBeCalledWith(expect.objectContaining({ key: 'name' }));
   });
 });

--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -16,7 +16,7 @@ describe('HeaderRow', () => {
         .addColumn('name')
         .addColumn('packSize', { sortable: false })
         .build(),
-      { onChangeSortBy }
+      { onChangeSortBy, sortBy }
     );
 
     if (!column1 || !column2) return null;
@@ -25,12 +25,8 @@ describe('HeaderRow', () => {
       <table>
         <thead>
           <HeaderRow>
-            <HeaderCell column={column1} sortBy={sortBy}>
-              Header1
-            </HeaderCell>
-            <HeaderCell column={column2} sortBy={sortBy}>
-              Header2
-            </HeaderCell>
+            <HeaderCell column={column1} />
+            <HeaderCell column={column2} />
           </HeaderRow>
         </thead>
       </table>
@@ -64,8 +60,8 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const nameHeader = getByRole('button', { name: /header1/i });
-    const packSizeHeader = queryByRole('button', { name: /header2/i });
+    const nameHeader = getByRole('button', { name: /name/i });
+    const packSizeHeader = queryByRole('button', { name: /pack size/i });
 
     expect(nameHeader).toBeInTheDocument();
     expect(packSizeHeader).not.toBeInTheDocument();
@@ -81,7 +77,7 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const nameHeader = getByRole('button', { name: /header1/i });
+    const nameHeader = getByRole('button', { name: /name/i });
 
     act(() => userEvent.click(nameHeader));
 
@@ -98,7 +94,7 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const idHeader = getByRole('button', { name: /header1/i });
+    const idHeader = getByRole('button', { name: /name/i });
 
     act(() => userEvent.click(idHeader));
 

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -1,10 +1,9 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC } from 'react';
 import { TableCell, TableRow, TableSortLabel } from '@mui/material';
 import { ObjectWithStringKeys } from '../../../../../types/utility';
 import { Column } from '../../columns/types';
 import { SortDesc } from '../../../../icons';
 import { DomainObject } from '../../../../../types';
-import { SortBy } from '../../../../../hooks';
 
 export const HeaderRow: FC = props => (
   <TableRow
@@ -21,19 +20,24 @@ export const HeaderRow: FC = props => (
 );
 
 interface HeaderCellProps<T extends DomainObject> {
-  sortBy: SortBy<T>;
   column: Column<T>;
-  children: ReactNode;
 }
 
 export const HeaderCell = <T extends ObjectWithStringKeys & DomainObject>({
-  sortBy,
-  children,
   column,
 }: HeaderCellProps<T>): JSX.Element => {
-  const { minWidth, width, onChangeSortBy, key, sortable, align } = column;
+  const {
+    minWidth,
+    width,
+    onChangeSortBy,
+    key,
+    sortable,
+    align,
+    sortBy,
+    Header,
+  } = column;
 
-  const { direction, key: currentSortKey } = sortBy;
+  const { direction, key: currentSortKey } = sortBy ?? {};
 
   const isSorted = key === currentSortKey;
 
@@ -68,10 +72,10 @@ export const HeaderCell = <T extends ObjectWithStringKeys & DomainObject>({
           direction={direction}
           IconComponent={SortDesc}
         >
-          {children}
+          <Header column={column} />
         </TableSortLabel>
       ) : (
-        children
+        <Header column={column} />
       )}
     </TableCell>
   );

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -1,8 +1,10 @@
 import React, { FC, ReactNode } from 'react';
 import { TableCell, TableRow, TableSortLabel } from '@mui/material';
 import { ObjectWithStringKeys } from '../../../../../types/utility';
-import { SortRule } from '../../../../../hooks/useSortBy';
+import { Column } from '../../columns/types';
 import { SortDesc } from '../../../../icons';
+import { DomainObject } from '../../../../../types';
+import { SortBy } from '../../../../../hooks';
 
 export const HeaderRow: FC = props => (
   <TableRow
@@ -18,36 +20,30 @@ export const HeaderRow: FC = props => (
   />
 );
 
-interface HeaderCellProps<T extends ObjectWithStringKeys> {
-  onSortBy?: (sortBy: SortRule<T>) => void;
-  isSortable: boolean;
-  isSorted?: boolean;
-  align?: 'left' | 'right' | 'center';
-  columnKey: keyof T;
-  direction?: 'asc' | 'desc';
+interface HeaderCellProps<T extends DomainObject> {
+  sortBy: SortBy<T>;
+  column: Column<T>;
   children: ReactNode;
-  width?: number;
-  minWidth?: number;
 }
 
-export const HeaderCell = <T extends ObjectWithStringKeys>({
-  onSortBy,
-  isSortable,
-  isSorted,
-  align,
-  columnKey,
-  direction,
+export const HeaderCell = <T extends ObjectWithStringKeys & DomainObject>({
+  sortBy,
   children,
-  width,
-  minWidth,
+  column,
 }: HeaderCellProps<T>): JSX.Element => {
+  const { minWidth, width, onChangeSortBy, key, sortable, align } = column;
+
+  const { direction, key: currentSortKey } = sortBy;
+
+  const isSorted = key === currentSortKey;
+
   return (
     <TableCell
       role="columnheader"
       onClick={
-        onSortBy &&
+        onChangeSortBy &&
         (() => {
-          isSortable && onSortBy({ key: columnKey });
+          sortable && onChangeSortBy(column);
         })
       }
       align={align}
@@ -62,10 +58,10 @@ export const HeaderCell = <T extends ObjectWithStringKeys>({
         flex: `${width} 0 auto`,
         fontWeight: 'bold',
       }}
-      aria-label={String(columnKey)}
+      aria-label={String(key)}
       sortDirection={isSorted ? direction : false}
     >
-      {isSortable ? (
+      {sortable ? (
         <TableSortLabel
           hideSortIcon={false}
           active={isSorted}

--- a/packages/common/src/ui/layout/tables/hooks/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns.tsx
@@ -9,6 +9,7 @@ import {
 } from '../columns/types';
 import { useFormatDate } from '../../../../intl';
 import { BasicCell, BasicHeader } from '../components';
+import { SortBy } from '../../../..';
 
 const getColumnWidths = <T extends DomainObject>(
   column: ColumnDefinition<T>
@@ -20,7 +21,8 @@ const getColumnWidths = <T extends DomainObject>(
 };
 
 interface ColumnOptions<T extends DomainObject> {
-  onChangeSortBy: (column: Column<T>) => void;
+  onChangeSortBy?: (column: Column<T>) => void;
+  sortBy?: SortBy<T>;
 }
 
 export const useColumns = <T extends DomainObject>(
@@ -45,12 +47,13 @@ export const useColumns = <T extends DomainObject>(
           sortDescFirst: column.format === ColumnFormat.date,
           align: ColumnAlign.Left,
           onChangeSortBy: options?.onChangeSortBy,
+          sortBy: options?.sortBy,
           ...getColumnWidths(column),
         };
 
         return { ...defaults, ...column };
       }),
-    []
+    [options?.sortBy]
   );
 };
 

--- a/packages/common/src/ui/layout/tables/hooks/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns.tsx
@@ -19,8 +19,13 @@ const getColumnWidths = <T extends DomainObject>(
   return { minWidth, width };
 };
 
+interface ColumnOptions<T extends DomainObject> {
+  onChangeSortBy: (column: Column<T>) => void;
+}
+
 export const useColumns = <T extends DomainObject>(
-  columnsToMap: ColumnDefinition<T>[]
+  columnsToMap: ColumnDefinition<T>[],
+  options?: ColumnOptions<T>
 ): Column<T>[] => {
   const formatDate = useFormatDate();
   const defaultAccessor = getAccessor<T>(formatDate);
@@ -39,6 +44,7 @@ export const useColumns = <T extends DomainObject>(
           sortInverted: column.format === ColumnFormat.date,
           sortDescFirst: column.format === ColumnFormat.date,
           align: ColumnAlign.Left,
+          onChangeSortBy: options?.onChangeSortBy,
           ...getColumnWidths(column),
         };
 

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -21,7 +21,6 @@ export interface TableProps<T extends DomainObject> {
   data?: T[];
   sortBy: SortBy<T>;
   isLoading?: boolean;
-  onSortBy: (sortRule: SortRule<T>) => void;
   pagination: Pagination & { total?: number };
   onChangePage: (page: number) => void;
   onRowClick?: (row: T) => void;

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { LocaleKey } from '@openmsupply-client/common/src/intl/intlHelpers';
 import { ObjectWithStringKeys, DomainObject } from './../../../types';
 import { Pagination } from '../../../hooks/usePagination';
-import { SortBy, SortRule } from '../../../hooks/useSortBy';
+import { SortRule } from '../../../hooks/useSortBy';
 import { Column } from './columns/types';
 
 export interface QueryProps<D extends ObjectWithStringKeys> {
@@ -19,7 +19,6 @@ export interface QueryResponse<T> {
 export interface TableProps<T extends DomainObject> {
   columns: Column<T>[];
   data?: T[];
-  sortBy: SortBy<T>;
   isLoading?: boolean;
   pagination: Pagination & { total?: number };
   onChangePage: (page: number) => void;

--- a/packages/mocks/src/handlers.ts
+++ b/packages/mocks/src/handlers.ts
@@ -20,7 +20,7 @@ const ItemData: {
 }[] = [];
 
 const getItems = (transactionId: string) => {
-  const items = Array.from({ length: Math.random() * 10 + 1 }).map(() => ({
+  const items = Array.from({ length: Math.random() * 10 + 1000 }).map(() => ({
     id: `${faker.datatype.uuid()}`,
     code: `${faker.random.alpha({ count: 6 })}`,
     name: `${faker.commerce.productName()}`,

--- a/packages/mocks/src/handlers.ts
+++ b/packages/mocks/src/handlers.ts
@@ -20,7 +20,7 @@ const ItemData: {
 }[] = [];
 
 const getItems = (transactionId: string) => {
-  const items = Array.from({ length: Math.random() * 10 + 1000 }).map(() => ({
+  const items = Array.from({ length: Math.random() * 10 + 1 }).map(() => ({
     id: `${faker.datatype.uuid()}`,
     code: `${faker.random.alpha({ count: 6 })}`,
     name: `${faker.commerce.productName()}`,

--- a/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
@@ -152,7 +152,7 @@ export const OutboundShipmentDetailViewComponent: FC = () => {
     .addColumn(getEditableQuantityColumn())
     .build();
 
-  const columns = useColumns(defaultColumns, { onChangeSortBy });
+  const columns = useColumns(defaultColumns, { onChangeSortBy, sortBy });
 
   return draft ? (
     <TabContext value={String(currentTab)}>

--- a/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
@@ -29,7 +29,10 @@ import {
   PlusCircle,
   Box,
   useDraftDocument,
-  SortRule,
+  getEditableQuantityColumn,
+  useColumns,
+  ColumnSetBuilder,
+  Column,
 } from '@openmsupply-client/common';
 import { reducer, onSortBy } from './reducer';
 import { getOutboundShipmentDetailViewApi } from '../../api';
@@ -47,8 +50,9 @@ const useDraftOutbound = () => {
     getOutboundShipmentDetailViewApi(id ?? '')
   );
 
-  const onChangeSortBy: (sortBy: SortRule<ItemRow>) => void = ({ key }) =>
-    dispatch(onSortBy(key));
+  const onChangeSortBy: (sortBy: Column<ItemRow>) => void = column => {
+    dispatch(onSortBy(column));
+  };
 
   return { draft, save, dispatch, onChangeSortBy, sortBy: state.sortBy };
 };
@@ -141,6 +145,15 @@ export const OutboundShipmentDetailViewComponent: FC = () => {
 
   const { currentTab, onChangeTab } = useTabs('general');
 
+  const defaultColumns = new ColumnSetBuilder<ItemRow>()
+    .addColumn('code')
+    .addColumn('name')
+    .addColumn('packSize')
+    .addColumn(getEditableQuantityColumn())
+    .build();
+
+  const columns = useColumns(defaultColumns, { onChangeSortBy });
+
   return draft ? (
     <TabContext value={String(currentTab)}>
       <AppBarButtonsPortal>
@@ -178,8 +191,8 @@ export const OutboundShipmentDetailViewComponent: FC = () => {
       <Box display="flex" flex={1}>
         <TabPanel sx={{ flex: 1, padding: 0, display: 'flex' }} value="general">
           <GeneralTab
+            columns={columns}
             data={draft?.items ?? []}
-            onChangeSortBy={onChangeSortBy}
             sortBy={sortBy}
           />
         </TabPanel>

--- a/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/DetailView.tsx
@@ -29,26 +29,32 @@ import {
   PlusCircle,
   Box,
   useDraftDocument,
+  SortRule,
 } from '@openmsupply-client/common';
-import { reducer } from './reducer';
+import { reducer, onSortBy } from './reducer';
 import { getOutboundShipmentDetailViewApi } from '../../api';
 import { GeneralTab } from './tabs/GeneralTab';
 import { ExternalURL } from '@openmsupply-client/config';
 import { DialogButton } from '@openmsupply-client/common/src/ui/components/buttons/DialogButton';
+import { ItemRow } from './types';
 
 const useDraftOutbound = () => {
   const { id } = useParams();
 
-  const { draft, save } = useDraftDocument(
+  const { draft, save, dispatch, state } = useDraftDocument(
     ['transaction', id ?? 'new'],
     reducer,
     getOutboundShipmentDetailViewApi(id ?? '')
   );
-  return { draft, save };
+
+  const onChangeSortBy: (sortBy: SortRule<ItemRow>) => void = ({ key }) =>
+    dispatch(onSortBy(key));
+
+  return { draft, save, dispatch, onChangeSortBy, sortBy: state.sortBy };
 };
 
 export const OutboundShipmentDetailViewComponent: FC = () => {
-  const { draft } = useDraftOutbound();
+  const { draft, onChangeSortBy, sortBy } = useDraftOutbound();
   const { OpenButton, setActions, setSections } = useDetailPanel();
   const t = useTranslation();
   const d = useFormatDate();
@@ -171,7 +177,11 @@ export const OutboundShipmentDetailViewComponent: FC = () => {
 
       <Box display="flex" flex={1}>
         <TabPanel sx={{ flex: 1, padding: 0, display: 'flex' }} value="general">
-          <GeneralTab data={draft?.items ?? []} />
+          <GeneralTab
+            data={draft?.items ?? []}
+            onChangeSortBy={onChangeSortBy}
+            sortBy={sortBy}
+          />
         </TabPanel>
 
         <TabPanel sx={{ flex: 1 }} value="transport">

--- a/packages/transactions/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/transactions/src/OutboundShipment/DetailView/reducer.ts
@@ -1,11 +1,42 @@
 import { Dispatch } from 'react';
 import {
-  Transaction,
   DraftActionSet,
   DraftActionType,
+  SortBy,
+  Transaction,
 } from '@openmsupply-client/common';
 import { placeholderTransaction } from './index';
-import { ActionType, OutboundShipment, CustomerInvoiceAction } from './types';
+import {
+  ActionType,
+  OutboundShipment,
+  CustomerInvoiceAction,
+  ItemRow,
+} from './types';
+
+const parseValue = (object: any, key: string) => {
+  const value = object[key];
+  if (typeof value === 'string') {
+    const valueAsNumber = Number.parseFloat(value);
+
+    if (!Number.isNaN(valueAsNumber)) return valueAsNumber;
+    return value.toUpperCase(); // ignore case
+  }
+  return value;
+};
+
+const getDataSorter = (sortKey: any, desc: boolean) => (a: any, b: any) => {
+  const valueA = parseValue(a, sortKey);
+  const valueB = parseValue(b, sortKey);
+
+  if (valueA < valueB) {
+    return desc ? 1 : -1;
+  }
+  if (valueA > valueB) {
+    return desc ? -1 : 1;
+  }
+
+  return 0;
+};
 
 export const updateQuantity = (
   rowKey: string,
@@ -15,26 +46,42 @@ export const updateQuantity = (
   payload: { rowKey, quantity },
 });
 
+export const onSortBy = (key: keyof ItemRow): CustomerInvoiceAction => ({
+  type: ActionType.SortBy,
+  payload: { key },
+});
+
 export const OutboundAction = {
   updateQuantity,
+  onSortBy,
 };
+
+interface InitialState {
+  draft: OutboundShipment;
+  sortBy: SortBy<ItemRow>;
+}
+
+export const getInitialState = (): InitialState => ({
+  draft: placeholderTransaction,
+  sortBy: { key: 'quantity', isDesc: true, direction: 'asc' },
+});
 
 export const reducer =
   (
-    data: Transaction | undefined = placeholderTransaction,
+    data: Transaction = placeholderTransaction,
     dispatch: Dispatch<DraftActionSet<CustomerInvoiceAction>> | null
   ) =>
   (
-    state: OutboundShipment | undefined = placeholderTransaction,
+    state = getInitialState(),
     action: DraftActionSet<CustomerInvoiceAction>
-  ): OutboundShipment => {
+  ): ReturnType<typeof getInitialState> => {
     switch (action.type) {
       case DraftActionType.Init: {
         return state;
       }
 
       case DraftActionType.Merge: {
-        const newInvoice = Object.keys(state).reduce(
+        const newInvoice = Object.keys(state.draft).reduce(
           (acc, key) => ({ ...acc, [key]: data[key] }),
           {} as OutboundShipment
         );
@@ -47,19 +94,38 @@ export const reducer =
 
         newInvoice.items = newItems;
 
-        return newInvoice;
+        return { ...state, draft: newInvoice };
+      }
+
+      case ActionType.SortBy: {
+        const { payload } = action;
+        const { key } = payload;
+
+        const { draft, sortBy } = state;
+        const { items } = draft;
+        const { key: currentSortKey, isDesc: currentIsDesc } = sortBy;
+
+        const newIsDesc = currentSortKey === key ? !currentIsDesc : false;
+        const newDirection: 'asc' | 'desc' = newIsDesc ? 'desc' : 'asc';
+        const newSortBy = { key, isDesc: newIsDesc, direction: newDirection };
+
+        const sorter = getDataSorter(newSortBy.key, newSortBy.isDesc);
+        const newItems = items.sort(sorter);
+        draft.items = newItems;
+
+        return { ...state, sortBy: newSortBy };
       }
 
       case ActionType.UpdateQuantity: {
         const { payload } = action;
         const { rowKey, quantity } = payload;
 
-        const rowIdx = state.items.findIndex(({ id }) => id === rowKey);
-        const row = state.items[rowIdx];
+        const rowIdx = state.draft.items.findIndex(({ id }) => id === rowKey);
+        const row = state.draft.items[rowIdx];
 
         if (row) {
           const newRow = { ...row, quantity };
-          const newItems = [...state.items];
+          const newItems = [...state.draft.items];
           newItems[rowIdx] = newRow;
           const newState = { ...state, items: newItems };
 

--- a/packages/transactions/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/transactions/src/OutboundShipment/DetailView/reducer.ts
@@ -56,12 +56,12 @@ export const OutboundAction = {
   onSortBy,
 };
 
-interface InitialState {
+interface OutboundShipmentStateShape {
   draft: OutboundShipment;
   sortBy: SortBy<ItemRow>;
 }
 
-export const getInitialState = (): InitialState => ({
+export const getInitialState = (): OutboundShipmentStateShape => ({
   draft: placeholderTransaction,
   sortBy: { key: 'quantity', isDesc: true, direction: 'asc' },
 });
@@ -74,7 +74,7 @@ export const reducer =
   (
     state = getInitialState(),
     action: DraftActionSet<CustomerInvoiceAction>
-  ): ReturnType<typeof getInitialState> => {
+  ): OutboundShipmentStateShape => {
     switch (action.type) {
       case DraftActionType.Init: {
         return state;

--- a/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
@@ -26,7 +26,11 @@ describe('GeneralTab', () => {
   const Example = () => {
     return (
       <TestingProvider>
-        <GeneralTab data={items} />
+        <GeneralTab
+          data={items}
+          sortBy={{ key: 'quantity', direction: 'asc' }}
+          onChangeSortBy={() => {}}
+        />
       </TestingProvider>
     );
   };

--- a/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { TestingProvider } from '@openmsupply-client/common';
+import {
+  ColumnSetBuilder,
+  TestingProvider,
+  useColumns,
+} from '@openmsupply-client/common';
 import { render, waitFor, within } from '@testing-library/react';
 import { GeneralTab } from './GeneralTab';
+import { ItemRow } from '../types';
 
 const items = [
   {
@@ -24,12 +29,20 @@ const items = [
 
 describe('GeneralTab', () => {
   const Example = () => {
+    const defaultColumns = new ColumnSetBuilder<ItemRow>()
+      .addColumn('code')
+      .addColumn('name')
+      .addColumn('packSize')
+      .build();
+
+    const columns = useColumns(defaultColumns, { onChangeSortBy: () => {} });
+
     return (
       <TestingProvider>
         <GeneralTab
           data={items}
+          columns={columns}
           sortBy={{ key: 'quantity', direction: 'asc' }}
-          onChangeSortBy={() => {}}
         />
       </TestingProvider>
     );

--- a/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
@@ -38,18 +38,20 @@ describe('GeneralTab', () => {
     const columns = useColumns(defaultColumns, { onChangeSortBy: () => {} });
 
     return (
-      <TestingProvider>
-        <GeneralTab
-          data={items}
-          columns={columns}
-          sortBy={{ key: 'quantity', direction: 'asc' }}
-        />
-      </TestingProvider>
+      <GeneralTab
+        data={items}
+        columns={columns}
+        sortBy={{ key: 'quantity', direction: 'asc' }}
+      />
     );
   };
 
   it('renders the passed values into a row', async () => {
-    const { findByRole } = render(<Example />);
+    const { findByRole } = render(
+      <TestingProvider>
+        <Example />
+      </TestingProvider>
+    );
 
     await waitFor(async () => {
       const row = (await findByRole('cell', { name: 'ibuprofen' })).closest(
@@ -61,12 +63,10 @@ describe('GeneralTab', () => {
       if (row) {
         const code = within(row).getByRole('cell', { name: /abc123/i });
         const name = within(row).getByRole('cell', { name: /ibuprofen/i });
-        const quantity = within(row).getByRole('cell', { name: /100/i });
         const packSize = within(row).getByRole('cell', { name: /^2$/i });
 
         expect(code).toBeInTheDocument();
         expect(name).toBeInTheDocument();
-        expect(quantity).toBeInTheDocument();
         expect(packSize).toBeInTheDocument();
       }
     });

--- a/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -1,38 +1,32 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
-  ColumnSetBuilder,
   RemoteDataTable,
-  useColumns,
-  getEditableQuantityColumn,
-  SortRule,
   ObjectWithStringKeys,
   SortBy,
   usePagination,
   useRowRenderCount,
+  Column,
+  DomainObject,
 } from '@openmsupply-client/common';
 import { ItemRow } from '../types';
 
-interface GeneralTabProps<T extends ObjectWithStringKeys> {
+interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   data: T[];
-  onChangeSortBy: (sortBy: SortRule<T>) => void;
+  columns: Column<T>[];
   sortBy: SortBy<T>;
 }
 
 export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({
   data,
-  onChangeSortBy,
+  columns,
   sortBy,
 }) => {
-  const { pagination } = usePagination(useRowRenderCount());
+  const numberOfRows = useRowRenderCount();
+  const { pagination } = usePagination(numberOfRows);
 
-  const defaultColumns = new ColumnSetBuilder<ItemRow>()
-    .addColumn('code')
-    .addColumn('name')
-    .addColumn('packSize')
-    .addColumn(getEditableQuantityColumn())
-    .build();
-
-  const columns = useColumns(defaultColumns);
+  useEffect(() => {
+    pagination.onChangeFirst(numberOfRows);
+  }, [numberOfRows, pagination.first]);
 
   return (
     <RemoteDataTable
@@ -40,7 +34,6 @@ export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
       data={data.slice(pagination.offset, pagination.offset + pagination.first)}
-      onSortBy={onChangeSortBy}
       onChangePage={pagination.onChangePage}
       noDataMessageKey="error.no-items"
     />

--- a/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -16,11 +16,7 @@ interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   sortBy: SortBy<T>;
 }
 
-export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({
-  data,
-  columns,
-  sortBy,
-}) => {
+export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({ data, columns }) => {
   const numberOfRows = useRowRenderCount();
   const { pagination } = usePagination(numberOfRows);
 
@@ -30,7 +26,6 @@ export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({
 
   return (
     <RemoteDataTable
-      sortBy={sortBy}
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
       data={data.slice(pagination.offset, pagination.offset + pagination.first)}

--- a/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/transactions/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -3,21 +3,27 @@ import {
   ColumnSetBuilder,
   RemoteDataTable,
   useColumns,
-  useQueryParams,
-  useSortedData,
   getEditableQuantityColumn,
+  SortRule,
+  ObjectWithStringKeys,
+  SortBy,
+  usePagination,
+  useRowRenderCount,
 } from '@openmsupply-client/common';
 import { ItemRow } from '../types';
 
-interface GeneralTabProps<T> {
+interface GeneralTabProps<T extends ObjectWithStringKeys> {
   data: T[];
+  onChangeSortBy: (sortBy: SortRule<T>) => void;
+  sortBy: SortBy<T>;
 }
 
-export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({ data }) => {
-  const { pagination } = useQueryParams({ key: 'quantity' });
-  const { sortedData, onChangeSortBy, sortBy } = useSortedData(data ?? [], {
-    key: 'quantity',
-  });
+export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({
+  data,
+  onChangeSortBy,
+  sortBy,
+}) => {
+  const { pagination } = usePagination(useRowRenderCount());
 
   const defaultColumns = new ColumnSetBuilder<ItemRow>()
     .addColumn('code')
@@ -33,10 +39,7 @@ export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({ data }) => {
       sortBy={sortBy}
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
-      data={sortedData.slice(
-        pagination.offset,
-        pagination.offset + pagination.first
-      )}
+      data={data.slice(pagination.offset, pagination.offset + pagination.first)}
       onSortBy={onChangeSortBy}
       onChangePage={pagination.onChangePage}
       noDataMessageKey="error.no-items"

--- a/packages/transactions/src/OutboundShipment/DetailView/types.ts
+++ b/packages/transactions/src/OutboundShipment/DetailView/types.ts
@@ -14,6 +14,7 @@ export interface OutboundShipment extends Transaction {
 
 export enum ActionType {
   UpdateQuantity = 'OutboundShipment/updateQuantity',
+  SortBy = 'OutboundShipment/sortBy',
 }
 
 export type CustomerInvoiceAction =
@@ -21,4 +22,10 @@ export type CustomerInvoiceAction =
   | {
       type: ActionType.UpdateQuantity;
       payload: { rowKey: string; quantity: number };
+    }
+  | {
+      type: ActionType.SortBy;
+      payload: {
+        key: keyof ItemRow;
+      };
     };

--- a/packages/transactions/src/OutboundShipment/DetailView/types.ts
+++ b/packages/transactions/src/OutboundShipment/DetailView/types.ts
@@ -2,6 +2,7 @@ import {
   Item,
   Transaction,
   DefaultDraftAction,
+  Column,
 } from '@openmsupply-client/common';
 
 export interface ItemRow extends Item {
@@ -25,7 +26,5 @@ export type CustomerInvoiceAction =
     }
   | {
       type: ActionType.SortBy;
-      payload: {
-        key: keyof ItemRow;
-      };
+      payload: { column: Column<ItemRow> };
     };

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -113,7 +113,8 @@ export const OutboundShipmentListViewComponent: FC = () => {
       .addColumn('total')
       .addColumn('comment')
       .addColumn('selection')
-      .build()
+      .build(),
+    { onChangeSortBy }
   );
 
   return (
@@ -150,7 +151,6 @@ export const OutboundShipmentListViewComponent: FC = () => {
       </AppBarButtonsPortal>
 
       <RemoteDataTable
-        onSortBy={onChangeSortBy}
         sortBy={sortBy}
         pagination={{ ...pagination, total: totalLength }}
         onChangePage={onChangePage}

--- a/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/transactions/src/OutboundShipment/ListView/ListView.tsx
@@ -114,7 +114,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
       .addColumn('comment')
       .addColumn('selection')
       .build(),
-    { onChangeSortBy }
+    { onChangeSortBy, sortBy }
   );
 
   return (
@@ -151,7 +151,6 @@ export const OutboundShipmentListViewComponent: FC = () => {
       </AppBarButtonsPortal>
 
       <RemoteDataTable
-        sortBy={sortBy}
         pagination={{ ...pagination, total: totalLength }}
         onChangePage={onChangePage}
         columns={columns}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16913,11 +16913,6 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
-use-immer@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/use-immer/-/use-immer-0.6.0.tgz#ca6aa5ade93018e2c65cf128d19ada54fc23f70d"
-  integrity sha512-dFGRfvWCqPDTOt/S431ETYTg6+uxbpb7A1pptufwXVzGJY3RlXr38+3wyLNpc6SbbmAKjWl6+EP6uW74fkEsXQ==
-
 use-isomorphic-layout-effect@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10052,6 +10052,11 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
+immer@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -16907,6 +16912,11 @@ use-composed-ref@^1.0.0:
   integrity sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==
   dependencies:
     ts-essentials "^2.0.3"
+
+use-immer@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/use-immer/-/use-immer-0.6.0.tgz#ca6aa5ade93018e2c65cf128d19ada54fc23f70d"
+  integrity sha512-dFGRfvWCqPDTOt/S431ETYTg6+uxbpb7A1pptufwXVzGJY3RlXr38+3wyLNpc6SbbmAKjWl6+EP6uW74fkEsXQ==
 
 use-isomorphic-layout-effect@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Fixes #193 

Combining a few things here

- Putting the state of sorting for the detail view in the reducer. The `useSortedData` hook was a problem as it was difficult to keep the sort stable after an edit .. (needed to memoize to keep the data sorted, but if you don't memoize, editing values caused a re-sort..).
- Added `immer`. The reducer is much more readable now. Went with using `immer` and `produce` over using the `use-immer` package with `useImmerReducer` because I added the hook and then had some type problems and saved more time by not using the hook 🤷 
- I put the `sortBy` object and `onChangeSortBy` into the `useColumns` hook. I think this works pretty nicely, the `Column` is the active object for the table and `ColumnDefinition` is just that. Saves prob drilling and makes a little more sense for the table to not actually know about sorting, since it doesn't actually do anything with it.
- Cleaned up the `Header` by just passing the column through, which was on my TODO from a previous PR
- Went with the state being `{draft: { .. } ... }`, though this makes it more of a 'page state', now so unsure on the naming, etc.