### PR TITLE
6 - #311 group by batch 1

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -31,3 +31,4 @@ export * from './useWindowDimensions';
 export * from './useDebounce';
 export * from './useDocument';
 export * from './useToggle';
+export * from './useContentAreaHeight';

--- a/packages/common/src/hooks/useContentAreaHeight/index.ts
+++ b/packages/common/src/hooks/useContentAreaHeight/index.ts
@@ -1,0 +1,1 @@
+export * from './useContentAreaHeight';

--- a/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.test.tsx
+++ b/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useContentAreaHeight } from '.';
+import { useAppTheme } from '../..';
+
+describe('useContentAreaHeight', () => {
+  beforeEach(() => {
+    window.resizeTo(1000, 1000);
+  });
+
+  it('calculates the correct content height', () => {
+    const { result } = renderHook(() => {
+      const theme = useAppTheme();
+      theme.mixins.footer = { height: 0 };
+      return useContentAreaHeight();
+    });
+
+    expect(result.current).toBe(1000);
+  });
+
+  it('calculates the correct content height accounting for a footer', () => {
+    const { result } = renderHook(() => {
+      const theme = useAppTheme();
+      theme.mixins.footer = { height: 100 };
+      return useContentAreaHeight();
+    });
+
+    expect(result.current).toBe(900);
+  });
+});

