### PR TITLE
Add debounced column sorting

### DIFF
--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import { ObjectWithStringKeys } from '../../../../../types/utility';
 import { Column } from '../../columns/types';
 import { SortDescIcon } from '../../../../icons';
 import { DomainObject } from '../../../../../types';
+import { useDebounceCallback } from '../../../../..';
 
 export const HeaderRow: FC = props => (
   <TableRow
@@ -41,15 +42,15 @@ export const HeaderCell = <T extends ObjectWithStringKeys & DomainObject>({
 
   const isSorted = key === currentSortKey;
 
+  const onSort = useDebounceCallback(
+    () => onChangeSortBy && sortable && onChangeSortBy(column),
+    [column]
+  );
+
   return (
     <TableCell
       role="columnheader"
-      onClick={
-        onChangeSortBy &&
-        (() => {
-          sortable && onChangeSortBy(column);
-        })
-      }
+      onClick={onSort}
       align={align}
       padding={'none'}
       sx={{


### PR DESCRIPTION
Fixes #326 

Went this route because I don't think a column should ever be not sortable - even though there is a slight lag when pressed