### PR TITLE
add some columns

### DIFF
--- a/packages/common/src/intl/intlHelpers.ts
+++ b/packages/common/src/intl/intlHelpers.ts
@@ -1,4 +1,4 @@
-import { useIntl } from 'react-intl';
+import { FormatNumberOptions, useIntl } from 'react-intl';
 import type { PrimitiveType } from 'intl-messageformat';
 
 // "import type" ensures en messages aren't bundled by default
@@ -39,6 +39,14 @@ export const useFormatDate = (): ((
 ) => string) => {
   const intl = useIntl();
   return (value, options) => intl.formatDate(value, options);
+};
+
+export const useFormatNumber = (): ((
+  value: number | bigint,
+  options?: FormatNumberOptions
+) => string) => {
+  const intl = useIntl();
+  return (value, options) => intl.formatNumber(value, options);
 };
 
 export const useRtl = (): boolean => {

--- a/packages/common/src/ui/components/StatusCrumbs.stories.tsx
+++ b/packages/common/src/ui/components/StatusCrumbs.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { LoadingSpinner } from './LoadingSpinner';
 import { StatusCrumbs } from './StatusCrumbs';
 import { OutboundShipmentStatus } from '../..';
 import { LocaleKey, useTranslation } from '../../intl/intlHelpers';

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -19,6 +19,7 @@ export interface HeaderProps<T extends DomainObject> {
 }
 
 export enum ColumnFormat {
+  Currency,
   Date,
   Integer,
   Real,

--- a/packages/common/src/ui/layout/tables/hooks/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns.tsx
@@ -6,7 +6,7 @@ import {
   ColumnAlign,
   Column,
 } from '../columns/types';
-import { useFormatDate } from '../../../../intl';
+import { useFormatDate, useFormatNumber } from '../../../../intl';
 import { BasicCell, BasicHeader } from '../components';
 import { SortBy } from '../../../..';
 import { ColumnDefinitionSetBuilder, ColumnKey } from '..';
@@ -72,6 +72,7 @@ const getSortType = (column: { format?: ColumnFormat }) => {
   switch (column.format) {
     case ColumnFormat.Date:
       return 'datetime';
+    case ColumnFormat.Currency:
     case ColumnFormat.Real:
     case ColumnFormat.Integer:
       return 'numeric';
@@ -82,8 +83,9 @@ const getSortType = (column: { format?: ColumnFormat }) => {
 
 const getDefaultAccessor =
   <T extends DomainObject>(column: ColumnDefinition<T>) =>
-  (row: T) =>
-    row[column.key] as string;
+  (row: T) => {
+    return row[column.key] as string;
+  };
 
 const getDefaultFormatter = <T extends DomainObject>(
   column: ColumnDefinition<T>
@@ -93,6 +95,15 @@ const getDefaultFormatter = <T extends DomainObject>(
       return (date: unknown) => {
         const formatDate = useFormatDate();
         return formatDate(new Date(date as string));
+      };
+    }
+    case ColumnFormat.Currency: {
+      return (value: unknown) => {
+        if (Number.isNaN(value)) return '';
+
+        const formatNumber = useFormatNumber();
+        // TODO: fetch currency symbol or use style: 'currency'
+        return `$${formatNumber(Number(value))}`;
       };
     }
     default: {

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -25,7 +25,10 @@ export type ColumnKey =
   | 'quantity'
   | 'itemCode'
   | 'itemName'
-  | 'expiry';
+  | 'expiry'
+  | 'batch'
+  | 'costPrice'
+  | 'sellPrice';
 
 const getColumnLookup = <T extends DomainObject>(): Record<
   ColumnKey,
@@ -34,18 +37,18 @@ const getColumnLookup = <T extends DomainObject>(): Record<
   expiry: {
     key: 'expiry',
     format: ColumnFormat.Date,
-    label: 'label.date',
-    width: 75,
+    label: 'label.expiry',
+    width: 50,
   },
   itemCode: {
     key: 'itemCode',
     label: 'label.code',
-    width: 75,
+    width: 50,
   },
   itemName: {
     key: 'itemName',
     label: 'label.name',
-    width: 75,
+    width: 125,
   },
   name: {
     key: 'name',
@@ -100,7 +103,7 @@ const getColumnLookup = <T extends DomainObject>(): Record<
   packSize: {
     label: 'label.packSize',
     key: 'packSize',
-    width: 20,
+    width: 75,
     align: ColumnAlign.Right,
   },
   quantity: {
@@ -108,6 +111,25 @@ const getColumnLookup = <T extends DomainObject>(): Record<
     key: 'quantity',
     width: 20,
     align: ColumnAlign.Right,
+  },
+  batch: {
+    label: 'label.batch',
+    key: 'batch',
+    width: 50,
+  },
+  costPrice: {
+    label: 'label.cost',
+    key: 'costPricePerPack',
+    width: 35,
+    align: ColumnAlign.Right,
+    format: ColumnFormat.Currency,
+  },
+  sellPrice: {
+    label: 'label.sell',
+    key: 'sellPricePerPack',
+    width: 35,
+    align: ColumnAlign.Right,
+    format: ColumnFormat.Currency,
   },
 });
 

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -149,7 +149,16 @@ export const OutboundShipmentDetailViewComponent: FC = () => {
   const { currentTab, onChangeTab } = useTabs('general');
 
   const columns = useColumns<ItemRow>(
-    ['itemCode', 'itemName', 'expiry', getEditableQuantityColumn()],
+    [
+      'itemCode',
+      'itemName',
+      'batch',
+      'expiry',
+      'costPrice',
+      'sellPrice',
+      'packSize',
+      getEditableQuantityColumn(),
+    ],
     { onChangeSortBy, sortBy },
     [sortBy]
   );

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -147,8 +147,6 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
 
   const checkAllocatedQuantities = () => {
     const values = getValues();
-    batchRows.map(batch => console.info(Number(values[batch.id] || 0)));
-
     const allocatedQuantity = batchRows.reduce(
       (total, batch) => (total += Number(values[batch.id] || 0)),
       0

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -16,6 +16,24 @@ interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   sortBy: SortBy<T>;
 }
 
+const flattenData = (row: ItemRow) => {
+  const { stockLine } = row;
+  const {
+    batch,
+    costPricePerPack: costPrice,
+    packSize,
+    sellPricePerPack: sellPrice,
+  } = stockLine || {};
+
+  return {
+    ...row,
+    batch,
+    costPrice,
+    packSize,
+    sellPrice,
+  };
+};
+
 export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({ data, columns }) => {
   const numberOfRows = useRowRenderCount();
   const { pagination } = usePagination(numberOfRows);
@@ -28,7 +46,9 @@ export const GeneralTab: FC<GeneralTabProps<ItemRow>> = ({ data, columns }) => {
     <RemoteDataTable
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
-      data={data.slice(pagination.offset, pagination.offset + pagination.first)}
+      data={data
+        .slice(pagination.offset, pagination.offset + pagination.first)
+        .map(flattenData)}
       onChangePage={pagination.onChangePage}
       noDataMessageKey="error.no-items"
     />

--- a/packages/invoices/src/OutboundShipment/DetailView/types.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/types.ts
@@ -7,6 +7,10 @@ import {
 } from '@openmsupply-client/common';
 
 export interface ItemRow extends InvoiceLine {
+  batch?: string;
+  costPrice?: number;
+  packSize?: number;
+  sellPrice?: number;
   updateQuantity: (quantity: number) => void;
 }
 


### PR DESCRIPTION
Fixes #289 

Added the columns and in the process got a little frustrated with the nested API response. This won't work with the current way we have the key in the accessor, so I've flattened the data for now.

Also popped in currency formatting.. that should probably pick up INTL format from somewhere, which doesn't exist yet

<img width="1063" alt="Screen Shot 2021-10-20 at 3 31 01 PM" src="https://user-images.githubusercontent.com/9192912/138018259-56971d10-af66-4b0a-a083-2b7aa9fe0d21.png">
.
