### PR TITLE
5 - #311 group by batch

### DIFF
--- a/packages/common/src/hooks/useQueryParams/useQueryParams.ts
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.ts
@@ -16,7 +16,7 @@ export interface QueryParamsState<T extends ObjectWithStringKeys>
 export const useQueryParams = <T extends ObjectWithStringKeys>(
   initialSortBy: SortRule<T>
 ): QueryParamsState<T> => {
-  const pagination = usePagination(20);
+  const pagination = usePagination();
   const { sortBy, onChangeSortBy } = useSortBy<T>(initialSortBy);
 
   const queryParams = { ...pagination, pagination, sortBy, onChangeSortBy };

--- a/packages/common/src/intl/locales/ar.json
+++ b/packages/common/src/intl/locales/ar.json
@@ -64,6 +64,8 @@
   "label.delivered": "Delivered",
   "label.draft": "Draft",
   "label.entered": "Entered",
+  "label.expand": "Expand",
+  "label.expand-all": "Expand all",
   "label.expiry": "Expiry",
   "label.general": "General",
   "label.hold": "Hold",

--- a/packages/common/src/intl/locales/en.json
+++ b/packages/common/src/intl/locales/en.json
@@ -64,6 +64,8 @@
   "label.delivered": "Delivered",
   "label.draft": "Draft",
   "label.entered": "Entered",
+  "label.expand": "Expand",
+  "label.expand-all": "Expand all",
   "label.expiry": "Expiry",
   "label.general": "General",
   "label.hold": "Hold",

--- a/packages/common/src/intl/locales/fr.json
+++ b/packages/common/src/intl/locales/fr.json
@@ -64,6 +64,8 @@
   "label.delivered": "Delivered",
   "label.draft": "Draft",
   "label.entered": "Entered",
+  "label.expand": "Expand",
+  "label.expand-all": "Expand all",
   "label.expiry": "Expiry",
   "label.general": "General",
   "label.hold": "Hold",

--- a/packages/common/src/intl/locales/pt.json
+++ b/packages/common/src/intl/locales/pt.json
@@ -64,6 +64,8 @@
   "label.delivered": "Delivered",
   "label.draft": "Draft",
   "label.entered": "Entered",
+  "label.expand": "Expand",
+  "label.expand-all": "Expand all",
   "label.expiry": "Expiry",
   "label.general": "General",
   "label.hold": "Hold",

--- a/packages/common/src/ui/icons/ChevronsDown.tsx
+++ b/packages/common/src/ui/icons/ChevronsDown.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+
+export const ChevronsDownIcon = (props: SvgIconProps): JSX.Element => {
+  return (
+    <SvgIcon
+      {...props}
+      style={{
+        strokeWidth: 2,
+        strokeLinecap: 'round',
+        strokeLinejoin: 'round',
+        stroke: 'currentColor',
+        fill: 'none',
+      }}
+      viewBox="0 0 24 24"
+    >
+      <polyline points="7 13 12 18 17 13"></polyline>
+      <polyline points="7 6 12 11 17 6"></polyline>
+    </SvgIcon>
+  );
+};

--- a/packages/common/src/ui/icons/Icon.stories.tsx
+++ b/packages/common/src/ui/icons/Icon.stories.tsx
@@ -11,6 +11,7 @@ import { CheckboxCheckedIcon } from './CheckboxChecked';
 import { CheckboxEmptyIcon } from './CheckboxEmpty';
 import { CheckboxIndeterminateIcon } from './CheckboxIndeterminate';
 import { ChevronDownIcon } from './ChevronDown';
+import { ChevronsDownIcon } from './ChevronsDown';
 import { CircleIcon } from './Circle';
 import { ClockIcon } from './Clock';
 import { CloseIcon } from './Close';
@@ -80,6 +81,7 @@ const Template: ComponentStory<React.FC<SvgIconProps>> = args => {
     },
     { icon: <CheckboxEmptyIcon {...args} />, name: 'CheckboxEmpty' },
     { icon: <ChevronDownIcon {...args} />, name: 'ChevronDown' },
+    { icon: <ChevronsDownIcon {...args} />, name: 'ChevronsDown' },
     { icon: <CircleIcon {...args} />, name: 'Circle' },
     { icon: <ClockIcon {...args} />, name: 'Clock' },
     { icon: <CloseIcon {...args} />, name: 'Close' },

--- a/packages/common/src/ui/icons/index.ts
+++ b/packages/common/src/ui/icons/index.ts
@@ -7,6 +7,7 @@ export { CheckboxEmptyIcon } from './CheckboxEmpty';
 export { CheckboxIndeterminateIcon } from './CheckboxIndeterminate';
 export { CheckIcon } from './Check';
 export { ChevronDownIcon } from './ChevronDown';
+export { ChevronsDownIcon } from './ChevronsDown';
 export { CircleIcon } from './Circle';
 export { ClockIcon } from './Clock';
 export { CloseIcon } from './Close';

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -27,6 +27,7 @@ export const DataTable = <T extends DomainObject>({
   pagination,
   onChangePage,
   noDataMessageKey,
+  ExpandContent,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation();
   const { setActiveRows } = useTableStore();
@@ -72,6 +73,7 @@ export const DataTable = <T extends DomainObject>({
           {data.map((row, idx) => {
             return (
               <DataRow
+                ExpandContent={ExpandContent}
                 columns={columns}
                 key={row.id}
                 onClick={onRowClick}

--- a/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -34,7 +34,7 @@ export const getCheckboxSelectionColumn = <
   key: GenericColumnKey.Selection,
   sortable: false,
   align: ColumnAlign.Right,
-  width: 40,
+  width: 60,
   Header: () => {
     const { toggleAll, allSelected, someSelected } = useTableStore(state => {
       const allSelected =

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -1,0 +1,102 @@
+import { Box } from '@mui/material';
+import React, { useCallback } from 'react';
+import { ColumnAlign, ColumnDefinition } from '..';
+import { TableStore, useTableStore } from '../..';
+import { IconButton } from '../../../..';
+
+import {
+  ChevronDownIcon,
+  ChevronsDownIcon,
+  DomainObject,
+} from '../../../../..';
+
+const useExpanded = (rowId: string) => {
+  const selector = useCallback(
+    (state: TableStore) => {
+      return {
+        rowId,
+        isExpanded: state.rowState[rowId]?.isExpanded,
+        toggleExpanded: () => state.toggleExpanded(rowId),
+        expanded: state.numberExpanded > 0,
+      };
+    },
+    [rowId]
+  );
+
+  const equalityFn = (
+    oldState: ReturnType<typeof selector>,
+    newState: ReturnType<typeof selector>
+  ) =>
+    oldState?.isExpanded === newState?.isExpanded &&
+    oldState.rowId === newState.rowId;
+
+  const { isExpanded, toggleExpanded, expanded } = useTableStore(
+    selector,
+    equalityFn
+  );
+
+  return { isExpanded, toggleExpanded, expanded };
+};
+
+export const getRowExpandColumn = <
+  T extends DomainObject
+>(): ColumnDefinition<T> => ({
+  key: 'expand',
+  sortable: false,
+  align: ColumnAlign.Center,
+  width: 60,
+  Header: () => {
+    const { numberExpanded, toggleAllExpanded } = useTableStore();
+    return (
+      <IconButton
+        labelKey="app.admin"
+        onClick={toggleAllExpanded}
+        icon={
+          <Box
+            sx={{
+              transition: theme =>
+                theme.transitions.create('transform', {
+                  duration: theme.transitions.duration.leavingScreen,
+                }),
+              transform: !!numberExpanded ? 'rotate(180deg)' : 'rotate(360deg)',
+            }}
+          >
+            <ChevronsDownIcon />
+          </Box>
+        }
+      />
+    );
+  },
+  Cell: ({ rowData }) => {
+    const { toggleExpanded, expanded } = useExpanded(rowData.id);
+
+    return (
+      <IconButton
+        labelKey="app.admin"
+        onClick={event => {
+          event.stopPropagation();
+          toggleExpanded();
+        }}
+        icon={
+          <Box
+            // sx={{
+            //   animation: !!expanded
+            //     ? `${spin} 1s ease`
+            //     : `${otherSpin} 1s ease`,
+            // }}
+            sx={{
+              transition: theme =>
+                theme.transitions.create('transform', {
+                  easing: theme.transitions.easing.sharp,
+                  duration: theme.transitions.duration.leavingScreen,
+                }),
+              transform: expanded ? 'rotate(180deg)' : 'rotate(360deg)',
+            }}
+          >
+            <ChevronDownIcon />
+          </Box>
+        }
+      />
+    );
+  },
+});

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -31,7 +31,7 @@ export const getRowExpandColumn = <
                 theme.transitions.create('transform', {
                   duration: theme.transitions.duration.leavingScreen,
                 }),
-              transform: !!numberExpanded ? 'rotate(360deg)' : 'rotate(270deg)',
+              transform: !!numberExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
             }}
           >
             <ChevronsDownIcon />
@@ -58,7 +58,7 @@ export const getRowExpandColumn = <
                   easing: theme.transitions.easing.sharp,
                   duration: theme.transitions.duration.leavingScreen,
                 }),
-              transform: isExpanded ? 'rotate(360deg)' : 'rotate(270deg)',
+              transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
             }}
           >
             <ChevronDownIcon />

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -1,42 +1,14 @@
 import { Box } from '@mui/material';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { ColumnAlign, ColumnDefinition } from '..';
-import { TableStore, useTableStore } from '../..';
+import { useExpanded } from '../..';
 import { IconButton } from '../../../..';
-
 import {
   ChevronDownIcon,
   ChevronsDownIcon,
   DomainObject,
+  useTableStore,
 } from '../../../../..';
-
-const useExpanded = (rowId: string) => {
-  const selector = useCallback(
-    (state: TableStore) => {
-      return {
-        rowId,
-        isExpanded: state.rowState[rowId]?.isExpanded,
-        toggleExpanded: () => state.toggleExpanded(rowId),
-        expanded: state.numberExpanded > 0,
-      };
-    },
-    [rowId]
-  );
-
-  const equalityFn = (
-    oldState: ReturnType<typeof selector>,
-    newState: ReturnType<typeof selector>
-  ) =>
-    oldState?.isExpanded === newState?.isExpanded &&
-    oldState.rowId === newState.rowId;
-
-  const { isExpanded, toggleExpanded, expanded } = useTableStore(
-    selector,
-    equalityFn
-  );
-
-  return { isExpanded, toggleExpanded, expanded };
-};
 
 export const getRowExpandColumn = <
   T extends DomainObject
@@ -47,9 +19,10 @@ export const getRowExpandColumn = <
   width: 60,
   Header: () => {
     const { numberExpanded, toggleAllExpanded } = useTableStore();
+
     return (
       <IconButton
-        labelKey="app.admin"
+        labelKey="label.expand-all"
         onClick={toggleAllExpanded}
         icon={
           <Box
@@ -58,7 +31,7 @@ export const getRowExpandColumn = <
                 theme.transitions.create('transform', {
                   duration: theme.transitions.duration.leavingScreen,
                 }),
-              transform: !!numberExpanded ? 'rotate(180deg)' : 'rotate(360deg)',
+              transform: !!numberExpanded ? 'rotate(360deg)' : 'rotate(270deg)',
             }}
           >
             <ChevronsDownIcon />
@@ -68,29 +41,24 @@ export const getRowExpandColumn = <
     );
   },
   Cell: ({ rowData }) => {
-    const { toggleExpanded, expanded } = useExpanded(rowData.id);
+    const { toggleExpanded, isExpanded } = useExpanded(rowData.id);
 
     return (
       <IconButton
-        labelKey="app.admin"
+        labelKey="label.expand"
         onClick={event => {
           event.stopPropagation();
           toggleExpanded();
         }}
         icon={
           <Box
-            // sx={{
-            //   animation: !!expanded
-            //     ? `${spin} 1s ease`
-            //     : `${otherSpin} 1s ease`,
-            // }}
             sx={{
               transition: theme =>
                 theme.transitions.create('transform', {
                   easing: theme.transitions.easing.sharp,
                   duration: theme.transitions.duration.leavingScreen,
                 }),
-              transform: expanded ? 'rotate(180deg)' : 'rotate(360deg)',
+              transform: isExpanded ? 'rotate(360deg)' : 'rotate(270deg)',
             }}
           >
             <ChevronDownIcon />

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/index.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/index.tsx
@@ -1,0 +1,1 @@
+export * from './RowExpand';

--- a/packages/common/src/ui/layout/tables/columns/index.ts
+++ b/packages/common/src/ui/layout/tables/columns/index.ts
@@ -2,3 +2,4 @@ export { getEditableQuantityColumn } from './EditableQuantityColumn';
 export { getCheckboxSelectionColumn } from './CheckboxSelectionColumn';
 export { getNameAndColorColumn } from './NameAndColorColumn';
 export * from './types';
+export * from './RowExpand';

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -1,9 +1,9 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { Column } from '../../columns/types';
 import { DomainObject } from '../../../../../types';
-import { TableStore, useTableStore } from '../..';
+import { useExpanded } from '../..';
 import { Collapse } from '@mui/material';
 
 interface DataRowProps<T extends DomainObject> {
@@ -13,30 +13,6 @@ interface DataRowProps<T extends DomainObject> {
   rowKey: string;
   ExpandContent?: FC;
 }
-
-const useExpanded = (rowId: string) => {
-  const selector = useCallback(
-    (state: TableStore) => {
-      return {
-        rowId,
-        isExpanded: state.rowState[rowId]?.isExpanded,
-        toggleExpanded: () => state.toggleExpanded(rowId),
-      };
-    },
-    [rowId]
-  );
-
-  const equalityFn = (
-    oldState: ReturnType<typeof selector>,
-    newState: ReturnType<typeof selector>
-  ) =>
-    oldState?.isExpanded === newState?.isExpanded &&
-    oldState.rowId === newState.rowId;
-
-  const { isExpanded, toggleExpanded } = useTableStore(selector, equalityFn);
-
-  return { isExpanded, toggleExpanded };
-};
 
 export const DataRow = <T extends DomainObject>({
   columns,

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -1,68 +1,102 @@
-import React from 'react';
+import React, { FC, useCallback } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { Column } from '../../columns/types';
 import { DomainObject } from '../../../../../types';
+import { TableStore, useTableStore } from '../..';
+import { Collapse } from '@mui/material';
 
 interface DataRowProps<T extends DomainObject> {
   columns: Column<T>[];
   onClick?: (rowValues: T) => void;
   rowData: T;
   rowKey: string;
+  ExpandContent?: FC;
 }
+
+const useExpanded = (rowId: string) => {
+  const selector = useCallback(
+    (state: TableStore) => {
+      return {
+        rowId,
+        isExpanded: state.rowState[rowId]?.isExpanded,
+        toggleExpanded: () => state.toggleExpanded(rowId),
+      };
+    },
+    [rowId]
+  );
+
+  const equalityFn = (
+    oldState: ReturnType<typeof selector>,
+    newState: ReturnType<typeof selector>
+  ) =>
+    oldState?.isExpanded === newState?.isExpanded &&
+    oldState.rowId === newState.rowId;
+
+  const { isExpanded, toggleExpanded } = useTableStore(selector, equalityFn);
+
+  return { isExpanded, toggleExpanded };
+};
 
 export const DataRow = <T extends DomainObject>({
   columns,
   onClick,
   rowData,
   rowKey,
+  ExpandContent,
 }: DataRowProps<T>): JSX.Element => {
   const hasOnClick = !!onClick;
+  const { isExpanded } = useExpanded(rowData.id);
 
   const onRowClick = () => onClick && onClick(rowData);
 
   return (
-    <TableRow
-      sx={{
-        alignItems: 'center',
-        height: '40px',
-        maxHeight: '45px',
-        boxShadow: 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
-        padding: '0px 20px',
-        display: 'flex',
-        flex: '1 0 auto',
-      }}
-      onClick={onRowClick}
-      hover={hasOnClick}
-    >
-      {columns.map(column => {
-        return (
-          <TableCell
-            key={`${rowKey}${column.key}`}
-            align={column.align}
-            sx={{
-              borderBottom: 'none',
-              justifyContent: 'flex-end',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              padding: 0,
-              paddingRight: '16px',
-              ...(hasOnClick && { cursor: 'pointer' }),
-              flex: `${column.width} 0 auto`,
-              minWidth: column.minWidth,
-              width: column.width,
-            }}
-          >
-            <column.Cell
-              rowData={rowData}
-              columns={columns}
-              column={column}
-              rowKey={rowKey}
-            />
-          </TableCell>
-        );
-      })}
-    </TableRow>
+    <>
+      <TableRow
+        sx={{
+          alignItems: 'center',
+          height: '40px',
+          maxHeight: '45px',
+          boxShadow: 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
+          padding: '0px 20px',
+          display: 'flex',
+          flex: '1 0 auto',
+        }}
+        onClick={onRowClick}
+        hover={hasOnClick}
+      >
+        {columns.map(column => {
+          return (
+            <TableCell
+              key={`${rowKey}${column.key}`}
+              align={column.align}
+              sx={{
+                borderBottom: 'none',
+                justifyContent: 'flex-end',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                padding: 0,
+                paddingRight: '16px',
+                ...(hasOnClick && { cursor: 'pointer' }),
+                flex: `${column.width} 0 auto`,
+                minWidth: column.minWidth,
+                width: column.width,
+              }}
+            >
+              <column.Cell
+                rowData={rowData}
+                columns={columns}
+                column={column}
+                rowKey={rowKey}
+              />
+            </TableCell>
+          );
+        })}
+      </TableRow>
+      <Collapse in={isExpanded}>
+        {ExpandContent ? <ExpandContent /> : null}
+      </Collapse>
+    </>
   );
 };

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -70,9 +70,13 @@ export const DataRow = <T extends DomainObject>({
           );
         })}
       </TableRow>
-      <Collapse in={isExpanded}>
-        {ExpandContent ? <ExpandContent /> : null}
-      </Collapse>
+      <tr>
+        <td style={{ display: 'flex' }}>
+          <Collapse sx={{ flex: 1 }} in={isExpanded}>
+            {ExpandContent ? <ExpandContent /> : null}
+          </Collapse>
+        </td>
+      </tr>
     </>
   );
 };

--- a/packages/common/src/ui/layout/tables/context/TableContext.test.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.test.ts
@@ -170,4 +170,78 @@ describe('TableContext', () => {
     expect(result.current.rowState['b']?.isExpanded).toBe(false);
     expect(result.current.rowState['c']?.isExpanded).toBe(false);
   });
+
+  it('sets all active rows as expanded when expand all is called', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows, toggleAllExpanded } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+      toggleAllExpanded();
+    });
+
+    expect(result.current.rowState['a']?.isExpanded).toBe(true);
+    expect(result.current.rowState['b']?.isExpanded).toBe(true);
+    expect(result.current.rowState['c']?.isExpanded).toBe(true);
+  });
+
+  it('sets all active rows as not expanded when expand all is called twice', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows, toggleAllExpanded } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+      toggleAllExpanded();
+      toggleAllExpanded();
+    });
+
+    expect(result.current.rowState['a']?.isExpanded).toBe(false);
+    expect(result.current.rowState['b']?.isExpanded).toBe(false);
+    expect(result.current.rowState['c']?.isExpanded).toBe(false);
+  });
+
+  it('sets all active rows as expanded when expand all is called in an indeterminate state', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows, toggleExpanded, toggleAllExpanded } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+      toggleAllExpanded();
+      toggleExpanded('b');
+      toggleAllExpanded();
+    });
+
+    expect(result.current.rowState['a']?.isExpanded).toBe(true);
+    expect(result.current.rowState['b']?.isExpanded).toBe(true);
+    expect(result.current.rowState['c']?.isExpanded).toBe(true);
+  });
+
+  it('only sets the expanded state when toggling, not the selected state', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows, toggleExpanded } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+      toggleExpanded('a');
+    });
+
+    expect(result.current.rowState['a']?.isExpanded).toBe(true);
+    expect(result.current.rowState['a']?.isSelected).toBe(false);
+  });
+
+  it('after setting active rows, there are no expanded rows', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+    });
+
+    expect(result.current.numberExpanded).toBe(0);
+  });
 });

