### PR TITLE
Add fix test case warnings

### DIFF
--- a/packages/common/src/ui/components/portals/AppFooter/AppFooter.test.tsx
+++ b/packages/common/src/ui/components/portals/AppFooter/AppFooter.test.tsx
@@ -1,0 +1,68 @@
+import React, { FC } from 'react';
+import { act, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppFooterPortal, AppFooter } from './AppFooter';
+
+describe('AppBarContent', () => {
+  const TestAppBarContent: FC<{ initialShow: boolean }> = ({ initialShow }) => {
+    const [show, setShow] = React.useState(initialShow);
+
+    return (
+      <>
+        <button onClick={() => setShow(state => !state)} />
+        {show && (
+          <div id="source">
+            <AppFooter />
+          </div>
+        )}
+
+        <div data-testid="2">
+          <AppFooterPortal
+            SessionDetails={<span>josh</span>}
+            Content={<span>mark</span>}
+          />
+        </div>
+      </>
+    );
+  };
+
+  it('Portal children are rendered under the source', () => {
+    const { getByText } = render(<TestAppBarContent initialShow />);
+
+    const node = getByText(/josh/);
+    const node2 = getByText(/mark/);
+
+    expect(node.parentNode).not.toHaveAttribute('data-testid', '2');
+    expect(node.closest('#source')).toBeInTheDocument();
+    expect(node2.parentNode).not.toHaveAttribute('data-testid', '2');
+    expect(node2.closest('#source')).toBeInTheDocument();
+  });
+
+  it('Portal children dismount if the portal dismounts', () => {
+    const { queryByText, getByRole } = render(
+      <TestAppBarContent initialShow />
+    );
+
+    const button = getByRole(/button/);
+
+    act(() => {
+      userEvent.click(button);
+    });
+
+    const node = queryByText(/josh/);
+    const node2 = queryByText(/mark/);
+
+    expect(node).not.toBeInTheDocument();
+    expect(node2).not.toBeInTheDocument();
+  });
+
+  it('The portal children are not rendered if the source is not rendered', () => {
+    const { queryByText } = render(<TestAppBarContent initialShow={false} />);
+
+    const node = queryByText(/josh/);
+    const node2 = queryByText(/mark/);
+
+    expect(node).not.toBeInTheDocument();
+    expect(node2).not.toBeInTheDocument();
+  });
+});

--- a/packages/invoices/src/OutboundShipment/CustomerSearchInput.tsx
+++ b/packages/invoices/src/OutboundShipment/CustomerSearchInput.tsx
@@ -33,10 +33,12 @@ export const CustomerSearchInput: FC<CustomerSearchProps> = ({
       disabled={disabled}
       clearable={false}
       value={
-        value && {
-          ...value,
-          label: String(value?.name),
-        }
+        value && !!value.name
+          ? {
+              ...value,
+              label: String(value?.name ?? ''),
+            }
+          : undefined
       }
       filterOptionConfig={filterOptions}
       loading={isLoading}

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundDetailToolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundDetailToolbar.tsx
@@ -50,7 +50,7 @@ export const OutboundDetailToolbar: FC<OutboundShipmentToolbarProps> = ({
                   disabled
                   size="small"
                   sx={{ width: 250 }}
-                  value={draft.theirReference}
+                  value={draft?.theirReference ?? ''}
                   onChange={event => {
                     draft.update?.('theirReference', event.target.value);
                   }}


### PR DESCRIPTION
Just a few fixes of some warning when I ran `yarn test`

There is a slightly bigger problem in that the mock-worker is now using a data source with less predictable IDs (rather than an index starting from `0`) which means the `DetailView` test isn't actually getting data anymore. I think I'll leave that for now and revisit