### PR TITLE
#331 column format default

### DIFF
--- a/packages/common/src/ui/layout/tables/hooks/useColumns/index.ts
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/index.ts
@@ -1,0 +1,1 @@
+export * from './useColumns';

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
@@ -1,0 +1,138 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { ColumnAlign, ColumnFormat } from '../..';
+import { useColumns } from '../../..';
+import { DomainObject } from '../../../../..';
+
+interface Test extends DomainObject {
+  id: string;
+}
+
+describe('useColumns', () => {
+  it('assigns sensible defaults for an unspecified column', () => {
+    const { result } = renderHook(() => useColumns<Test>([{ key: 'default' }]));
+
+    const defaults = {
+      format: ColumnFormat.Text,
+      sortable: true,
+      sortInverted: false,
+      sortDescFirst: false,
+      align: ColumnAlign.Left,
+      width: 100,
+      minWidth: 100,
+    };
+
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+    expect(result.current[0]?.Cell).toBeTruthy();
+    expect(result.current[0]?.Header).toBeTruthy();
+    expect(result.current[0]?.accessor).toBeTruthy();
+    expect(result.current[0]?.formatter).toBeTruthy();
+  });
+
+  it('assigns sensible defaults for an integer column', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', format: ColumnFormat.Integer }])
+    );
+
+    const defaults = {
+      format: ColumnFormat.Integer,
+      sortable: true,
+      sortInverted: false,
+      sortDescFirst: false,
+      align: ColumnAlign.Right,
+      width: 100,
+      minWidth: 100,
+    };
+
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+    expect(result.current[0]?.Cell).toBeTruthy();
+    expect(result.current[0]?.Header).toBeTruthy();
+    expect(result.current[0]?.accessor).toBeTruthy();
+    expect(result.current[0]?.formatter).toBeTruthy();
+  });
+
+  it('assigns sensible defaults for a "real" type column', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', format: ColumnFormat.Real }])
+    );
+
+    const defaults = {
+      format: ColumnFormat.Real,
+      sortable: true,
+      sortInverted: false,
+      sortDescFirst: false,
+      align: ColumnAlign.Right,
+      width: 100,
+      minWidth: 100,
+    };
+
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+    expect(result.current[0]?.Cell).toBeTruthy();
+    expect(result.current[0]?.Header).toBeTruthy();
+    expect(result.current[0]?.accessor).toBeTruthy();
+    expect(result.current[0]?.formatter).toBeTruthy();
+  });
+
+  it('assigns sensible defaults for a date type column', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', format: ColumnFormat.Date }])
+    );
+
+    const defaults = {
+      format: ColumnFormat.Date,
+      sortable: true,
+      sortInverted: true,
+      sortDescFirst: true,
+      align: ColumnAlign.Right,
+      width: 100,
+      minWidth: 100,
+    };
+
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+    expect(result.current[0]?.Cell).toBeTruthy();
+    expect(result.current[0]?.Header).toBeTruthy();
+    expect(result.current[0]?.accessor).toBeTruthy();
+    expect(result.current[0]?.formatter).toBeTruthy();
+  });
+
+  it('uses the width as specified for the minWidth if unspecified', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', width: 200 }])
+    );
+
+    const defaults = {
+      width: 200,
+      minWidth: 200,
+    };
+
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+  });
+
+  it('uses the correct width and min width if specified', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', width: 200, minWidth: 100 }])
+    );
+
+    const defaults = {
+      width: 200,
+      minWidth: 100,
+    };
+
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+  });
+
+  it('uses the correct width and min width if specified', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', width: 200, minWidth: 100 }])
+    );
+    const defaults = { width: 200, minWidth: 100 };
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+  });
+
+  it('has a stable reference when re-rendering', () => {
+    const { result, rerender } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', format: ColumnFormat.Integer }])
+    );
+    rerender();
+    expect(result.all[0]).toBe(result.all[1]);
+  });
+});

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
@@ -39,8 +39,8 @@ describe('useColumns', () => {
       sortInverted: false,
       sortDescFirst: false,
       align: ColumnAlign.Right,
-      width: 100,
-      minWidth: 100,
+      width: 60,
+      minWidth: 60,
     };
 
     expect(result.current[0]).toEqual(expect.objectContaining(defaults));
@@ -125,6 +125,14 @@ describe('useColumns', () => {
       useColumns<Test>([{ key: 'default', width: 200, minWidth: 100 }])
     );
     const defaults = { width: 200, minWidth: 100 };
+    expect(result.current[0]).toEqual(expect.objectContaining(defaults));
+  });
+
+  it('defaults to a width of 60 for integers', () => {
+    const { result } = renderHook(() =>
+      useColumns<Test>([{ key: 'default', format: ColumnFormat.Integer }])
+    );
+    const defaults = { width: 60, minWidth: 60 };
     expect(result.current[0]).toEqual(expect.objectContaining(defaults));
   });
 

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -1,15 +1,19 @@
 import { DependencyList, useMemo } from 'react';