--- a/packages/common/src/ui/layout/tables/context/TableContext.test.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.test.ts
@@ -139,4 +139,35 @@ describe('TableContext', () => {
     expect(result.current.rowState['c']?.isSelected).toBe(false);
     expect(result.current.numberSelected).toBe(0);
   });
+
+  it('sets a single row as expanded once called', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows, toggleExpanded } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+      toggleExpanded('a');
+    });
+
+    expect(result.current.rowState['a']?.isExpanded).toBe(true);
+    expect(result.current.rowState['b']?.isExpanded).toBe(false);
+    expect(result.current.rowState['c']?.isExpanded).toBe(false);
+  });
+
+  it('sets a single row as not expanded when called twice', () => {
+    const { result } = renderHook<unknown, TableStore>(useStore);
+
+    const { setActiveRows, toggleExpanded } = result.current;
+
+    act(() => {
+      setActiveRows(['a', 'b', 'c']);
+      toggleExpanded('a');
+      toggleExpanded('a');
+    });
+
+    expect(result.current.rowState['a']?.isExpanded).toBe(false);
+    expect(result.current.rowState['b']?.isExpanded).toBe(false);
+    expect(result.current.rowState['c']?.isExpanded).toBe(false);
+  });
 });

--- a/packages/common/src/ui/layout/tables/context/TableContext.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import create, { UseStore } from 'zustand';
 import createContext from 'zustand/context';
 
