### PR TITLE
7 - Add example batch grouping

### DIFF
--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -1,7 +1,8 @@
-import React, { FC } from 'react';
+import React from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { Column } from '../../columns/types';
+import { ExpandContentProps } from '../../types';
 import { DomainObject } from '../../../../../types';
 import { useExpanded } from '../..';
 import { Collapse } from '@mui/material';
@@ -11,7 +12,7 @@ interface DataRowProps<T extends DomainObject> {
   onClick?: (rowValues: T) => void;
   rowData: T;
   rowKey: string;
-  ExpandContent?: FC;
+  ExpandContent?: (props: ExpandContentProps<T>) => JSX.Element;
 }
 
 export const DataRow = <T extends DomainObject>({
@@ -71,7 +72,7 @@ export const DataRow = <T extends DomainObject>({
         })}
       </TableRow>
       <Collapse in={isExpanded}>
-        {ExpandContent ? <ExpandContent /> : null}
+        {ExpandContent ? <ExpandContent rowData={rowData} /> : null}
       </Collapse>
     </>
   );

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode, FC } from 'react';
+import { ReactNode } from 'react';
 import { LocaleKey } from '@openmsupply-client/common/src/intl/intlHelpers';
 import { ObjectWithStringKeys, DomainObject } from './../../../types';
 import { Pagination } from '../../../hooks/usePagination';
@@ -16,6 +16,10 @@ export interface QueryResponse<T> {
   totalLength: number;
 }
 
+export interface ExpandContentProps<T> {
+  rowData: T;
+}
+
 export interface TableProps<T extends DomainObject> {
   columns: Column<T>[];
   data?: T[];
@@ -25,5 +29,5 @@ export interface TableProps<T extends DomainObject> {
   onRowClick?: (row: T) => void;
   children?: ReactNode;
   noDataMessageKey?: LocaleKey;
-  ExpandContent?: FC;
+  ExpandContent?: (props: ExpandContentProps<T>) => JSX.Element;
 }

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -61,7 +61,7 @@ export const DetailView: FC = () => {
   return draft ? (
     <TableProvider createStore={createTableStore}>
       <AppBarButtons
-        isDisabled={isInvoiceEditable(draft)}
+        isDisabled={!isInvoiceEditable(draft)}
         onAddItem={itemModalControl.toggleOn}
       />
 

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Checkbox,
-  Divider,
   FieldValues,
   InfoIcon,
   Item,
@@ -121,48 +120,45 @@ export const BatchesTable: React.FC<BatchesTableProps> = ({
     onChange('placeholder', Number(event.target.value));
 
   return (
-    <>
-      <TableContainer>
-        <Divider margin={40} />
-        <Table>
-          <TableHead>
-            <TableRow>
-              <HeaderCell></HeaderCell>
-              <HeaderCell>{t('label.issue')}</HeaderCell>
-              <HeaderCell>{t('label.hold')}</HeaderCell>
-              <HeaderCell>{t('label.available')}</HeaderCell>
-              <HeaderCell>{t('label.in-store')}</HeaderCell>
-              <HeaderCell>{t('label.pack')}</HeaderCell>
-              <HeaderCell>{t('label.batch')}</HeaderCell>
-              <HeaderCell>{t('label.expiry')}</HeaderCell>
-              <HeaderCell>{t('label.cost')}</HeaderCell>
-              <HeaderCell>{t('label.sell')}</HeaderCell>
-              <HeaderCell></HeaderCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map((batch, index) => (
-              <BatchesRow
-                batch={batch}
-                key={batch.id}
-                label={t('label.line', { number: index + 1 })}
-                onChange={onChange}
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <HeaderCell></HeaderCell>
+            <HeaderCell>{t('label.issue')}</HeaderCell>
+            <HeaderCell>{t('label.hold')}</HeaderCell>
+            <HeaderCell>{t('label.available')}</HeaderCell>
+            <HeaderCell>{t('label.in-store')}</HeaderCell>
+            <HeaderCell>{t('label.pack')}</HeaderCell>
+            <HeaderCell>{t('label.batch')}</HeaderCell>
+            <HeaderCell>{t('label.expiry')}</HeaderCell>
+            <HeaderCell>{t('label.cost')}</HeaderCell>
+            <HeaderCell>{t('label.sell')}</HeaderCell>
+            <HeaderCell></HeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((batch, index) => (
+            <BatchesRow
+              batch={batch}
+              key={batch.id}
+              label={t('label.line', { number: index + 1 })}
+              onChange={onChange}
+            />
+          ))}
+          <TableRow>
+            <BasicCell align="right" sx={{ paddingTop: '3px' }}>
+              {t('label.placeholder')}
+            </BasicCell>
+            <BasicCell sx={{ paddingTop: '3px' }}>
+              <NumericTextInput
+                {...placeholderInputProps}
+                onChange={onChangeValue}
               />
-            ))}
-            <TableRow>
-              <BasicCell align="right" sx={{ paddingTop: '3px' }}>
-                {t('label.placeholder')}
-              </BasicCell>
-              <BasicCell sx={{ paddingTop: '3px' }}>
-                <NumericTextInput
-                  {...placeholderInputProps}
-                  onChange={onChangeValue}
-                />
-              </BasicCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </>
+            </BasicCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -11,6 +11,7 @@ import {
   useQuery,
   useDialog,
   FormProvider,
+  Divider,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { BatchesTable } from './BatchesTable';
@@ -246,6 +247,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
               register={register}
               isLoading={isLoading}
             />
+            <Divider margin={40} />
             <BatchesTable
               item={selectedItem}
               onChange={onChangeRowQuantity}

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -6,24 +6,39 @@ import {
   Column,
   DomainObject,
   Box,
+  FormProvider,
+  useForm,
+  ExpandContentProps,
 } from '@openmsupply-client/common';
 import { ItemRow } from '../types';
+import { BatchesTable } from '../modals/BatchesTable';
 
 interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   data: T[];
   columns: Column<T>[];
 }
 
-const Expand: FC = () => {
+const Expand = (props: ExpandContentProps<ItemRow>) => {
+  const methods = useForm({ mode: 'onBlur' });
   return (
-    <Box p={1} height={300}>
-      <Box
-        flex={1}
-        display="flex"
-        height="100%"
-        borderRadius={4}
-        bgcolor="#c7c9d933"
-      />
+    <Box p={1}>
+      <Box height="100%" borderRadius={4}>
+        <FormProvider {...methods}>
+          <form>
+            <BatchesTable
+              item={props?.rowData?.item ?? null}
+              onChange={() => {}}
+              rows={
+                props?.rowData?.item?.availableBatches?.nodes?.map(batch => ({
+                  ...batch,
+                  quantity: 0,
+                })) ?? []
+              }
+              register={(() => {}) as unknown as any}
+            />
+          </form>
+        </FormProvider>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
Just intended as an example ui 

I'm struggling to understand what is wanted, maybe.

The modal shows which batches are allocated to a line and which quantities and, I assume, is 1 click on a line. We want an expansion which is also 1 click, which shows which batches are allocated to a line and what quantities..

It makes sense to me that we remove the modal and just use an accordion to assign batches. When adding a new line, just add an empty line and the `name` column is the auto complete - when choosing a name, expand the row 

![image](https://user-images.githubusercontent.com/35858975/139597764-1e19bc22-59bb-4f7f-be22-49a441cfe850.png)

The only other idea I have that is wanted for this feature is a read only view of the batches when you expand, but surely not? That would mean that you do a single click to see a single read only view or a single editable view - why bother with the read only view 🤷 