-import { DomainObject } from '../../../../types/index';
+import { DomainObject } from '../../../../../types/index';
 import {
   ColumnDefinition,
   ColumnFormat,
   ColumnAlign,
   Column,
-} from '../columns/types';
-import { useFormatDate, useFormatNumber } from '../../../../intl';
-import { BasicCell, BasicHeader } from '../components';
-import { SortBy } from '../../../..';
-import { ColumnDefinitionSetBuilder, ColumnKey, ColumnDataAccessor } from '..';
+} from '../../columns/types';
+import { useFormatDate, useFormatNumber } from '../../../../../intl';
+import { BasicCell, BasicHeader } from '../../components';
+import { SortBy } from '../../../../..';
+import {
+  ColumnDefinitionSetBuilder,
+  ColumnKey,
+  ColumnDataAccessor,
+} from '../..';
 
 const getColumnWidths = <T extends DomainObject>(
   column: ColumnDefinition<T>

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -18,8 +18,20 @@ import {
 const getColumnWidths = <T extends DomainObject>(
   column: ColumnDefinition<T>
 ) => {
-  const minWidth = column.minWidth || column.width || 100;
-  const width = column.width || 100;
+  const getDefaultWidth = () => {
+    switch (column.format) {
+      case ColumnFormat.Integer:
+        return 60;
+      default: {
+        return 100;
+      }
+    }
+  };
+
+  const defaultWidth = getDefaultWidth();
+
+  const minWidth = column.minWidth || column.width || defaultWidth;
+  const width = column.width || defaultWidth;
 
   return { minWidth, width };
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -1,11 +1,8 @@
-import { renderHook } from '@testing-library/react-hooks';
 import {
-  TestingProvider,
-  useColumns,
   DocumentAction,
   Invoice,
+  createColumns,
 } from '@openmsupply-client/common';
-
 import { placeholderInvoice } from './index';
 import { reducer, OutboundShipmentStateShape, OutboundAction } from './reducer';
 import { ItemRow } from './types';
@@ -73,12 +70,8 @@ describe('DetailView reducer', () => {
       draft: { ...placeholderInvoice, lines },
       sortBy: { key: 'quantity', isDesc: true, direction: 'desc' },
     };
-    const { result } = renderHook(() => useColumns<ItemRow>(['quantity']), {
-      wrapper: TestingProvider,
-    });
 
-    const quantityColumn = result.current[0];
-
+    const [quantityColumn] = createColumns<ItemRow>(['quantity']);
     if (!quantityColumn) throw new Error('This test is broken!');
 
     const reducerResult = reducer(undefined, null)(
@@ -101,12 +94,8 @@ describe('DetailView reducer', () => {
       draft: { ...placeholderInvoice, lines },
       sortBy: { key: 'quantity', isDesc: false, direction: 'asc' },
     };
-    const { result } = renderHook(() => useColumns<ItemRow>(['quantity']), {
-      wrapper: TestingProvider,
-    });
 
-    const quantityColumn = result.current[0];
-
+    const [quantityColumn] = createColumns<ItemRow>(['quantity']);
     if (!quantityColumn) throw new Error('This test is broken!');
 
     const reducerResult = reducer(undefined, null)(
@@ -131,12 +120,8 @@ describe('DetailView reducer', () => {
       draft: { ...placeholderInvoice, lines },
       sortBy: { key: 'quantity', isDesc: true, direction: 'desc' },
     };
-    const { result } = renderHook(() => useColumns<ItemRow>(['itemName']), {
-      wrapper: TestingProvider,
-    });
 
-    const itemNameColumn = result.current[0];
-
+    const [itemNameColumn] = createColumns<ItemRow>(['itemName']);
     if (!itemNameColumn) throw new Error('This test is broken!');
 
     const reducerResult = reducer(undefined, null)(


### PR DESCRIPTION
Fixes #331 

- Goal was to ensure the default column alignment took into account the format
- Then I offroaded into extracting the logic of `useColumns` into a function and just having the hook basially memoise and call this function. This is because I have been meaning to do this for a bit, as it makes some tests easier to write, in some cases - so I updated the reducer test cases
- Then I added some tests for `useColumns` 