@@ -159,3 +160,30 @@ export const createTableStore = (): UseStore<TableStore> =>
       });
     },
   }));
+
+interface UseExpandedControl {
+  isExpanded: boolean;
+  toggleExpanded: () => void;
+}
+
+export const useExpanded = (rowId: string): UseExpandedControl => {
+  const selector = useCallback(
+    (state: TableStore) => {
+      return {
+        rowId,
+        isExpanded: state.rowState[rowId]?.isExpanded ?? false,
+        toggleExpanded: () => state.toggleExpanded(rowId),
+      };
+    },
+    [rowId]
+  );
+
+  const equalityFn = (
+    oldState: ReturnType<typeof selector>,
+    newState: ReturnType<typeof selector>
+  ) =>
+    oldState?.isExpanded === newState?.isExpanded &&
+    oldState.rowId === newState.rowId;
+
+  return useTableStore(selector, equalityFn);
+};

--- a/packages/common/src/ui/layout/tables/context/TableContext.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.ts
@@ -10,6 +10,7 @@ export interface TableStore {
   rowState: Record<string, RowState>;
   numberSelected: number;
 
+  toggleExpanded: (id: string) => void;
   toggleSelected: (id: string) => void;
   toggleAll: () => void;
   setActiveRows: (id: string[]) => void;
@@ -60,6 +61,7 @@ export const createTableStore = (): UseStore<TableStore> =>
               [id]: {
                 ...rowState[id],
                 isSelected: rowState[id]?.isSelected ?? false,
+                isExpanded: false,
               },
             };
           },