--- a/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.tsx
+++ b/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.tsx
@@ -1,0 +1,16 @@
+import { useAppBarRectStore, useWindowDimensions } from '..';
+import { useAppTheme } from '../../styles';
+
+export const useContentAreaHeight = (): number => {
+  const { height: appBarHeight } = useAppBarRectStore();
+  const { height: windowHeight } = useWindowDimensions();
+  const theme = useAppTheme();
+  const { mixins } = theme;
+
+  const pageFooterHeight = mixins.footer.height;
+
+  const contentAreaHeight =
+    windowHeight - (appBarHeight ?? 0) - pageFooterHeight;
+
+  return contentAreaHeight;
+};

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -36,7 +36,6 @@ interface ListDataState<T extends ObjectWithStringKeys> extends QueryParams<T> {
   isUpdateLoading: boolean;
   isDeleteLoading: boolean;
   isLoading: boolean;
-  numberOfRows: number;
 }
 
 export const useListData = <T extends ObjectWithStringKeys>(
@@ -46,8 +45,7 @@ export const useListData = <T extends ObjectWithStringKeys>(
   onError?: (e: ClientError) => void
 ): ListDataState<T> => {
   const queryClient = useQueryClient();
-  const { queryParams, first, offset, sortBy, numberOfRows } =
-    useQueryParams(initialSortBy);
+  const { queryParams, first, offset, sortBy } = useQueryParams(initialSortBy);
   const fullQueryKey = [queryKey, 'list', queryParams];
   const { error } = useNotification();
   const defaultErrorHandler = (e: ClientError) =>
@@ -84,11 +82,10 @@ export const useListData = <T extends ObjectWithStringKeys>(
   return {
     ...queryParams,
     totalCount: data?.totalCount,
-    data: data?.nodes,
+    data: data?.nodes.slice(0, 20),
     onCreate,
     invalidate,
     isCreateLoading,
-    numberOfRows,
     fullQueryKey,
     queryParams,
     onUpdate,

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
@@ -3,7 +3,6 @@ import { TestingProvider } from '../../utils/testing';
 import { useTheme } from '../../styles';
 import { renderHook } from '@testing-library/react-hooks';
 import { useQueryParams } from './useQueryParams';
-import { act } from 'react-dom/test-utils';
 
 type TestSortBy = {
   id: string;
@@ -78,68 +77,10 @@ describe('useQueryParams', () => {
     expect(result.current).toEqual(
       expect.objectContaining({
         sortBy: { key: 'id', isDesc: false, direction: 'asc' },
-        pagination: expect.objectContaining({ page: 0, offset: 0, first: 100 }),
+        pagination: expect.objectContaining({ page: 0, offset: 0, first: 20 }),
         page: 0,
         offset: 0,
-        first: 100,
-      })
-    );
-  });
-
-  it('when the number of rows changes to be more than the amount of data cached, the pagination first value changes', () => {
-    window.resizeTo(1000, 1000);
-
-    const { result } = renderHook(
-      () => useQueryParams<TestSortBy>({ key: 'id' }),
-      {
-        wrapper: getWrapper(),
-      }
-    );
-
-    act(() => {
-      window.resizeTo(2000, 2000);
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    expect(result.current).toEqual(
-      expect.objectContaining({
-        sortBy: { key: 'id', isDesc: false, direction: 'asc' },
-        pagination: expect.objectContaining({ page: 0, offset: 0, first: 200 }),
-        page: 0,
-        offset: 0,
-        first: 200,
-      })
-    );
-  });
-
-  it('when the number of rows changes to be less than the amount of data cached, the pagination first value does not change', () => {
-    window.resizeTo(1000, 1000);
-
-    const { result } = renderHook(
-      () => useQueryParams<TestSortBy>({ key: 'id' }),
-      {
-        wrapper: getWrapper(),
-      }
-    );
-
-    act(() => {
-      window.resizeTo(500, 500);
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    expect(result.current).toEqual(
-      expect.objectContaining({
-        sortBy: { key: 'id', isDesc: false, direction: 'asc' },
-        pagination: expect.objectContaining({ page: 0, offset: 0, first: 100 }),
-        page: 0,
-        offset: 0,
-        first: 100,
+        first: 20,
       })
     );
   });

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.ts
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.ts
@@ -1,6 +1,4 @@
-import { useEffect } from 'react';
 import { ObjectWithStringKeys } from './../../types/utility';
-import { useRowRenderCount } from '../useRowRenderCount';
 import { usePagination, PaginationState } from '../usePagination';
 import { useSortBy, SortState, SortRule } from '../useSortBy';
 
@@ -13,21 +11,13 @@ export interface QueryParamsState<T extends ObjectWithStringKeys>
     PaginationState {
   pagination: PaginationState;
   queryParams: QueryParams<T>;
-  numberOfRows: number;
 }
 
 export const useQueryParams = <T extends ObjectWithStringKeys>(
   initialSortBy: SortRule<T>
 ): QueryParamsState<T> => {
-  const numberOfRows = useRowRenderCount();
-  const pagination = usePagination(numberOfRows);
+  const pagination = usePagination(20);
   const { sortBy, onChangeSortBy } = useSortBy<T>(initialSortBy);
-
-  useEffect(() => {
-    if (numberOfRows > pagination.first) {
-      pagination.onChangeFirst(numberOfRows);
-    }
-  }, [numberOfRows, pagination.first]);
 
   const queryParams = { ...pagination, pagination, sortBy, onChangeSortBy };
 
@@ -37,6 +27,5 @@ export const useQueryParams = <T extends ObjectWithStringKeys>(
     sortBy,
     onChangeSortBy,
     queryParams,
-    numberOfRows,
   };
 };

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -27,7 +27,6 @@ export const DataTable = <T extends DomainObject>({
   pagination,
   onChangePage,
   noDataMessageKey,
-  height,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation();
   const { setActiveRows } = useTableStore();
@@ -60,37 +59,29 @@ export const DataTable = <T extends DomainObject>({
   }
 
   return (
-    <Box flexDirection="column" width="100%">
-      <TableContainer>
-        <MuiTable
-          sx={{
-            height,
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          <TableHead>
-            <HeaderRow>
-              {columns.map(column => (
-                <HeaderCell column={column} key={String(column.key)} />
-              ))}
-            </HeaderRow>
-          </TableHead>
-          <TableBody sx={{ overflow: 'auto', flex: 1 }}>
-            {data.map((row, idx) => {
-              return (
-                <DataRow
-                  columns={columns}
-                  key={row.id}
-                  onClick={onRowClick}
-                  rowData={row}
-                  rowKey={String(idx)}
-                />
-              );
-            })}
-          </TableBody>
-        </MuiTable>
-      </TableContainer>
+    <TableContainer sx={{ display: 'flex', flexDirection: 'column' }}>
+      <MuiTable sx={{ overflow: 'auto', display: 'block' }}>
+        <TableHead sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <HeaderRow>
+            {columns.map(column => (
+              <HeaderCell column={column} key={String(column.key)} />
+            ))}
+          </HeaderRow>
+        </TableHead>
+        <TableBody sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          {data.map((row, idx) => {
+            return (
+              <DataRow
+                columns={columns}
+                key={row.id}
+                onClick={onRowClick}
+                rowData={row}
+                rowKey={String(idx)}
+              />
+            );
+          })}
+        </TableBody>
+      </MuiTable>
       <PaginationRow
         page={pagination.page}
         offset={pagination.offset}
@@ -98,6 +89,6 @@ export const DataTable = <T extends DomainObject>({
         total={pagination.total ?? 0}
         onChange={onChangePage}
       />
-    </Box>
+    </TableContainer>
   );
 };

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -27,6 +27,7 @@ export const DataTable = <T extends DomainObject>({
   pagination,
   onChangePage,
   noDataMessageKey,
+  height,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation();
   const { setActiveRows } = useTableStore();
@@ -59,35 +60,37 @@ export const DataTable = <T extends DomainObject>({
   }
 
   return (
-    <TableContainer
-      sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        flexDirection: 'column',
-      }}
-    >
-      <MuiTable sx={{ display: 'block', overflow: 'auto' }}>
-        <TableHead sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          <HeaderRow>
-            {columns.map(column => (
-              <HeaderCell column={column} key={String(column.key)} />
-            ))}
-          </HeaderRow>
-        </TableHead>
-        <TableBody sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          {data.map((row, idx) => {
-            return (
-              <DataRow
-                columns={columns}
-                key={row.id}
-                onClick={onRowClick}
-                rowData={row}
-                rowKey={String(idx)}
-              />
-            );
-          })}
-        </TableBody>
-      </MuiTable>
+    <Box flexDirection="column" width="100%">
+      <TableContainer>
+        <MuiTable
+          sx={{
+            height,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <TableHead>
+            <HeaderRow>
+              {columns.map(column => (
+                <HeaderCell column={column} key={String(column.key)} />
+              ))}
+            </HeaderRow>
+          </TableHead>
+          <TableBody sx={{ overflow: 'auto', flex: 1 }}>
+            {data.map((row, idx) => {
+              return (
+                <DataRow
+                  columns={columns}
+                  key={row.id}
+                  onClick={onRowClick}
+                  rowData={row}
+                  rowKey={String(idx)}
+                />
+              );
+            })}
+          </TableBody>
+        </MuiTable>
+      </TableContainer>
       <PaginationRow
         page={pagination.page}
         offset={pagination.offset}
@@ -95,6 +98,6 @@ export const DataTable = <T extends DomainObject>({
         total={pagination.total ?? 0}
         onChange={onChangePage}
       />
-    </TableContainer>
+    </Box>
   );
 };

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -19,7 +19,6 @@ export interface QueryResponse<T> {
 export interface TableProps<T extends DomainObject> {
   columns: Column<T>[];
   data?: T[];
-  height: number;
   isLoading?: boolean;
   pagination: Pagination & { total?: number };
   onChangePage: (page: number) => void;

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -19,6 +19,7 @@ export interface QueryResponse<T> {
 export interface TableProps<T extends DomainObject> {
   columns: Column<T>[];
   data?: T[];
+  height: number;
   isLoading?: boolean;
   pagination: Pagination & { total?: number };
   onChangePage: (page: number) => void;

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -189,12 +189,7 @@ const Host: FC = () => {
                   <Viewport>
                     <Box display="flex">
                       <AppDrawer />
-                      <Box
-                        overflow="auto"
-                        flex={1}
-                        display="flex"
-                        flexDirection="column"
-                      >
+                      <Box flex={1} display="flex" flexDirection="column">
                         <AppBar />
                         <Box display="flex" flex={1}>
                           <React.Suspense fallback={'Loading'}>

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -187,11 +187,16 @@ const Host: FC = () => {
               <CommandK>
                 <SnackbarProvider maxSnack={3}>
                   <Viewport>
-                    <Box display="flex">
+                    <Box display="flex" height="100%">
                       <AppDrawer />
-                      <Box flex={1} display="flex" flexDirection="column">
+                      <Box
+                        flex={1}
+                        display="flex"
+                        flexDirection="column"
+                        overflow="hidden"
+                      >
                         <AppBar />
-                        <Box display="flex" flex={1}>
+                        <Box display="flex" flex={1} overflow="hidden">
                           <React.Suspense fallback={'Loading'}>
                             <Routes>
                               <Route

--- a/packages/host/src/Viewport.tsx
+++ b/packages/host/src/Viewport.tsx
@@ -8,6 +8,7 @@ const globalStyles = {
   },
   '#root': {
     height: '100vh',
+    width: '100vw',
     display: 'flex',
     flexDirection: 'column',
   },

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -1,11 +1,11 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import {
   DataTable,
   ObjectWithStringKeys,
   usePagination,
-  useRowRenderCount,
   Column,
   DomainObject,
+  useContentAreaHeight,
 } from '@openmsupply-client/common';
 import { ItemRow } from '../types';
 
@@ -18,15 +18,16 @@ export const GeneralTabComponent: FC<GeneralTabProps<ItemRow>> = ({
   data,
   columns,
 }) => {
-  const numberOfRows = useRowRenderCount();
-  const { pagination } = usePagination(numberOfRows);
+  const tableHeight = useContentAreaHeight();
+  const { pagination } = usePagination(20);
 
-  useEffect(() => {
-    pagination.onChangeFirst(numberOfRows);
-  }, [numberOfRows, pagination.first]);
+  // This accounts for the pagination below the table and the row of buttons
+  // and status.
+  const heightOffset = 110;
 
   return (
     <DataTable
+      height={tableHeight - heightOffset}
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
       data={data.slice(pagination.offset, pagination.offset + pagination.first)}

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -5,7 +5,6 @@ import {
   usePagination,
   Column,
   DomainObject,
-  useContentAreaHeight,
 } from '@openmsupply-client/common';
 import { ItemRow } from '../types';
 
@@ -18,16 +17,10 @@ export const GeneralTabComponent: FC<GeneralTabProps<ItemRow>> = ({
   data,
   columns,
 }) => {
-  const tableHeight = useContentAreaHeight();
   const { pagination } = usePagination(20);
-
-  // This accounts for the pagination below the table and the row of buttons
-  // and status.
-  const heightOffset = 110;
 
   return (
     <DataTable
-      height={tableHeight - heightOffset}
       pagination={{ ...pagination, total: data.length }}
       columns={columns}
       data={data.slice(pagination.offset, pagination.offset + pagination.first)}

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -25,7 +25,6 @@ import {
   ButtonWithIcon,
   Grid,
   OutboundShipmentStatus,
-  useContentAreaHeight,
 } from '@openmsupply-client/common';
 import { OutboundShipmentListViewApi } from '../../api';
 import { ExternalURL } from '@openmsupply-client/config';
@@ -74,9 +73,6 @@ const ListViewToolBar: FC<{
 export const OutboundShipmentListViewComponent: FC = () => {
   const { info, success } = useNotification();
   const navigate = useNavigate();
-  const contentHeight = useContentAreaHeight();
-  // This accounts for the pagination row under the table.
-  const tableHeight = contentHeight - 40;
 
   const {
     totalCount,
@@ -172,7 +168,6 @@ export const OutboundShipmentListViewComponent: FC = () => {
       </AppBarButtonsPortal>
 
       <DataTable
-        height={tableHeight}
         pagination={{ ...pagination, total: totalCount }}
         onChangePage={onChangePage}
         columns={columns}

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -25,6 +25,7 @@ import {
   ButtonWithIcon,
   Grid,
   OutboundShipmentStatus,
+  useContentAreaHeight,
 } from '@openmsupply-client/common';
 import { OutboundShipmentListViewApi } from '../../api';
 import { ExternalURL } from '@openmsupply-client/config';
@@ -73,6 +74,9 @@ const ListViewToolBar: FC<{
 export const OutboundShipmentListViewComponent: FC = () => {
   const { info, success } = useNotification();
   const navigate = useNavigate();
+  const contentHeight = useContentAreaHeight();
+  // This accounts for the pagination row under the table.
+  const tableHeight = contentHeight - 40;
 
   const {
     totalCount,
@@ -81,7 +85,6 @@ export const OutboundShipmentListViewComponent: FC = () => {
     onDelete,
     onUpdate,
     sortBy,
-    numberOfRows,
     onChangeSortBy,
     onCreate,
     onChangePage,
@@ -169,10 +172,11 @@ export const OutboundShipmentListViewComponent: FC = () => {
       </AppBarButtonsPortal>
 
       <DataTable
+        height={tableHeight}
         pagination={{ ...pagination, total: totalCount }}
         onChangePage={onChangePage}
         columns={columns}
-        data={data?.slice(0, numberOfRows) || []}
+        data={data ?? []}
         isLoading={isLoading}
         onRowClick={row => {
           navigate(`/distribution/outbound-shipment/${row.id}`);

--- a/packages/system/src/Customer/ListView/ListView.tsx
+++ b/packages/system/src/Customer/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   ListApi,
   createTableStore,
   SortBy,
+  useContentAreaHeight,
 } from '@openmsupply-client/common';
 
 const getNameListQuery = (): string => gql`
@@ -82,11 +83,12 @@ const Api: ListApi<Name> = {
 };
 
 export const ListView: FC = () => {
+  const contentHeight = useContentAreaHeight();
+  const tableHeight = contentHeight - 40;
   const {
     totalCount,
     data,
     isLoading,
-    numberOfRows,
     onChangePage,
     pagination,
     sortBy,
@@ -102,10 +104,11 @@ export const ListView: FC = () => {
   return (
     <TableProvider createStore={createTableStore}>
       <DataTable
+        height={tableHeight}
         pagination={{ ...pagination, total: totalCount }}
         onChangePage={onChangePage}
         columns={columns}
-        data={data?.slice(0, numberOfRows) || []}
+        data={data ?? []}
         isLoading={isLoading}
         onRowClick={row => {
           navigate(`/distribution/customer/${row.id}`);

--- a/packages/system/src/Customer/ListView/ListView.tsx
+++ b/packages/system/src/Customer/ListView/ListView.tsx
@@ -12,7 +12,6 @@ import {
   ListApi,
   createTableStore,
   SortBy,
-  useContentAreaHeight,
 } from '@openmsupply-client/common';
 
 const getNameListQuery = (): string => gql`
@@ -83,8 +82,6 @@ const Api: ListApi<Name> = {
 };
 
 export const ListView: FC = () => {
-  const contentHeight = useContentAreaHeight();
-  const tableHeight = contentHeight - 40;
   const {
     totalCount,
     data,
@@ -104,7 +101,6 @@ export const ListView: FC = () => {
   return (
     <TableProvider createStore={createTableStore}>
       <DataTable
-        height={tableHeight}
         pagination={{ ...pagination, total: totalCount }}
         onChangePage={onChangePage}
         columns={columns}

--- a/packages/system/src/Item/ListView/ListView.tsx
+++ b/packages/system/src/Item/ListView/ListView.tsx
@@ -12,7 +12,6 @@ import {
   ListApi,
   createTableStore,
   SortBy,
-  useContentAreaHeight,
 } from '@openmsupply-client/common';
 
 const listQueryFn = async ({
@@ -99,8 +98,6 @@ const Api: ListApi<Item> = {
 };
 
 export const ListView: FC = () => {
-  const contentHeight = useContentAreaHeight();
-  const tableHeight = contentHeight - 40;
   const {
     totalCount,
     data,
@@ -120,7 +117,6 @@ export const ListView: FC = () => {
   return (
     <TableProvider createStore={createTableStore}>
       <DataTable
-        height={tableHeight}
         pagination={{ ...pagination, total: totalCount }}
         onChangePage={onChangePage}
         columns={columns}

--- a/packages/system/src/Item/ListView/ListView.tsx
+++ b/packages/system/src/Item/ListView/ListView.tsx
@@ -12,6 +12,7 @@ import {
   ListApi,
   createTableStore,
   SortBy,
+  useContentAreaHeight,
 } from '@openmsupply-client/common';
 
 const listQueryFn = async ({
@@ -98,11 +99,12 @@ const Api: ListApi<Item> = {
 };
 
 export const ListView: FC = () => {
+  const contentHeight = useContentAreaHeight();
+  const tableHeight = contentHeight - 40;
   const {
     totalCount,
     data,
     isLoading,
-    numberOfRows,
     onChangePage,
     pagination,
     sortBy,
@@ -118,10 +120,11 @@ export const ListView: FC = () => {
   return (
     <TableProvider createStore={createTableStore}>
       <DataTable
+        height={tableHeight}
         pagination={{ ...pagination, total: totalCount }}
         onChangePage={onChangePage}
         columns={columns}
-        data={data?.slice(0, numberOfRows) || []}
+        data={data ?? []}
         isLoading={isLoading}
         onRowClick={row => {
           navigate(`/catalogue/items/${row.id}`);


### PR DESCRIPTION
Oh, smaller than I thought..! Nice suprise

- I am in the process of adding expanding to the rows, which means we need scroll.
- I had a bit of rough time with this of course, trying to have a flex table which when overflowing, horizontally and vertically scrolls.
- I've gotten there with the scrolling (You can just duplicate columns to see the column scroll - I think some of our columns have minWidths which are too small, though) however I've made the headers non-sticky, now. I've played around with mui `stickHeader` and also apparently you can put `position:'sticky'` on the `td` for a header, however it doesn't seem to work with `display:'flex'` on the header cells. Sigh!
- I spent way too much time messing with this so I've stopped here with the messed up headers which I will come back to
- I've also set the pagination to be `20` by default. I thought to get feedback first. With this scrolling we can have a 'number of rows selector' thing, which people had mentioned in our demo