@@ -95,6 +97,24 @@ export const createTableStore = (): UseStore<TableStore> =>
               ...state.rowState[id],
               isSelected,
               isExpanded: state.rowState[id]?.isExpanded ?? false,
+            },
+          },
+        };
+      });
+    },
+
+    toggleExpanded: (id: string) => {
+      set(state => {
+        const { rowState } = state;
+
+        return {
+          ...state,
+          rowState: {
+            ...rowState,
+            [id]: {
+              ...rowState[id],
+              isSelected: rowState[id]?.isSelected ?? false,
+              isExpanded: !rowState[id]?.isExpanded,
             },
           },
         };

--- a/packages/common/src/ui/layout/tables/context/TableContext.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.ts
@@ -3,6 +3,7 @@ import createContext from 'zustand/context';
 
 export interface RowState {
   isSelected: boolean;
+  isExpanded: boolean;
 }
 
 export interface TableStore {
@@ -35,7 +36,11 @@ export const createTableStore = (): UseStore<TableStore> =>
           rowState: Object.keys(state.rowState).reduce(
             (newState, id) => ({
               ...newState,
-              [id]: { isSelected },
+              [id]: {
+                ...state.rowState[id],
+                isSelected,
+                isExpanded: state.rowState[id]?.isExpanded ?? false,
+              },
             }),
             state.rowState
           ),
@@ -52,7 +57,10 @@ export const createTableStore = (): UseStore<TableStore> =>
           (newRowState, id) => {
             return {
               ...newRowState,
-              [id]: { isSelected: rowState[id]?.isSelected ?? false },
+              [id]: {
+                ...rowState[id],
+                isSelected: rowState[id]?.isSelected ?? false,
+              },
             };
           },
           {}
@@ -83,7 +91,11 @@ export const createTableStore = (): UseStore<TableStore> =>
           numberSelected: newNumberSelected,
           rowState: {
             ...state.rowState,
-            [id]: { ...state.rowState[id], isSelected },
+            [id]: {
+              ...state.rowState[id],
+              isSelected,
+              isExpanded: state.rowState[id]?.isExpanded ?? false,
+            },
           },
         };
       });

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, FC } from 'react';
 import { LocaleKey } from '@openmsupply-client/common/src/intl/intlHelpers';
 import { ObjectWithStringKeys, DomainObject } from './../../../types';
 import { Pagination } from '../../../hooks/usePagination';
@@ -25,4 +25,5 @@ export interface TableProps<T extends DomainObject> {
   onRowClick?: (row: T) => void;
   children?: ReactNode;
   noDataMessageKey?: LocaleKey;
+  ExpandContent?: FC;
 }

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -7,6 +7,7 @@ import {
   useColumns,
   useDocument,
   useToggle,
+  getRowExpandColumn,
 } from '@openmsupply-client/common';
 import { reducer, OutboundAction } from './reducer';
 import { getOutboundShipmentDetailViewApi } from '../../api';
@@ -51,6 +52,7 @@ export const DetailView: FC = () => {
       'sellPricePerPack',
       'packSize',
       'numberOfPacks',
+      getRowExpandColumn<ItemRow>(),
     ],
     { onChangeSortBy, sortBy },
     [sortBy]

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -32,7 +32,7 @@ export const GeneralTabComponent: FC<GeneralTabProps<ItemRow>> = ({
   data,
   columns,
 }) => {
-  const { pagination } = usePagination(20);
+  const { pagination } = usePagination();
 
   return (
     <DataTable

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -5,6 +5,7 @@ import {
   usePagination,
   Column,
   DomainObject,
+  Box,
 } from '@openmsupply-client/common';
 import { ItemRow } from '../types';
 
@@ -12,6 +13,20 @@ interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   data: T[];
   columns: Column<T>[];
 }
+
+const Expand: FC = () => {
+  return (
+    <Box p={1} height={300}>
+      <Box
+        flex={1}
+        display="flex"
+        height="100%"
+        borderRadius={4}
+        bgcolor="#c7c9d933"
+      />
+    </Box>
+  );
+};
 
 export const GeneralTabComponent: FC<GeneralTabProps<ItemRow>> = ({
   data,
@@ -21,6 +36,7 @@ export const GeneralTabComponent: FC<GeneralTabProps<ItemRow>> = ({
 
   return (
     <DataTable
+      ExpandContent={Expand}
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
       data={data.slice(pagination.offset, pagination.offset + pagination.first)}


### PR DESCRIPTION
I messed up commits - whoops.

First one is https://github.com/openmsupply/openmsupply-client/pull/349 - Accidentally committed to that branch *and* pushed, so took an earlier commit and made that PR.


----------

This one introduces row expanding

![image](https://user-images.githubusercontent.com/35858975/139566255-2ee632ba-e88b-44dc-a700-9512de82d559.png)

- It's in the `TableContext` which made this quite easy
- I used chevron because the plus looked strange, then I googled and it said use chevron for accordions - the double chevrons.. uh.. maybe not..
- The content is just placeholder
- I am fairly convinced that using an accordion for rows AND a modal is too much - I don't see why we need both (and now have a preference for the accordion...)
