### PR TITLE
Add item query to use code gen

### DIFF
--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -178,3 +178,88 @@ query names(
     }
   }
 }
+
+query items(
+  $first: Int
+  $offset: Int
+  $key: ItemSortFieldInput!
+  $desc: Boolean
+) {
+  items(
+    page: { first: $first, offset: $offset }
+    sort: { key: $key, desc: $desc }
+  ) {
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
+      }
+    }
+    ... on ItemConnector {
+      __typename
+      nodes {
+        __typename
+        availableBatches {
+          ... on ConnectorError {
+            __typename
+            error {
+              description
+              ... on DatabaseError {
+                __typename
+                description
+                fullError
+              }
+              ... on PaginationError {
+                __typename
+                description
+                rangeError {
+                  description
+                  field
+                  max
+                  min
+                }
+              }
+            }
+          }
+          ... on StockLineConnector {
+            nodes {
+              __typename
+              availableNumberOfPacks
+              batch
+              costPricePerPack
+              expiryDate
+              id
+              itemId
+              packSize
+              sellPricePerPack
+              storeId
+              totalNumberOfPacks
+              onHold
+            }
+            totalCount
+          }
+        }
+        code
+        id
+        isVisible
+        name
+      }
+      totalCount
+    }
+  }
+}

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -215,6 +215,7 @@ query items(
       nodes {
         __typename
         availableBatches {
+          __typename
           ... on ConnectorError {
             __typename
             error {
@@ -237,6 +238,7 @@ query items(
             }
           }
           ... on StockLineConnector {
+            __typename
             nodes {
               __typename
               availableNumberOfPacks

--- a/packages/common/src/schema.graphql
+++ b/packages/common/src/schema.graphql
@@ -638,6 +638,8 @@ type StockLineNode {
   availableNumberOfPacks: Int!
   totalNumberOfPacks: Int!
   expiryDate: NaiveDate
+  location: String
+  onHold: Boolean!
 }
 
 union StockLineResponse = NodeError | StockLineNode

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -21,9 +21,7 @@ export interface Item extends DomainObject {
   code: string;
   name: string;
   availableQuantity: number;
-  availableBatches: {
-    nodes: StockLine[];
-  };
+  availableBatches: StockLine[];
   unit: string;
 }
 
@@ -31,14 +29,14 @@ export interface StockLine extends DomainObject {
   id: string;
   availableNumberOfPacks: number;
   costPricePerPack: number;
-  expiryDate: string;
-  batch: string;
-  item: Item;
+  expiryDate?: string | null;
+  batch?: string | null;
+  // item: Item;
   name: string;
   packSize: number;
   sellPricePerPack: number;
   totalNumberOfPacks: number;
-  location: string;
+  location?: string | null;
   onHold: boolean;
 }
 

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -2,15 +2,9 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -22,49 +16,36 @@ export type Scalars = {
   NaiveDate: any;
 };
 
-export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'BatchIsReserved';
-    description: Scalars['String'];
-  };
+export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'BatchIsReserved';
+  description: Scalars['String'];
+};
 
-export type CanOnlyEditInvoicesInLoggedInStoreError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
-    description: Scalars['String'];
-  };
+export type CanOnlyEditInvoicesInLoggedInStoreError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
+  description: Scalars['String'];
+};
 
-export type CannotChangeInvoiceBackToDraft =
-  UpdateSupplierInvoiceErrorInterface & {
-    __typename?: 'CannotChangeInvoiceBackToDraft';
-    description: Scalars['String'];
-  };
+export type CannotChangeInvoiceBackToDraft = UpdateSupplierInvoiceErrorInterface & {
+  __typename?: 'CannotChangeInvoiceBackToDraft';
+  description: Scalars['String'];
+};
 
-export type CannotChangeStatusBackToDraftError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'CannotChangeStatusBackToDraftError';
-    description: Scalars['String'];
-  };
+export type CannotChangeStatusBackToDraftError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'CannotChangeStatusBackToDraftError';
+  description: Scalars['String'];
+};
 
-export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface &
-  DeleteSupplierInvoiceErrorInterface & {
-    __typename?: 'CannotDeleteInvoiceWithLines';
-    description: Scalars['String'];
-    lines: InvoiceLineConnector;
-  };
+export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface & DeleteSupplierInvoiceErrorInterface & {
+  __typename?: 'CannotDeleteInvoiceWithLines';
+  description: Scalars['String'];
+  lines: InvoiceLineConnector;
+};
 
-export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'CannotEditFinalisedInvoice';
-    description: Scalars['String'];
-  };
+export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'CannotEditFinalisedInvoice';
+  description: Scalars['String'];
+};
 
 export type ConnectorError = {
   __typename?: 'ConnectorError';
@@ -75,24 +56,11 @@ export type ConnectorErrorInterface = {
   description: Scalars['String'];
 };
 
-export type DatabaseError = ConnectorErrorInterface &
-  DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertCustomerInvoiceErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  NodeErrorInterface &
-  UpdateCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'DatabaseError';
-    description: Scalars['String'];
-    fullError: Scalars['String'];
-  };
+export type DatabaseError = ConnectorErrorInterface & DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'DatabaseError';
+  description: Scalars['String'];
+  fullError: Scalars['String'];
+};
 
 export type DatetimeFilterInput = {
   afterOrEqualTo?: Maybe<Scalars['DateTime']>;
@@ -123,13 +91,9 @@ export type DeleteCustomerInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteCustomerInvoiceLineResponse =
-  | DeleteCustomerInvoiceLineError
-  | DeleteResponse;
+export type DeleteCustomerInvoiceLineResponse = DeleteCustomerInvoiceLineError | DeleteResponse;
 
-export type DeleteCustomerInvoiceResponse =
-  | DeleteCustomerInvoiceError
-  | DeleteResponse;
+export type DeleteCustomerInvoiceResponse = DeleteCustomerInvoiceError | DeleteResponse;
 
 export type DeleteResponse = {
   __typename?: 'DeleteResponse';
@@ -163,13 +127,9 @@ export type DeleteSupplierInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteSupplierInvoiceLineResponse =
-  | DeleteResponse
-  | DeleteSupplierInvoiceLineError;
+export type DeleteSupplierInvoiceLineResponse = DeleteResponse | DeleteSupplierInvoiceLineError;
 
-export type DeleteSupplierInvoiceResponse =
-  | DeleteResponse
-  | DeleteSupplierInvoiceError;
+export type DeleteSupplierInvoiceResponse = DeleteResponse | DeleteSupplierInvoiceError;
 
 export type EqualFilterBoolInput = {
   equalTo?: Maybe<Scalars['Boolean']>;
@@ -187,33 +147,23 @@ export type EqualFilterStringInput = {
   equalTo?: Maybe<Scalars['String']>;
 };
 
-export type FinalisedInvoiceIsNotEditableError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'FinalisedInvoiceIsNotEditableError';
-    description: Scalars['String'];
-  };
+export type FinalisedInvoiceIsNotEditableError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'FinalisedInvoiceIsNotEditableError';
+  description: Scalars['String'];
+};
 
 export enum ForeignKey {
   InvoiceId = 'INVOICE_ID',
   ItemId = 'ITEM_ID',
   OtherPartyId = 'OTHER_PARTY_ID',
-  StockLineId = 'STOCK_LINE_ID',
+  StockLineId = 'STOCK_LINE_ID'
 }
 
-export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertCustomerInvoiceErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'ForeignKeyError';
-    description: Scalars['String'];
-    key: ForeignKey;
-  };
+export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'ForeignKeyError';
+  description: Scalars['String'];
+  key: ForeignKey;
+};
 
 export type InsertCustomerInvoiceError = {
   __typename?: 'InsertCustomerInvoiceError';
@@ -249,15 +199,9 @@ export type InsertCustomerInvoiceLineInput = {
   stockLineId: Scalars['String'];
 };
 
-export type InsertCustomerInvoiceLineResponse =
-  | InsertCustomerInvoiceLineError
-  | InvoiceLineNode
-  | NodeError;
+export type InsertCustomerInvoiceLineResponse = InsertCustomerInvoiceLineError | InvoiceLineNode | NodeError;
 
-export type InsertCustomerInvoiceResponse =
-  | InsertCustomerInvoiceError
-  | InvoiceNode
-  | NodeError;
+export type InsertCustomerInvoiceResponse = InsertCustomerInvoiceError | InvoiceNode | NodeError;
 
 export type InsertSupplierInvoiceError = {
   __typename?: 'InsertSupplierInvoiceError';
@@ -297,15 +241,9 @@ export type InsertSupplierInvoiceLineInput = {
   sellPricePerPack: Scalars['Float'];
 };
 
-export type InsertSupplierInvoiceLineResponse =
-  | InsertSupplierInvoiceLineError
-  | InvoiceLineNode
-  | NodeError;
+export type InsertSupplierInvoiceLineResponse = InsertSupplierInvoiceLineError | InvoiceLineNode | NodeError;
 
-export type InsertSupplierInvoiceResponse =
-  | InsertSupplierInvoiceError
-  | InvoiceNode
-  | NodeError;
+export type InsertSupplierInvoiceResponse = InsertSupplierInvoiceError | InvoiceNode | NodeError;
 
 export type InvoiceConnector = {
   __typename?: 'InvoiceConnector';
@@ -313,19 +251,10 @@ export type InvoiceConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceDoesNotBelongToCurrentStore =
-  DeleteCustomerInvoiceErrorInterface &
-    DeleteCustomerInvoiceLineErrorInterface &
-    DeleteSupplierInvoiceErrorInterface &
-    DeleteSupplierInvoiceLineErrorInterface &
-    InsertCustomerInvoiceLineErrorInterface &
-    InsertSupplierInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface &
-    UpdateSupplierInvoiceErrorInterface &
-    UpdateSupplierInvoiceLineErrorInterface & {
-      __typename?: 'InvoiceDoesNotBelongToCurrentStore';
-      description: Scalars['String'];
-    };
+export type InvoiceDoesNotBelongToCurrentStore = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'InvoiceDoesNotBelongToCurrentStore';
+  description: Scalars['String'];
+};
 
 export type InvoiceFilterInput = {
   comment?: Maybe<SimpleStringFilterInput>;
@@ -339,15 +268,11 @@ export type InvoiceFilterInput = {
   type?: Maybe<EqualFilterInvoiceTypeInput>;
 };
 
-export type InvoiceLineBelongsToAnotherInvoice =
-  DeleteCustomerInvoiceLineErrorInterface &
-    DeleteSupplierInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface &
-    UpdateSupplierInvoiceLineErrorInterface & {
-      __typename?: 'InvoiceLineBelongsToAnotherInvoice';
-      description: Scalars['String'];
-      invoice: InvoiceResponse;
-    };
+export type InvoiceLineBelongsToAnotherInvoice = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'InvoiceLineBelongsToAnotherInvoice';
+  description: Scalars['String'];
+  invoice: InvoiceResponse;
+};
 
 export type InvoiceLineConnector = {
   __typename?: 'InvoiceLineConnector';
@@ -355,12 +280,11 @@ export type InvoiceLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceLineHasNoStockLineError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'InvoiceLineHasNoStockLineError';
-    description: Scalars['String'];
-    invoiceLineId: Scalars['String'];
-  };
+export type InvoiceLineHasNoStockLineError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'InvoiceLineHasNoStockLineError';
+  description: Scalars['String'];
+  invoiceLineId: Scalars['String'];
+};
 
 export type InvoiceLineNode = {
   __typename?: 'InvoiceLineNode';
@@ -414,12 +338,12 @@ export enum InvoiceNodeStatus {
   Draft = 'DRAFT',
   Finalised = 'FINALISED',
   Picked = 'PICKED',
-  Shipped = 'SHIPPED',
+  Shipped = 'SHIPPED'
 }
 
 export enum InvoiceNodeType {
   CustomerInvoice = 'CUSTOMER_INVOICE',
-  SupplierInvoice = 'SUPPLIER_INVOICE',
+  SupplierInvoice = 'SUPPLIER_INVOICE'
 }
 
 export type InvoicePriceResponse = InvoicePricingNode | NodeError;
@@ -436,7 +360,7 @@ export enum InvoiceSortFieldInput {
   EntryDatetime = 'ENTRY_DATETIME',
   FinalisedDateTime = 'FINALISED_DATE_TIME',
   Status = 'STATUS',
-  Type = 'TYPE',
+  Type = 'TYPE'
 }
 
 export type InvoiceSortInput = {
@@ -452,12 +376,10 @@ export type ItemConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type ItemDoesNotMatchStockLine =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'ItemDoesNotMatchStockLine';
-      description: Scalars['String'];
-    };
+export type ItemDoesNotMatchStockLine = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'ItemDoesNotMatchStockLine';
+  description: Scalars['String'];
+};
 
 export type ItemFilterInput = {
   code?: Maybe<SimpleStringFilterInput>;
@@ -476,7 +398,7 @@ export type ItemNode = {
 
 export enum ItemSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME',
+  Name = 'NAME'
 }
 
 export type ItemSortInput = {
@@ -486,11 +408,10 @@ export type ItemSortInput = {
 
 export type ItemsResponse = ConnectorError | ItemConnector;
 
-export type LineDoesNotReferenceStockLine =
-  UpdateCustomerInvoiceLineErrorInterface & {
-    __typename?: 'LineDoesNotReferenceStockLine';
-    description: Scalars['String'];
-  };
+export type LineDoesNotReferenceStockLine = UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'LineDoesNotReferenceStockLine';
+  description: Scalars['String'];
+};
 
 export type Mutations = {
   __typename?: 'Mutations';
@@ -508,49 +429,61 @@ export type Mutations = {
   updateSupplierInvoiceLine: UpdateSupplierInvoiceLineResponse;
 };
 
+
 export type MutationsDeleteCustomerInvoiceArgs = {
   id: Scalars['String'];
 };
+
 
 export type MutationsDeleteCustomerInvoiceLineArgs = {
   input: DeleteCustomerInvoiceLineInput;
 };
 
+
 export type MutationsDeleteSupplierInvoiceArgs = {
   input: DeleteSupplierInvoiceInput;
 };
+
 
 export type MutationsDeleteSupplierInvoiceLineArgs = {
   input: DeleteSupplierInvoiceLineInput;
 };
 
+
 export type MutationsInsertCustomerInvoiceArgs = {
   input: InsertCustomerInvoiceInput;
 };
+
 
 export type MutationsInsertCustomerInvoiceLineArgs = {
   input: InsertCustomerInvoiceLineInput;
 };
 
+
 export type MutationsInsertSupplierInvoiceArgs = {
   input: InsertSupplierInvoiceInput;
 };
+
 
 export type MutationsInsertSupplierInvoiceLineArgs = {
   input: InsertSupplierInvoiceLineInput;
 };
 
+
 export type MutationsUpdateCustomerInvoiceArgs = {
   input: UpdateCustomerInvoiceInput;
 };
+
 
 export type MutationsUpdateCustomerInvoiceLineArgs = {
   input: UpdateCustomerInvoiceLineInput;
 };
 
+
 export type MutationsUpdateSupplierInvoiceArgs = {
   input: UpdateSupplierInvoiceInput;
 };
+
 
 export type MutationsUpdateSupplierInvoiceLineArgs = {
   input: UpdateSupplierInvoiceLineInput;
@@ -580,7 +513,7 @@ export type NameNode = {
 
 export enum NameSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME',
+  Name = 'NAME'
 }
 
 export type NameSortInput = {
@@ -599,57 +532,44 @@ export type NodeErrorInterface = {
   description: Scalars['String'];
 };
 
-export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface & {
-    __typename?: 'NotACustomerInvoice';
-    description: Scalars['String'];
-  };
+export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'NotACustomerInvoice';
+  description: Scalars['String'];
+};
 
 export type NotACustomerInvoiceError = UpdateCustomerInvoiceErrorInterface & {
   __typename?: 'NotACustomerInvoiceError';
   description: Scalars['String'];
 };
 
-export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'NotASupplierInvoice';
-    description: Scalars['String'];
-  };
+export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'NotASupplierInvoice';
+  description: Scalars['String'];
+};
 
-export type NotEnoughStockForReduction =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'NotEnoughStockForReduction';
-      batch: StockLineResponse;
-      description: Scalars['String'];
-      line?: Maybe<InvoiceLineResponse>;
-    };
+export type NotEnoughStockForReduction = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'NotEnoughStockForReduction';
+  batch: StockLineResponse;
+  description: Scalars['String'];
+  line?: Maybe<InvoiceLineResponse>;
+};
 
-export type OtherPartyCannotBeThisStoreError =
-  InsertCustomerInvoiceErrorInterface &
-    UpdateCustomerInvoiceErrorInterface & {
-      __typename?: 'OtherPartyCannotBeThisStoreError';
-      description: Scalars['String'];
-    };
+export type OtherPartyCannotBeThisStoreError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'OtherPartyCannotBeThisStoreError';
+  description: Scalars['String'];
+};
 
-export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'OtherPartyNotACustomerError';
-    description: Scalars['String'];
-    otherParty: NameNode;
-  };
+export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'OtherPartyNotACustomerError';
+  description: Scalars['String'];
+  otherParty: NameNode;
+};
 
-export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceErrorInterface & {
-    __typename?: 'OtherPartyNotASupplier';
-    description: Scalars['String'];
-    otherParty: NameNode;
-  };
+export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface & UpdateSupplierInvoiceErrorInterface & {
+  __typename?: 'OtherPartyNotASupplier';
+  description: Scalars['String'];
+  otherParty: NameNode;
+};
 
 export type PaginationError = ConnectorErrorInterface & {
   __typename?: 'PaginationError';
@@ -670,9 +590,11 @@ export type Queries = {
   names: NamesResponse;
 };
 
+
 export type QueriesInvoiceArgs = {
   id: Scalars['String'];
 };
+
 
 export type QueriesInvoicesArgs = {
   filter?: Maybe<InvoiceFilterInput>;
@@ -680,11 +602,13 @@ export type QueriesInvoicesArgs = {
   sort?: Maybe<Array<InvoiceSortInput>>;
 };
 
+
 export type QueriesItemsArgs = {
   filter?: Maybe<ItemFilterInput>;
   page?: Maybe<PaginationInput>;
   sort?: Maybe<Array<ItemSortInput>>;
 };
+
 
 export type QueriesNamesArgs = {
   filter?: Maybe<NameFilterInput>;
@@ -692,56 +616,40 @@ export type QueriesNamesArgs = {
   sort?: Maybe<Array<NameSortInput>>;
 };
 
-export type RangeError = InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'RangeError';
-    description: Scalars['String'];
-    field: RangeField;
-    max?: Maybe<Scalars['Int']>;
-    min?: Maybe<Scalars['Int']>;
-  };
+export type RangeError = InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'RangeError';
+  description: Scalars['String'];
+  field: RangeField;
+  max?: Maybe<Scalars['Int']>;
+  min?: Maybe<Scalars['Int']>;
+};
 
 export enum RangeField {
   First = 'FIRST',
   NumberOfPacks = 'NUMBER_OF_PACKS',
-  PackSize = 'PACK_SIZE',
+  PackSize = 'PACK_SIZE'
 }
 
-export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface & {
-    __typename?: 'RecordAlreadyExist';
-    description: Scalars['String'];
-  };
+export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & {
+  __typename?: 'RecordAlreadyExist';
+  description: Scalars['String'];
+};
 
-export type RecordNotFound = DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  NodeErrorInterface &
-  UpdateCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'RecordNotFound';
-    description: Scalars['String'];
-  };
+export type RecordNotFound = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'RecordNotFound';
+  description: Scalars['String'];
+};
 
 export type SimpleStringFilterInput = {
   equalTo?: Maybe<Scalars['String']>;
   like?: Maybe<Scalars['String']>;
 };
 
-export type StockLineAlreadyExistsInInvoice =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'StockLineAlreadyExistsInInvoice';
-      description: Scalars['String'];
-      line: InvoiceLineResponse;
-    };
+export type StockLineAlreadyExistsInInvoice = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'StockLineAlreadyExistsInInvoice';
+  description: Scalars['String'];
+  line: InvoiceLineResponse;
+};
 
 export type StockLineConnector = {
   __typename?: 'StockLineConnector';
@@ -749,12 +657,10 @@ export type StockLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type StockLineDoesNotBelongToCurrentStore =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'StockLineDoesNotBelongToCurrentStore';
-      description: Scalars['String'];
-    };
+export type StockLineDoesNotBelongToCurrentStore = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'StockLineDoesNotBelongToCurrentStore';
+  description: Scalars['String'];
+};
 
 export type StockLineNode = {
   __typename?: 'StockLineNode';
@@ -764,6 +670,8 @@ export type StockLineNode = {
   expiryDate?: Maybe<Scalars['NaiveDate']>;
   id: Scalars['String'];
   itemId: Scalars['String'];
+  location?: Maybe<Scalars['String']>;
+  onHold: Scalars['Boolean'];
   packSize: Scalars['Int'];
   sellPricePerPack: Scalars['Float'];
   storeId: Scalars['String'];
@@ -808,15 +716,9 @@ export type UpdateCustomerInvoiceLineInput = {
   stockLineId?: Maybe<Scalars['String']>;
 };
 
-export type UpdateCustomerInvoiceLineResponse =
-  | InvoiceLineNode
-  | NodeError
-  | UpdateCustomerInvoiceLineError;
+export type UpdateCustomerInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateCustomerInvoiceLineError;
 
-export type UpdateCustomerInvoiceResponse =
-  | InvoiceNode
-  | NodeError
-  | UpdateCustomerInvoiceError;
+export type UpdateCustomerInvoiceResponse = InvoiceNode | NodeError | UpdateCustomerInvoiceError;
 
 export type UpdateSupplierInvoiceError = {
   __typename?: 'UpdateSupplierInvoiceError';
@@ -856,74 +758,16 @@ export type UpdateSupplierInvoiceLineInput = {
   sellPricePerPack?: Maybe<Scalars['Float']>;
 };
 
-export type UpdateSupplierInvoiceLineResponse =
-  | InvoiceLineNode
-  | NodeError
-  | UpdateSupplierInvoiceLineError;
+export type UpdateSupplierInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateSupplierInvoiceLineError;
 
-export type UpdateSupplierInvoiceResponse =
-  | InvoiceNode
-  | NodeError
-  | UpdateSupplierInvoiceError;
+export type UpdateSupplierInvoiceResponse = InvoiceNode | NodeError | UpdateSupplierInvoiceError;
 
 export type InvoiceQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-export type InvoiceQuery = {
-  __typename?: 'Queries';
-  invoice:
-    | {
-        __typename?: 'InvoiceNode';
-        id: string;
-        comment?: string | null | undefined;
-        confirmedDatetime?: any | null | undefined;
-        entryDatetime: any;
-        finalisedDatetime?: any | null | undefined;
-        invoiceNumber: number;
-        draftDatetime?: any | null | undefined;
-        allocatedDatetime?: any | null | undefined;
-        pickedDatetime?: any | null | undefined;
-        shippedDatetime?: any | null | undefined;
-        deliveredDatetime?: any | null | undefined;
-        hold: boolean;
-        color: string;
-        otherPartyId: string;
-        otherPartyName: string;
-        status: InvoiceNodeStatus;
-        theirReference?: string | null | undefined;
-        type: InvoiceNodeType;
-        lines:
-          | { __typename?: 'ConnectorError' }
-          | {
-              __typename?: 'InvoiceLineConnector';
-              totalCount: number;
-              nodes: Array<{
-                __typename?: 'InvoiceLineNode';
-                batch?: string | null | undefined;
-                costPricePerPack: number;
-                expiryDate?: any | null | undefined;
-                id: string;
-                itemCode: string;
-                itemId: string;
-                itemName: string;
-                itemUnit: string;
-                numberOfPacks: number;
-                packSize: number;
-                sellPricePerPack: number;
-              }>;
-            };
-        pricing:
-          | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
-          | { __typename?: 'NodeError' };
-      }
-    | {
-        __typename: 'NodeError';
-        error:
-          | { __typename?: 'DatabaseError'; description: string }
-          | { __typename?: 'RecordNotFound'; description: string };
-      };
-};
+
+export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename?: 'InvoiceNode', id: string, comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, finalisedDatetime?: any | null | undefined, invoiceNumber: number, draftDatetime?: any | null | undefined, allocatedDatetime?: any | null | undefined, pickedDatetime?: any | null | undefined, shippedDatetime?: any | null | undefined, deliveredDatetime?: any | null | undefined, hold: boolean, color: string, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, lines: { __typename?: 'ConnectorError' } | { __typename?: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemCode: string, itemId: string, itemName: string, itemUnit: string, numberOfPacks: number, packSize: number, sellPricePerPack: number }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename?: 'NodeError' } } | { __typename: 'NodeError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'RecordNotFound', description: string } } };
 
 export type InvoicesQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -932,60 +776,8 @@ export type InvoicesQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-export type InvoicesQuery = {
-  __typename?: 'Queries';
-  invoices:
-    | {
-        __typename: 'ConnectorError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | {
-              __typename: 'PaginationError';
-              description: string;
-              rangeError: {
-                __typename?: 'RangeError';
-                description: string;
-                field: RangeField;
-                max?: number | null | undefined;
-                min?: number | null | undefined;
-              };
-            };
-      }
-    | {
-        __typename: 'InvoiceConnector';
-        totalCount: number;
-        nodes: Array<{
-          __typename?: 'InvoiceNode';
-          comment?: string | null | undefined;
-          confirmedDatetime?: any | null | undefined;
-          entryDatetime: any;
-          id: string;
-          invoiceNumber: number;
-          otherPartyId: string;
-          otherPartyName: string;
-          status: InvoiceNodeStatus;
-          color: string;
-          theirReference?: string | null | undefined;
-          type: InvoiceNodeType;
-          pricing:
-            | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
-            | {
-                __typename: 'NodeError';
-                error:
-                  | {
-                      __typename: 'DatabaseError';
-                      description: string;
-                      fullError: string;
-                    }
-                  | { __typename: 'RecordNotFound'; description: string };
-              };
-        }>;
-      };
-};
+
+export type InvoicesQuery = { __typename?: 'Queries', invoices: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceNode', comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, color: string, theirReference?: string | null | undefined, type: InvoiceNodeType, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } }> } };
 
 export type NamesQueryVariables = Exact<{
   key: NameSortFieldInput;
@@ -994,271 +786,281 @@ export type NamesQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
 }>;
 
-export type NamesQuery = {
-  __typename?: 'Queries';
-  names:
-    | {
-        __typename: 'ConnectorError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | {
-              __typename: 'PaginationError';
-              description: string;
-              rangeError: {
-                __typename?: 'RangeError';
-                description: string;
-                field: RangeField;
-                max?: number | null | undefined;
-                min?: number | null | undefined;
-              };
-            };
-      }
-    | {
-        __typename: 'NameConnector';
-        totalCount: number;
-        nodes: Array<{
-          __typename?: 'NameNode';
-          code: string;
-          id: string;
-          isCustomer: boolean;
-          isSupplier: boolean;
-          name: string;
-        }>;
-      };
-};
+
+export type NamesQuery = { __typename?: 'Queries', names: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'NameConnector', totalCount: number, nodes: Array<{ __typename?: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, name: string }> } };
+
+export type ItemsQueryVariables = Exact<{
+  first?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  key: ItemSortFieldInput;
+  desc?: Maybe<Scalars['Boolean']>;
+}>;
+
+
+export type ItemsQuery = { __typename?: 'Queries', items: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, availableBatches: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename?: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean }> } }> } };
+
 
 export const InvoiceDocument = gql`
-  query invoice($id: String!) {
-    invoice(id: $id) {
-      ... on InvoiceNode {
-        id
+    query invoice($id: String!) {
+  invoice(id: $id) {
+    ... on InvoiceNode {
+      id
+      comment
+      confirmedDatetime
+      entryDatetime
+      finalisedDatetime
+      invoiceNumber
+      draftDatetime
+      allocatedDatetime
+      pickedDatetime
+      shippedDatetime
+      deliveredDatetime
+      hold
+      color
+      lines {
+        ... on InvoiceLineConnector {
+          nodes {
+            batch
+            costPricePerPack
+            expiryDate
+            id
+            itemCode
+            itemId
+            itemName
+            itemUnit
+            numberOfPacks
+            packSize
+            sellPricePerPack
+          }
+          totalCount
+        }
+      }
+      otherPartyId
+      otherPartyName
+      pricing {
+        ... on InvoicePricingNode {
+          __typename
+          totalAfterTax
+        }
+      }
+      status
+      theirReference
+      type
+    }
+    ... on NodeError {
+      __typename
+      error {
+        description
+      }
+    }
+  }
+}
+    `;
+export const InvoicesDocument = gql`
+    query invoices($first: Int, $offset: Int, $key: InvoiceSortFieldInput!, $desc: Boolean) {
+  invoices(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
+      }
+    }
+    ... on InvoiceConnector {
+      __typename
+      nodes {
         comment
         confirmedDatetime
         entryDatetime
-        finalisedDatetime
+        id
         invoiceNumber
-        draftDatetime
-        allocatedDatetime
-        pickedDatetime
-        shippedDatetime
-        deliveredDatetime
-        hold
-        color
-        lines {
-          ... on InvoiceLineConnector {
-            nodes {
-              batch
-              costPricePerPack
-              expiryDate
-              id
-              itemCode
-              itemId
-              itemName
-              itemUnit
-              numberOfPacks
-              packSize
-              sellPricePerPack
-            }
-            totalCount
-          }
-        }
         otherPartyId
         otherPartyName
+        status
+        color
+        theirReference
+        type
         pricing {
+          ... on NodeError {
+            __typename
+            error {
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on DatabaseError {
+                __typename
+                description
+                fullError
+              }
+              description
+            }
+          }
           ... on InvoicePricingNode {
             __typename
             totalAfterTax
           }
         }
-        status
-        theirReference
-        type
       }
-      ... on NodeError {
-        __typename
-        error {
+      totalCount
+    }
+  }
+}
+    `;
+export const NamesDocument = gql`
+    query names($key: NameSortFieldInput!, $desc: Boolean, $first: Int, $offset: Int) {
+  names(
+    page: {first: $first, offset: $offset}
+    sort: {key: $key, desc: $desc}
+    filter: {isCustomer: true}
+  ) {
+    ... on ConnectorError {
+      __typename
+      error {
+        ... on DatabaseError {
+          __typename
           description
+          fullError
+        }
+        description
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
         }
       }
     }
+    ... on NameConnector {
+      __typename
+      nodes {
+        code
+        id
+        isCustomer
+        isSupplier
+        name
+      }
+      totalCount
+    }
   }
-`;
-export const InvoicesDocument = gql`
-  query invoices(
-    $first: Int
-    $offset: Int
-    $key: InvoiceSortFieldInput!
-    $desc: Boolean
-  ) {
-    invoices(
-      page: { first: $first, offset: $offset }
-      sort: { key: $key, desc: $desc }
-    ) {
-      ... on ConnectorError {
-        __typename
-        error {
+}
+    `;
+export const ItemsDocument = gql`
+    query items($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean) {
+  items(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
           description
-          ... on DatabaseError {
-            __typename
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
             description
-            fullError
-          }
-          ... on PaginationError {
-            __typename
-            description
-            rangeError {
-              description
-              field
-              max
-              min
-            }
+            field
+            max
+            min
           }
         }
       }
-      ... on InvoiceConnector {
+    }
+    ... on ItemConnector {
+      __typename
+      nodes {
         __typename
-        nodes {
-          comment
-          confirmedDatetime
-          entryDatetime
-          id
-          invoiceNumber
-          otherPartyId
-          otherPartyName
-          status
-          color
-          theirReference
-          type
-          pricing {
-            ... on NodeError {
-              __typename
-              error {
-                ... on RecordNotFound {
-                  __typename
-                  description
-                }
-                ... on DatabaseError {
-                  __typename
-                  description
-                  fullError
-                }
+        availableBatches {
+          ... on ConnectorError {
+            __typename
+            error {
+              description
+              ... on DatabaseError {
+                __typename
                 description
+                fullError
+              }
+              ... on PaginationError {
+                __typename
+                description
+                rangeError {
+                  description
+                  field
+                  max
+                  min
+                }
               }
             }
-            ... on InvoicePricingNode {
+          }
+          ... on StockLineConnector {
+            nodes {
               __typename
-              totalAfterTax
+              availableNumberOfPacks
+              batch
+              costPricePerPack
+              expiryDate
+              id
+              itemId
+              packSize
+              sellPricePerPack
+              storeId
+              totalNumberOfPacks
+              onHold
             }
+            totalCount
           }
         }
-        totalCount
+        code
+        id
+        isVisible
+        name
       }
+      totalCount
     }
   }
-`;
-export const NamesDocument = gql`
-  query names(
-    $key: NameSortFieldInput!
-    $desc: Boolean
-    $first: Int
-    $offset: Int
-  ) {
-    names(
-      page: { first: $first, offset: $offset }
-      sort: { key: $key, desc: $desc }
-      filter: { isCustomer: true }
-    ) {
-      ... on ConnectorError {
-        __typename
-        error {
-          ... on DatabaseError {
-            __typename
-            description
-            fullError
-          }
-          description
-          ... on PaginationError {
-            __typename
-            description
-            rangeError {
-              description
-              field
-              max
-              min
-            }
-          }
-        }
-      }
-      ... on NameConnector {
-        __typename
-        nodes {
-          code
-          id
-          isCustomer
-          isSupplier
-          name
-        }
-        totalCount
-      }
-    }
-  }
-`;
+}
+    `;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
+
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper
-) {
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    invoice(
-      variables: InvoiceQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<InvoiceQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<InvoiceQuery>(InvoiceDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'invoice'
-      );
+    invoice(variables: InvoiceQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoiceQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<InvoiceQuery>(InvoiceDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoice');
     },
-    invoices(
-      variables: InvoicesQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<InvoicesQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<InvoicesQuery>(InvoicesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'invoices'
-      );
+    invoices(variables: InvoicesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoicesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<InvoicesQuery>(InvoicesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoices');
     },
-    names(
-      variables: NamesQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<NamesQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<NamesQuery>(NamesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'names'
-      );
+    names(variables: NamesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<NamesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<NamesQuery>(NamesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'names');
     },
+    items(variables: ItemsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ItemsQuery>(ItemsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'items');
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -2,15 +2,9 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -22,49 +16,36 @@ export type Scalars = {
   NaiveDate: any;
 };
 
-export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'BatchIsReserved';
-    description: Scalars['String'];
-  };
+export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'BatchIsReserved';
+  description: Scalars['String'];
+};
 
-export type CanOnlyEditInvoicesInLoggedInStoreError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
-    description: Scalars['String'];
-  };
+export type CanOnlyEditInvoicesInLoggedInStoreError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
+  description: Scalars['String'];
+};
 
-export type CannotChangeInvoiceBackToDraft =
-  UpdateSupplierInvoiceErrorInterface & {
-    __typename?: 'CannotChangeInvoiceBackToDraft';
-    description: Scalars['String'];
-  };
+export type CannotChangeInvoiceBackToDraft = UpdateSupplierInvoiceErrorInterface & {
+  __typename?: 'CannotChangeInvoiceBackToDraft';
+  description: Scalars['String'];
+};
 
-export type CannotChangeStatusBackToDraftError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'CannotChangeStatusBackToDraftError';
-    description: Scalars['String'];
-  };
+export type CannotChangeStatusBackToDraftError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'CannotChangeStatusBackToDraftError';
+  description: Scalars['String'];
+};
 
-export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface &
-  DeleteSupplierInvoiceErrorInterface & {
-    __typename?: 'CannotDeleteInvoiceWithLines';
-    description: Scalars['String'];
-    lines: InvoiceLineConnector;
-  };
+export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface & DeleteSupplierInvoiceErrorInterface & {
+  __typename?: 'CannotDeleteInvoiceWithLines';
+  description: Scalars['String'];
+  lines: InvoiceLineConnector;
+};
 
-export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'CannotEditFinalisedInvoice';
-    description: Scalars['String'];
-  };
+export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'CannotEditFinalisedInvoice';
+  description: Scalars['String'];
+};
 
 export type ConnectorError = {
   __typename?: 'ConnectorError';
@@ -75,24 +56,11 @@ export type ConnectorErrorInterface = {
   description: Scalars['String'];
 };
 
-export type DatabaseError = ConnectorErrorInterface &
-  DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertCustomerInvoiceErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  NodeErrorInterface &
-  UpdateCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'DatabaseError';
-    description: Scalars['String'];
-    fullError: Scalars['String'];
-  };
+export type DatabaseError = ConnectorErrorInterface & DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'DatabaseError';
+  description: Scalars['String'];
+  fullError: Scalars['String'];
+};
 
 export type DatetimeFilterInput = {
   afterOrEqualTo?: Maybe<Scalars['DateTime']>;
@@ -123,13 +91,9 @@ export type DeleteCustomerInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteCustomerInvoiceLineResponse =
-  | DeleteCustomerInvoiceLineError
-  | DeleteResponse;
+export type DeleteCustomerInvoiceLineResponse = DeleteCustomerInvoiceLineError | DeleteResponse;
 
-export type DeleteCustomerInvoiceResponse =
-  | DeleteCustomerInvoiceError
-  | DeleteResponse;
+export type DeleteCustomerInvoiceResponse = DeleteCustomerInvoiceError | DeleteResponse;
 
 export type DeleteResponse = {
   __typename?: 'DeleteResponse';
@@ -163,13 +127,9 @@ export type DeleteSupplierInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteSupplierInvoiceLineResponse =
-  | DeleteResponse
-  | DeleteSupplierInvoiceLineError;
+export type DeleteSupplierInvoiceLineResponse = DeleteResponse | DeleteSupplierInvoiceLineError;
 
-export type DeleteSupplierInvoiceResponse =
-  | DeleteResponse
-  | DeleteSupplierInvoiceError;
+export type DeleteSupplierInvoiceResponse = DeleteResponse | DeleteSupplierInvoiceError;
 
 export type EqualFilterBoolInput = {
   equalTo?: Maybe<Scalars['Boolean']>;
@@ -187,33 +147,23 @@ export type EqualFilterStringInput = {
   equalTo?: Maybe<Scalars['String']>;
 };
 
-export type FinalisedInvoiceIsNotEditableError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'FinalisedInvoiceIsNotEditableError';
-    description: Scalars['String'];
-  };
+export type FinalisedInvoiceIsNotEditableError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'FinalisedInvoiceIsNotEditableError';
+  description: Scalars['String'];
+};
 
 export enum ForeignKey {
   InvoiceId = 'INVOICE_ID',
   ItemId = 'ITEM_ID',
   OtherPartyId = 'OTHER_PARTY_ID',
-  StockLineId = 'STOCK_LINE_ID',
+  StockLineId = 'STOCK_LINE_ID'
 }
 
-export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertCustomerInvoiceErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'ForeignKeyError';
-    description: Scalars['String'];
-    key: ForeignKey;
-  };
+export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'ForeignKeyError';
+  description: Scalars['String'];
+  key: ForeignKey;
+};
 
 export type InsertCustomerInvoiceError = {
   __typename?: 'InsertCustomerInvoiceError';
@@ -249,15 +199,9 @@ export type InsertCustomerInvoiceLineInput = {
   stockLineId: Scalars['String'];
 };
 
-export type InsertCustomerInvoiceLineResponse =
-  | InsertCustomerInvoiceLineError
-  | InvoiceLineNode
-  | NodeError;
+export type InsertCustomerInvoiceLineResponse = InsertCustomerInvoiceLineError | InvoiceLineNode | NodeError;
 
-export type InsertCustomerInvoiceResponse =
-  | InsertCustomerInvoiceError
-  | InvoiceNode
-  | NodeError;
+export type InsertCustomerInvoiceResponse = InsertCustomerInvoiceError | InvoiceNode | NodeError;
 
 export type InsertSupplierInvoiceError = {
   __typename?: 'InsertSupplierInvoiceError';
@@ -297,15 +241,9 @@ export type InsertSupplierInvoiceLineInput = {
   sellPricePerPack: Scalars['Float'];
 };
 
-export type InsertSupplierInvoiceLineResponse =
-  | InsertSupplierInvoiceLineError
-  | InvoiceLineNode
-  | NodeError;
+export type InsertSupplierInvoiceLineResponse = InsertSupplierInvoiceLineError | InvoiceLineNode | NodeError;
 
-export type InsertSupplierInvoiceResponse =
-  | InsertSupplierInvoiceError
-  | InvoiceNode
-  | NodeError;
+export type InsertSupplierInvoiceResponse = InsertSupplierInvoiceError | InvoiceNode | NodeError;
 
 export type InvoiceConnector = {
   __typename?: 'InvoiceConnector';
@@ -313,19 +251,10 @@ export type InvoiceConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceDoesNotBelongToCurrentStore =
-  DeleteCustomerInvoiceErrorInterface &
-    DeleteCustomerInvoiceLineErrorInterface &
-    DeleteSupplierInvoiceErrorInterface &
-    DeleteSupplierInvoiceLineErrorInterface &
-    InsertCustomerInvoiceLineErrorInterface &
-    InsertSupplierInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface &
-    UpdateSupplierInvoiceErrorInterface &
-    UpdateSupplierInvoiceLineErrorInterface & {
-      __typename?: 'InvoiceDoesNotBelongToCurrentStore';
-      description: Scalars['String'];
-    };
+export type InvoiceDoesNotBelongToCurrentStore = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'InvoiceDoesNotBelongToCurrentStore';
+  description: Scalars['String'];
+};
 
 export type InvoiceFilterInput = {
   comment?: Maybe<SimpleStringFilterInput>;
@@ -339,15 +268,11 @@ export type InvoiceFilterInput = {
   type?: Maybe<EqualFilterInvoiceTypeInput>;
 };
 
-export type InvoiceLineBelongsToAnotherInvoice =
-  DeleteCustomerInvoiceLineErrorInterface &
-    DeleteSupplierInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface &
-    UpdateSupplierInvoiceLineErrorInterface & {
-      __typename?: 'InvoiceLineBelongsToAnotherInvoice';
-      description: Scalars['String'];
-      invoice: InvoiceResponse;
-    };
+export type InvoiceLineBelongsToAnotherInvoice = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'InvoiceLineBelongsToAnotherInvoice';
+  description: Scalars['String'];
+  invoice: InvoiceResponse;
+};
 
 export type InvoiceLineConnector = {
   __typename?: 'InvoiceLineConnector';
@@ -355,12 +280,11 @@ export type InvoiceLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceLineHasNoStockLineError =
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'InvoiceLineHasNoStockLineError';
-    description: Scalars['String'];
-    invoiceLineId: Scalars['String'];
-  };
+export type InvoiceLineHasNoStockLineError = UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'InvoiceLineHasNoStockLineError';
+  description: Scalars['String'];
+  invoiceLineId: Scalars['String'];
+};
 
 export type InvoiceLineNode = {
   __typename?: 'InvoiceLineNode';
@@ -414,12 +338,12 @@ export enum InvoiceNodeStatus {
   Draft = 'DRAFT',
   Finalised = 'FINALISED',
   Picked = 'PICKED',
-  Shipped = 'SHIPPED',
+  Shipped = 'SHIPPED'
 }
 
 export enum InvoiceNodeType {
   CustomerInvoice = 'CUSTOMER_INVOICE',
-  SupplierInvoice = 'SUPPLIER_INVOICE',
+  SupplierInvoice = 'SUPPLIER_INVOICE'
 }
 
 export type InvoicePriceResponse = InvoicePricingNode | NodeError;
@@ -436,7 +360,7 @@ export enum InvoiceSortFieldInput {
   EntryDatetime = 'ENTRY_DATETIME',
   FinalisedDateTime = 'FINALISED_DATE_TIME',
   Status = 'STATUS',
-  Type = 'TYPE',
+  Type = 'TYPE'
 }
 
 export type InvoiceSortInput = {
@@ -452,12 +376,10 @@ export type ItemConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type ItemDoesNotMatchStockLine =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'ItemDoesNotMatchStockLine';
-      description: Scalars['String'];
-    };
+export type ItemDoesNotMatchStockLine = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'ItemDoesNotMatchStockLine';
+  description: Scalars['String'];
+};
 
 export type ItemFilterInput = {
   code?: Maybe<SimpleStringFilterInput>;
@@ -476,7 +398,7 @@ export type ItemNode = {
 
 export enum ItemSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME',
+  Name = 'NAME'
 }
 
 export type ItemSortInput = {
@@ -486,11 +408,10 @@ export type ItemSortInput = {
 
 export type ItemsResponse = ConnectorError | ItemConnector;
 
-export type LineDoesNotReferenceStockLine =
-  UpdateCustomerInvoiceLineErrorInterface & {
-    __typename?: 'LineDoesNotReferenceStockLine';
-    description: Scalars['String'];
-  };
+export type LineDoesNotReferenceStockLine = UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'LineDoesNotReferenceStockLine';
+  description: Scalars['String'];
+};
 
 export type Mutations = {
   __typename?: 'Mutations';
@@ -508,49 +429,61 @@ export type Mutations = {
   updateSupplierInvoiceLine: UpdateSupplierInvoiceLineResponse;
 };
 
+
 export type MutationsDeleteCustomerInvoiceArgs = {
   id: Scalars['String'];
 };
+
 
 export type MutationsDeleteCustomerInvoiceLineArgs = {
   input: DeleteCustomerInvoiceLineInput;
 };
 
+
 export type MutationsDeleteSupplierInvoiceArgs = {
   input: DeleteSupplierInvoiceInput;
 };
+
 
 export type MutationsDeleteSupplierInvoiceLineArgs = {
   input: DeleteSupplierInvoiceLineInput;
 };
 
+
 export type MutationsInsertCustomerInvoiceArgs = {
   input: InsertCustomerInvoiceInput;
 };
+
 
 export type MutationsInsertCustomerInvoiceLineArgs = {
   input: InsertCustomerInvoiceLineInput;
 };
 
+
 export type MutationsInsertSupplierInvoiceArgs = {
   input: InsertSupplierInvoiceInput;
 };
+
 
 export type MutationsInsertSupplierInvoiceLineArgs = {
   input: InsertSupplierInvoiceLineInput;
 };
 
+
 export type MutationsUpdateCustomerInvoiceArgs = {
   input: UpdateCustomerInvoiceInput;
 };
+
 
 export type MutationsUpdateCustomerInvoiceLineArgs = {
   input: UpdateCustomerInvoiceLineInput;
 };
 
+
 export type MutationsUpdateSupplierInvoiceArgs = {
   input: UpdateSupplierInvoiceInput;
 };
+
 
 export type MutationsUpdateSupplierInvoiceLineArgs = {
   input: UpdateSupplierInvoiceLineInput;
@@ -580,7 +513,7 @@ export type NameNode = {
 
 export enum NameSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME',
+  Name = 'NAME'
 }
 
 export type NameSortInput = {
@@ -599,57 +532,44 @@ export type NodeErrorInterface = {
   description: Scalars['String'];
 };
 
-export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface & {
-    __typename?: 'NotACustomerInvoice';
-    description: Scalars['String'];
-  };
+export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'NotACustomerInvoice';
+  description: Scalars['String'];
+};
 
 export type NotACustomerInvoiceError = UpdateCustomerInvoiceErrorInterface & {
   __typename?: 'NotACustomerInvoiceError';
   description: Scalars['String'];
 };
 
-export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'NotASupplierInvoice';
-    description: Scalars['String'];
-  };
+export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'NotASupplierInvoice';
+  description: Scalars['String'];
+};
 
-export type NotEnoughStockForReduction =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'NotEnoughStockForReduction';
-      batch: StockLineResponse;
-      description: Scalars['String'];
-      line?: Maybe<InvoiceLineResponse>;
-    };
+export type NotEnoughStockForReduction = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'NotEnoughStockForReduction';
+  batch: StockLineResponse;
+  description: Scalars['String'];
+  line?: Maybe<InvoiceLineResponse>;
+};
 
-export type OtherPartyCannotBeThisStoreError =
-  InsertCustomerInvoiceErrorInterface &
-    UpdateCustomerInvoiceErrorInterface & {
-      __typename?: 'OtherPartyCannotBeThisStoreError';
-      description: Scalars['String'];
-    };
+export type OtherPartyCannotBeThisStoreError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'OtherPartyCannotBeThisStoreError';
+  description: Scalars['String'];
+};
 
-export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceErrorInterface & {
-    __typename?: 'OtherPartyNotACustomerError';
-    description: Scalars['String'];
-    otherParty: NameNode;
-  };
+export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
+  __typename?: 'OtherPartyNotACustomerError';
+  description: Scalars['String'];
+  otherParty: NameNode;
+};
 
-export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceErrorInterface & {
-    __typename?: 'OtherPartyNotASupplier';
-    description: Scalars['String'];
-    otherParty: NameNode;
-  };
+export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface & UpdateSupplierInvoiceErrorInterface & {
+  __typename?: 'OtherPartyNotASupplier';
+  description: Scalars['String'];
+  otherParty: NameNode;
+};
 
 export type PaginationError = ConnectorErrorInterface & {
   __typename?: 'PaginationError';
@@ -670,9 +590,11 @@ export type Queries = {
   names: NamesResponse;
 };
 
+
 export type QueriesInvoiceArgs = {
   id: Scalars['String'];
 };
+
 
 export type QueriesInvoicesArgs = {
   filter?: Maybe<InvoiceFilterInput>;
@@ -680,11 +602,13 @@ export type QueriesInvoicesArgs = {
   sort?: Maybe<Array<InvoiceSortInput>>;
 };
 
+
 export type QueriesItemsArgs = {
   filter?: Maybe<ItemFilterInput>;
   page?: Maybe<PaginationInput>;
   sort?: Maybe<Array<ItemSortInput>>;
 };
+
 
 export type QueriesNamesArgs = {
   filter?: Maybe<NameFilterInput>;
@@ -692,56 +616,40 @@ export type QueriesNamesArgs = {
   sort?: Maybe<Array<NameSortInput>>;
 };
 
-export type RangeError = InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'RangeError';
-    description: Scalars['String'];
-    field: RangeField;
-    max?: Maybe<Scalars['Int']>;
-    min?: Maybe<Scalars['Int']>;
-  };
+export type RangeError = InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'RangeError';
+  description: Scalars['String'];
+  field: RangeField;
+  max?: Maybe<Scalars['Int']>;
+  min?: Maybe<Scalars['Int']>;
+};
 
 export enum RangeField {
   First = 'FIRST',
   NumberOfPacks = 'NUMBER_OF_PACKS',
-  PackSize = 'PACK_SIZE',
+  PackSize = 'PACK_SIZE'
 }
 
-export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface &
-  InsertCustomerInvoiceLineErrorInterface &
-  InsertSupplierInvoiceErrorInterface &
-  InsertSupplierInvoiceLineErrorInterface & {
-    __typename?: 'RecordAlreadyExist';
-    description: Scalars['String'];
-  };
+export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & {
+  __typename?: 'RecordAlreadyExist';
+  description: Scalars['String'];
+};
 
-export type RecordNotFound = DeleteCustomerInvoiceErrorInterface &
-  DeleteCustomerInvoiceLineErrorInterface &
-  DeleteSupplierInvoiceErrorInterface &
-  DeleteSupplierInvoiceLineErrorInterface &
-  NodeErrorInterface &
-  UpdateCustomerInvoiceErrorInterface &
-  UpdateCustomerInvoiceLineErrorInterface &
-  UpdateSupplierInvoiceErrorInterface &
-  UpdateSupplierInvoiceLineErrorInterface & {
-    __typename?: 'RecordNotFound';
-    description: Scalars['String'];
-  };
+export type RecordNotFound = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
+  __typename?: 'RecordNotFound';
+  description: Scalars['String'];
+};
 
 export type SimpleStringFilterInput = {
   equalTo?: Maybe<Scalars['String']>;
   like?: Maybe<Scalars['String']>;
 };
 
-export type StockLineAlreadyExistsInInvoice =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'StockLineAlreadyExistsInInvoice';
-      description: Scalars['String'];
-      line: InvoiceLineResponse;
-    };
+export type StockLineAlreadyExistsInInvoice = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'StockLineAlreadyExistsInInvoice';
+  description: Scalars['String'];
+  line: InvoiceLineResponse;
+};
 
 export type StockLineConnector = {
   __typename?: 'StockLineConnector';
@@ -749,12 +657,10 @@ export type StockLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type StockLineDoesNotBelongToCurrentStore =
-  InsertCustomerInvoiceLineErrorInterface &
-    UpdateCustomerInvoiceLineErrorInterface & {
-      __typename?: 'StockLineDoesNotBelongToCurrentStore';
-      description: Scalars['String'];
-    };
+export type StockLineDoesNotBelongToCurrentStore = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
+  __typename?: 'StockLineDoesNotBelongToCurrentStore';
+  description: Scalars['String'];
+};
 
 export type StockLineNode = {
   __typename?: 'StockLineNode';
@@ -810,15 +716,9 @@ export type UpdateCustomerInvoiceLineInput = {
   stockLineId?: Maybe<Scalars['String']>;
 };
 
-export type UpdateCustomerInvoiceLineResponse =
-  | InvoiceLineNode
-  | NodeError
-  | UpdateCustomerInvoiceLineError;
+export type UpdateCustomerInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateCustomerInvoiceLineError;
 
-export type UpdateCustomerInvoiceResponse =
-  | InvoiceNode
-  | NodeError
-  | UpdateCustomerInvoiceError;
+export type UpdateCustomerInvoiceResponse = InvoiceNode | NodeError | UpdateCustomerInvoiceError;
 
 export type UpdateSupplierInvoiceError = {
   __typename?: 'UpdateSupplierInvoiceError';
@@ -858,74 +758,16 @@ export type UpdateSupplierInvoiceLineInput = {
   sellPricePerPack?: Maybe<Scalars['Float']>;
 };
 
-export type UpdateSupplierInvoiceLineResponse =
-  | InvoiceLineNode
-  | NodeError
-  | UpdateSupplierInvoiceLineError;
+export type UpdateSupplierInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateSupplierInvoiceLineError;
 
-export type UpdateSupplierInvoiceResponse =
-  | InvoiceNode
-  | NodeError
-  | UpdateSupplierInvoiceError;
+export type UpdateSupplierInvoiceResponse = InvoiceNode | NodeError | UpdateSupplierInvoiceError;
 
 export type InvoiceQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-export type InvoiceQuery = {
-  __typename?: 'Queries';
-  invoice:
-    | {
-        __typename?: 'InvoiceNode';
-        id: string;
-        comment?: string | null | undefined;
-        confirmedDatetime?: any | null | undefined;
-        entryDatetime: any;
-        finalisedDatetime?: any | null | undefined;
-        invoiceNumber: number;
-        draftDatetime?: any | null | undefined;
-        allocatedDatetime?: any | null | undefined;
-        pickedDatetime?: any | null | undefined;
-        shippedDatetime?: any | null | undefined;
-        deliveredDatetime?: any | null | undefined;
-        hold: boolean;
-        color: string;
-        otherPartyId: string;
-        otherPartyName: string;
-        status: InvoiceNodeStatus;
-        theirReference?: string | null | undefined;
-        type: InvoiceNodeType;
-        lines:
-          | { __typename?: 'ConnectorError' }
-          | {
-              __typename?: 'InvoiceLineConnector';
-              totalCount: number;
-              nodes: Array<{
-                __typename?: 'InvoiceLineNode';
-                batch?: string | null | undefined;
-                costPricePerPack: number;
-                expiryDate?: any | null | undefined;
-                id: string;
-                itemCode: string;
-                itemId: string;
-                itemName: string;
-                itemUnit: string;
-                numberOfPacks: number;
-                packSize: number;
-                sellPricePerPack: number;
-              }>;
-            };
-        pricing:
-          | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
-          | { __typename?: 'NodeError' };
-      }
-    | {
-        __typename: 'NodeError';
-        error:
-          | { __typename?: 'DatabaseError'; description: string }
-          | { __typename?: 'RecordNotFound'; description: string };
-      };
-};
+
+export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename?: 'InvoiceNode', id: string, comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, finalisedDatetime?: any | null | undefined, invoiceNumber: number, draftDatetime?: any | null | undefined, allocatedDatetime?: any | null | undefined, pickedDatetime?: any | null | undefined, shippedDatetime?: any | null | undefined, deliveredDatetime?: any | null | undefined, hold: boolean, color: string, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, lines: { __typename?: 'ConnectorError' } | { __typename?: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemCode: string, itemId: string, itemName: string, itemUnit: string, numberOfPacks: number, packSize: number, sellPricePerPack: number }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename?: 'NodeError' } } | { __typename: 'NodeError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'RecordNotFound', description: string } } };
 
 export type InvoicesQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -934,60 +776,8 @@ export type InvoicesQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-export type InvoicesQuery = {
-  __typename?: 'Queries';
-  invoices:
-    | {
-        __typename: 'ConnectorError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | {
-              __typename: 'PaginationError';
-              description: string;
-              rangeError: {
-                __typename?: 'RangeError';
-                description: string;
-                field: RangeField;
-                max?: number | null | undefined;
-                min?: number | null | undefined;
-              };
-            };
-      }
-    | {
-        __typename: 'InvoiceConnector';
-        totalCount: number;
-        nodes: Array<{
-          __typename?: 'InvoiceNode';
-          comment?: string | null | undefined;
-          confirmedDatetime?: any | null | undefined;
-          entryDatetime: any;
-          id: string;
-          invoiceNumber: number;
-          otherPartyId: string;
-          otherPartyName: string;
-          status: InvoiceNodeStatus;
-          color: string;
-          theirReference?: string | null | undefined;
-          type: InvoiceNodeType;
-          pricing:
-            | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
-            | {
-                __typename: 'NodeError';
-                error:
-                  | {
-                      __typename: 'DatabaseError';
-                      description: string;
-                      fullError: string;
-                    }
-                  | { __typename: 'RecordNotFound'; description: string };
-              };
-        }>;
-      };
-};
+
+export type InvoicesQuery = { __typename?: 'Queries', invoices: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceNode', comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, color: string, theirReference?: string | null | undefined, type: InvoiceNodeType, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } }> } };
 
 export type NamesQueryVariables = Exact<{
   key: NameSortFieldInput;
@@ -996,42 +786,8 @@ export type NamesQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
 }>;
 
-export type NamesQuery = {
-  __typename?: 'Queries';
-  names:
-    | {
-        __typename: 'ConnectorError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | {
-              __typename: 'PaginationError';
-              description: string;
-              rangeError: {
-                __typename?: 'RangeError';
-                description: string;
-                field: RangeField;
-                max?: number | null | undefined;
-                min?: number | null | undefined;
-              };
-            };
-      }
-    | {
-        __typename: 'NameConnector';
-        totalCount: number;
-        nodes: Array<{
-          __typename?: 'NameNode';
-          code: string;
-          id: string;
-          isCustomer: boolean;
-          isSupplier: boolean;
-          name: string;
-        }>;
-      };
-};
+
+export type NamesQuery = { __typename?: 'Queries', names: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'NameConnector', totalCount: number, nodes: Array<{ __typename?: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, name: string }> } };
 
 export type ItemsQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -1040,408 +796,273 @@ export type ItemsQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-export type ItemsQuery = {
-  __typename?: 'Queries';
-  items:
-    | {
-        __typename: 'ConnectorError';
-        error:
-          | {
-              __typename: 'DatabaseError';
-              description: string;
-              fullError: string;
-            }
-          | {
-              __typename: 'PaginationError';
-              description: string;
-              rangeError: {
-                __typename?: 'RangeError';
-                description: string;
-                field: RangeField;
-                max?: number | null | undefined;
-                min?: number | null | undefined;
-              };
-            };
-      }
-    | {
-        __typename: 'ItemConnector';
-        totalCount: number;
-        nodes: Array<{
-          __typename: 'ItemNode';
-          code: string;
-          id: string;
-          isVisible: boolean;
-          name: string;
-          availableBatches:
-            | {
-                __typename: 'ConnectorError';
-                error:
-                  | {
-                      __typename: 'DatabaseError';
-                      description: string;
-                      fullError: string;
-                    }
-                  | {
-                      __typename: 'PaginationError';
-                      description: string;
-                      rangeError: {
-                        __typename?: 'RangeError';
-                        description: string;
-                        field: RangeField;
-                        max?: number | null | undefined;
-                        min?: number | null | undefined;
-                      };
-                    };
-              }
-            | {
-                __typename?: 'StockLineConnector';
-                totalCount: number;
-                nodes: Array<{
-                  __typename: 'StockLineNode';
-                  availableNumberOfPacks: number;
-                  batch?: string | null | undefined;
-                  costPricePerPack: number;
-                  expiryDate?: any | null | undefined;
-                  id: string;
-                  itemId: string;
-                  packSize: number;
-                  sellPricePerPack: number;
-                  storeId: string;
-                  totalNumberOfPacks: number;
-                  onHold: boolean;
-                }>;
-              };
-        }>;
-      };
-};
+
+export type ItemsQuery = { __typename?: 'Queries', items: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, availableBatches: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean }> } }> } };
+
 
 export const InvoiceDocument = gql`
-  query invoice($id: String!) {
-    invoice(id: $id) {
-      ... on InvoiceNode {
-        id
+    query invoice($id: String!) {
+  invoice(id: $id) {
+    ... on InvoiceNode {
+      id
+      comment
+      confirmedDatetime
+      entryDatetime
+      finalisedDatetime
+      invoiceNumber
+      draftDatetime
+      allocatedDatetime
+      pickedDatetime
+      shippedDatetime
+      deliveredDatetime
+      hold
+      color
+      lines {
+        ... on InvoiceLineConnector {
+          nodes {
+            batch
+            costPricePerPack
+            expiryDate
+            id
+            itemCode
+            itemId
+            itemName
+            itemUnit
+            numberOfPacks
+            packSize
+            sellPricePerPack
+          }
+          totalCount
+        }
+      }
+      otherPartyId
+      otherPartyName
+      pricing {
+        ... on InvoicePricingNode {
+          __typename
+          totalAfterTax
+        }
+      }
+      status
+      theirReference
+      type
+    }
+    ... on NodeError {
+      __typename
+      error {
+        description
+      }
+    }
+  }
+}
+    `;
+export const InvoicesDocument = gql`
+    query invoices($first: Int, $offset: Int, $key: InvoiceSortFieldInput!, $desc: Boolean) {
+  invoices(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
+      }
+    }
+    ... on InvoiceConnector {
+      __typename
+      nodes {
         comment
         confirmedDatetime
         entryDatetime
-        finalisedDatetime
+        id
         invoiceNumber
-        draftDatetime
-        allocatedDatetime
-        pickedDatetime
-        shippedDatetime
-        deliveredDatetime
-        hold
-        color
-        lines {
-          ... on InvoiceLineConnector {
-            nodes {
-              batch
-              costPricePerPack
-              expiryDate
-              id
-              itemCode
-              itemId
-              itemName
-              itemUnit
-              numberOfPacks
-              packSize
-              sellPricePerPack
-            }
-            totalCount
-          }
-        }
         otherPartyId
         otherPartyName
+        status
+        color
+        theirReference
+        type
         pricing {
+          ... on NodeError {
+            __typename
+            error {
+              ... on RecordNotFound {
+                __typename
+                description
+              }
+              ... on DatabaseError {
+                __typename
+                description
+                fullError
+              }
+              description
+            }
+          }
           ... on InvoicePricingNode {
             __typename
             totalAfterTax
           }
         }
-        status
-        theirReference
-        type
       }
-      ... on NodeError {
-        __typename
-        error {
-          description
-        }
-      }
+      totalCount
     }
   }
-`;
-export const InvoicesDocument = gql`
-  query invoices(
-    $first: Int
-    $offset: Int
-    $key: InvoiceSortFieldInput!
-    $desc: Boolean
-  ) {
-    invoices(
-      page: { first: $first, offset: $offset }
-      sort: { key: $key, desc: $desc }
-    ) {
-      ... on ConnectorError {
-        __typename
-        error {
-          description
-          ... on DatabaseError {
-            __typename
-            description
-            fullError
-          }
-          ... on PaginationError {
-            __typename
-            description
-            rangeError {
-              description
-              field
-              max
-              min
-            }
-          }
-        }
-      }
-      ... on InvoiceConnector {
-        __typename
-        nodes {
-          comment
-          confirmedDatetime
-          entryDatetime
-          id
-          invoiceNumber
-          otherPartyId
-          otherPartyName
-          status
-          color
-          theirReference
-          type
-          pricing {
-            ... on NodeError {
-              __typename
-              error {
-                ... on RecordNotFound {
-                  __typename
-                  description
-                }
-                ... on DatabaseError {
-                  __typename
-                  description
-                  fullError
-                }
-                description
-              }
-            }
-            ... on InvoicePricingNode {
-              __typename
-              totalAfterTax
-            }
-          }
-        }
-        totalCount
-      }
-    }
-  }
-`;
+}
+    `;
 export const NamesDocument = gql`
-  query names(
-    $key: NameSortFieldInput!
-    $desc: Boolean
-    $first: Int
-    $offset: Int
+    query names($key: NameSortFieldInput!, $desc: Boolean, $first: Int, $offset: Int) {
+  names(
+    page: {first: $first, offset: $offset}
+    sort: {key: $key, desc: $desc}
+    filter: {isCustomer: true}
   ) {
-    names(
-      page: { first: $first, offset: $offset }
-      sort: { key: $key, desc: $desc }
-      filter: { isCustomer: true }
-    ) {
-      ... on ConnectorError {
-        __typename
-        error {
-          ... on DatabaseError {
-            __typename
-            description
-            fullError
-          }
-          description
-          ... on PaginationError {
-            __typename
-            description
-            rangeError {
-              description
-              field
-              max
-              min
-            }
-          }
-        }
-      }
-      ... on NameConnector {
-        __typename
-        nodes {
-          code
-          id
-          isCustomer
-          isSupplier
-          name
-        }
-        totalCount
-      }
-    }
-  }
-`;
-export const ItemsDocument = gql`
-  query items(
-    $first: Int
-    $offset: Int
-    $key: ItemSortFieldInput!
-    $desc: Boolean
-  ) {
-    items(
-      page: { first: $first, offset: $offset }
-      sort: { key: $key, desc: $desc }
-    ) {
-      ... on ConnectorError {
-        __typename
-        error {
-          description
-          ... on DatabaseError {
-            __typename
-            description
-            fullError
-          }
-          ... on PaginationError {
-            __typename
-            description
-            rangeError {
-              description
-              field
-              max
-              min
-            }
-          }
-        }
-      }
-      ... on ItemConnector {
-        __typename
-        nodes {
+    ... on ConnectorError {
+      __typename
+      error {
+        ... on DatabaseError {
           __typename
-          availableBatches {
-            ... on ConnectorError {
-              __typename
-              error {
-                description
-                ... on DatabaseError {
-                  __typename
-                  description
-                  fullError
-                }
-                ... on PaginationError {
-                  __typename
-                  description
-                  rangeError {
-                    description
-                    field
-                    max
-                    min
-                  }
-                }
-              }
-            }
-            ... on StockLineConnector {
-              nodes {
-                __typename
-                availableNumberOfPacks
-                batch
-                costPricePerPack
-                expiryDate
-                id
-                itemId
-                packSize
-                sellPricePerPack
-                storeId
-                totalNumberOfPacks
-                onHold
-              }
-              totalCount
-            }
-          }
-          code
-          id
-          isVisible
-          name
+          description
+          fullError
         }
-        totalCount
+        description
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
       }
     }
+    ... on NameConnector {
+      __typename
+      nodes {
+        code
+        id
+        isCustomer
+        isSupplier
+        name
+      }
+      totalCount
+    }
   }
-`;
+}
+    `;
+export const ItemsDocument = gql`
+    query items($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean) {
+  items(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
+      }
+    }
+    ... on ItemConnector {
+      __typename
+      nodes {
+        __typename
+        availableBatches {
+          __typename
+          ... on ConnectorError {
+            __typename
+            error {
+              description
+              ... on DatabaseError {
+                __typename
+                description
+                fullError
+              }
+              ... on PaginationError {
+                __typename
+                description
+                rangeError {
+                  description
+                  field
+                  max
+                  min
+                }
+              }
+            }
+          }
+          ... on StockLineConnector {
+            __typename
+            nodes {
+              __typename
+              availableNumberOfPacks
+              batch
+              costPricePerPack
+              expiryDate
+              id
+              itemId
+              packSize
+              sellPricePerPack
+              storeId
+              totalNumberOfPacks
+              onHold
+            }
+            totalCount
+          }
+        }
+        code
+        id
+        isVisible
+        name
+      }
+      totalCount
+    }
+  }
+}
+    `;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
+
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper
-) {
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    invoice(
-      variables: InvoiceQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<InvoiceQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<InvoiceQuery>(InvoiceDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'invoice'
-      );
+    invoice(variables: InvoiceQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoiceQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<InvoiceQuery>(InvoiceDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoice');
     },
-    invoices(
-      variables: InvoicesQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<InvoicesQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<InvoicesQuery>(InvoicesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'invoices'
-      );
+    invoices(variables: InvoicesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoicesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<InvoicesQuery>(InvoicesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoices');
     },
-    names(
-      variables: NamesQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<NamesQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<NamesQuery>(NamesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'names'
-      );
+    names(variables: NamesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<NamesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<NamesQuery>(NamesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'names');
     },
-    items(
-      variables: ItemsQueryVariables,
-      requestHeaders?: Dom.RequestInit['headers']
-    ): Promise<ItemsQuery> {
-      return withWrapper(
-        wrappedRequestHeaders =>
-          client.request<ItemsQuery>(ItemsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'items'
-      );
-    },
+    items(variables: ItemsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ItemsQuery>(ItemsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'items');
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -2,9 +2,15 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -16,36 +22,49 @@ export type Scalars = {
   NaiveDate: any;
 };
 
-export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'BatchIsReserved';
-  description: Scalars['String'];
-};
+export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'BatchIsReserved';
+    description: Scalars['String'];
+  };
 
-export type CanOnlyEditInvoicesInLoggedInStoreError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
-  description: Scalars['String'];
-};
+export type CanOnlyEditInvoicesInLoggedInStoreError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
+    description: Scalars['String'];
+  };
 
-export type CannotChangeInvoiceBackToDraft = UpdateSupplierInvoiceErrorInterface & {
-  __typename?: 'CannotChangeInvoiceBackToDraft';
-  description: Scalars['String'];
-};
+export type CannotChangeInvoiceBackToDraft =
+  UpdateSupplierInvoiceErrorInterface & {
+    __typename?: 'CannotChangeInvoiceBackToDraft';
+    description: Scalars['String'];
+  };
 
-export type CannotChangeStatusBackToDraftError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'CannotChangeStatusBackToDraftError';
-  description: Scalars['String'];
-};
+export type CannotChangeStatusBackToDraftError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'CannotChangeStatusBackToDraftError';
+    description: Scalars['String'];
+  };
 
-export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface & DeleteSupplierInvoiceErrorInterface & {
-  __typename?: 'CannotDeleteInvoiceWithLines';
-  description: Scalars['String'];
-  lines: InvoiceLineConnector;
-};
+export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface &
+  DeleteSupplierInvoiceErrorInterface & {
+    __typename?: 'CannotDeleteInvoiceWithLines';
+    description: Scalars['String'];
+    lines: InvoiceLineConnector;
+  };
 
-export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'CannotEditFinalisedInvoice';
-  description: Scalars['String'];
-};
+export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'CannotEditFinalisedInvoice';
+    description: Scalars['String'];
+  };
 
 export type ConnectorError = {
   __typename?: 'ConnectorError';
@@ -56,11 +75,24 @@ export type ConnectorErrorInterface = {
   description: Scalars['String'];
 };
 
-export type DatabaseError = ConnectorErrorInterface & DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'DatabaseError';
-  description: Scalars['String'];
-  fullError: Scalars['String'];
-};
+export type DatabaseError = ConnectorErrorInterface &
+  DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertCustomerInvoiceErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  NodeErrorInterface &
+  UpdateCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'DatabaseError';
+    description: Scalars['String'];
+    fullError: Scalars['String'];
+  };
 
 export type DatetimeFilterInput = {
   afterOrEqualTo?: Maybe<Scalars['DateTime']>;
@@ -91,9 +123,13 @@ export type DeleteCustomerInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteCustomerInvoiceLineResponse = DeleteCustomerInvoiceLineError | DeleteResponse;
+export type DeleteCustomerInvoiceLineResponse =
+  | DeleteCustomerInvoiceLineError
+  | DeleteResponse;
 
-export type DeleteCustomerInvoiceResponse = DeleteCustomerInvoiceError | DeleteResponse;
+export type DeleteCustomerInvoiceResponse =
+  | DeleteCustomerInvoiceError
+  | DeleteResponse;
 
 export type DeleteResponse = {
   __typename?: 'DeleteResponse';
@@ -127,9 +163,13 @@ export type DeleteSupplierInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteSupplierInvoiceLineResponse = DeleteResponse | DeleteSupplierInvoiceLineError;
+export type DeleteSupplierInvoiceLineResponse =
+  | DeleteResponse
+  | DeleteSupplierInvoiceLineError;
 
-export type DeleteSupplierInvoiceResponse = DeleteResponse | DeleteSupplierInvoiceError;
+export type DeleteSupplierInvoiceResponse =
+  | DeleteResponse
+  | DeleteSupplierInvoiceError;
 
 export type EqualFilterBoolInput = {
   equalTo?: Maybe<Scalars['Boolean']>;
@@ -147,23 +187,33 @@ export type EqualFilterStringInput = {
   equalTo?: Maybe<Scalars['String']>;
 };
 
-export type FinalisedInvoiceIsNotEditableError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'FinalisedInvoiceIsNotEditableError';
-  description: Scalars['String'];
-};
+export type FinalisedInvoiceIsNotEditableError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'FinalisedInvoiceIsNotEditableError';
+    description: Scalars['String'];
+  };
 
 export enum ForeignKey {
   InvoiceId = 'INVOICE_ID',
   ItemId = 'ITEM_ID',
   OtherPartyId = 'OTHER_PARTY_ID',
-  StockLineId = 'STOCK_LINE_ID'
+  StockLineId = 'STOCK_LINE_ID',
 }
 
-export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'ForeignKeyError';
-  description: Scalars['String'];
-  key: ForeignKey;
-};
+export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertCustomerInvoiceErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'ForeignKeyError';
+    description: Scalars['String'];
+    key: ForeignKey;
+  };
 
 export type InsertCustomerInvoiceError = {
   __typename?: 'InsertCustomerInvoiceError';
@@ -199,9 +249,15 @@ export type InsertCustomerInvoiceLineInput = {
   stockLineId: Scalars['String'];
 };
 
-export type InsertCustomerInvoiceLineResponse = InsertCustomerInvoiceLineError | InvoiceLineNode | NodeError;
+export type InsertCustomerInvoiceLineResponse =
+  | InsertCustomerInvoiceLineError
+  | InvoiceLineNode
+  | NodeError;
 
-export type InsertCustomerInvoiceResponse = InsertCustomerInvoiceError | InvoiceNode | NodeError;
+export type InsertCustomerInvoiceResponse =
+  | InsertCustomerInvoiceError
+  | InvoiceNode
+  | NodeError;
 
 export type InsertSupplierInvoiceError = {
   __typename?: 'InsertSupplierInvoiceError';
@@ -241,9 +297,15 @@ export type InsertSupplierInvoiceLineInput = {
   sellPricePerPack: Scalars['Float'];
 };
 
-export type InsertSupplierInvoiceLineResponse = InsertSupplierInvoiceLineError | InvoiceLineNode | NodeError;
+export type InsertSupplierInvoiceLineResponse =
+  | InsertSupplierInvoiceLineError
+  | InvoiceLineNode
+  | NodeError;
 
-export type InsertSupplierInvoiceResponse = InsertSupplierInvoiceError | InvoiceNode | NodeError;
+export type InsertSupplierInvoiceResponse =
+  | InsertSupplierInvoiceError
+  | InvoiceNode
+  | NodeError;
 
 export type InvoiceConnector = {
   __typename?: 'InvoiceConnector';
@@ -251,10 +313,19 @@ export type InvoiceConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceDoesNotBelongToCurrentStore = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'InvoiceDoesNotBelongToCurrentStore';
-  description: Scalars['String'];
-};
+export type InvoiceDoesNotBelongToCurrentStore =
+  DeleteCustomerInvoiceErrorInterface &
+    DeleteCustomerInvoiceLineErrorInterface &
+    DeleteSupplierInvoiceErrorInterface &
+    DeleteSupplierInvoiceLineErrorInterface &
+    InsertCustomerInvoiceLineErrorInterface &
+    InsertSupplierInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface &
+    UpdateSupplierInvoiceErrorInterface &
+    UpdateSupplierInvoiceLineErrorInterface & {
+      __typename?: 'InvoiceDoesNotBelongToCurrentStore';
+      description: Scalars['String'];
+    };
 
 export type InvoiceFilterInput = {
   comment?: Maybe<SimpleStringFilterInput>;
@@ -268,11 +339,15 @@ export type InvoiceFilterInput = {
   type?: Maybe<EqualFilterInvoiceTypeInput>;
 };
 
-export type InvoiceLineBelongsToAnotherInvoice = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'InvoiceLineBelongsToAnotherInvoice';
-  description: Scalars['String'];
-  invoice: InvoiceResponse;
-};
+export type InvoiceLineBelongsToAnotherInvoice =
+  DeleteCustomerInvoiceLineErrorInterface &
+    DeleteSupplierInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface &
+    UpdateSupplierInvoiceLineErrorInterface & {
+      __typename?: 'InvoiceLineBelongsToAnotherInvoice';
+      description: Scalars['String'];
+      invoice: InvoiceResponse;
+    };
 
 export type InvoiceLineConnector = {
   __typename?: 'InvoiceLineConnector';
@@ -280,11 +355,12 @@ export type InvoiceLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceLineHasNoStockLineError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'InvoiceLineHasNoStockLineError';
-  description: Scalars['String'];
-  invoiceLineId: Scalars['String'];
-};
+export type InvoiceLineHasNoStockLineError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'InvoiceLineHasNoStockLineError';
+    description: Scalars['String'];
+    invoiceLineId: Scalars['String'];
+  };
 
 export type InvoiceLineNode = {
   __typename?: 'InvoiceLineNode';
@@ -338,12 +414,12 @@ export enum InvoiceNodeStatus {
   Draft = 'DRAFT',
   Finalised = 'FINALISED',
   Picked = 'PICKED',
-  Shipped = 'SHIPPED'
+  Shipped = 'SHIPPED',
 }
 
 export enum InvoiceNodeType {
   CustomerInvoice = 'CUSTOMER_INVOICE',
-  SupplierInvoice = 'SUPPLIER_INVOICE'
+  SupplierInvoice = 'SUPPLIER_INVOICE',
 }
 
 export type InvoicePriceResponse = InvoicePricingNode | NodeError;
@@ -360,7 +436,7 @@ export enum InvoiceSortFieldInput {
   EntryDatetime = 'ENTRY_DATETIME',
   FinalisedDateTime = 'FINALISED_DATE_TIME',
   Status = 'STATUS',
-  Type = 'TYPE'
+  Type = 'TYPE',
 }
 
 export type InvoiceSortInput = {
@@ -376,10 +452,12 @@ export type ItemConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type ItemDoesNotMatchStockLine = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'ItemDoesNotMatchStockLine';
-  description: Scalars['String'];
-};
+export type ItemDoesNotMatchStockLine =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'ItemDoesNotMatchStockLine';
+      description: Scalars['String'];
+    };
 
 export type ItemFilterInput = {
   code?: Maybe<SimpleStringFilterInput>;
@@ -398,7 +476,7 @@ export type ItemNode = {
 
 export enum ItemSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME'
+  Name = 'NAME',
 }
 
 export type ItemSortInput = {
@@ -408,10 +486,11 @@ export type ItemSortInput = {
 
 export type ItemsResponse = ConnectorError | ItemConnector;
 
-export type LineDoesNotReferenceStockLine = UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'LineDoesNotReferenceStockLine';
-  description: Scalars['String'];
-};
+export type LineDoesNotReferenceStockLine =
+  UpdateCustomerInvoiceLineErrorInterface & {
+    __typename?: 'LineDoesNotReferenceStockLine';
+    description: Scalars['String'];
+  };
 
 export type Mutations = {
   __typename?: 'Mutations';
@@ -429,61 +508,49 @@ export type Mutations = {
   updateSupplierInvoiceLine: UpdateSupplierInvoiceLineResponse;
 };
 
-
 export type MutationsDeleteCustomerInvoiceArgs = {
   id: Scalars['String'];
 };
-
 
 export type MutationsDeleteCustomerInvoiceLineArgs = {
   input: DeleteCustomerInvoiceLineInput;
 };
 
-
 export type MutationsDeleteSupplierInvoiceArgs = {
   input: DeleteSupplierInvoiceInput;
 };
-
 
 export type MutationsDeleteSupplierInvoiceLineArgs = {
   input: DeleteSupplierInvoiceLineInput;
 };
 
-
 export type MutationsInsertCustomerInvoiceArgs = {
   input: InsertCustomerInvoiceInput;
 };
-
 
 export type MutationsInsertCustomerInvoiceLineArgs = {
   input: InsertCustomerInvoiceLineInput;
 };
 
-
 export type MutationsInsertSupplierInvoiceArgs = {
   input: InsertSupplierInvoiceInput;
 };
-
 
 export type MutationsInsertSupplierInvoiceLineArgs = {
   input: InsertSupplierInvoiceLineInput;
 };
 
-
 export type MutationsUpdateCustomerInvoiceArgs = {
   input: UpdateCustomerInvoiceInput;
 };
-
 
 export type MutationsUpdateCustomerInvoiceLineArgs = {
   input: UpdateCustomerInvoiceLineInput;
 };
 
-
 export type MutationsUpdateSupplierInvoiceArgs = {
   input: UpdateSupplierInvoiceInput;
 };
-
 
 export type MutationsUpdateSupplierInvoiceLineArgs = {
   input: UpdateSupplierInvoiceLineInput;
@@ -513,7 +580,7 @@ export type NameNode = {
 
 export enum NameSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME'
+  Name = 'NAME',
 }
 
 export type NameSortInput = {
@@ -532,44 +599,57 @@ export type NodeErrorInterface = {
   description: Scalars['String'];
 };
 
-export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'NotACustomerInvoice';
-  description: Scalars['String'];
-};
+export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface & {
+    __typename?: 'NotACustomerInvoice';
+    description: Scalars['String'];
+  };
 
 export type NotACustomerInvoiceError = UpdateCustomerInvoiceErrorInterface & {
   __typename?: 'NotACustomerInvoiceError';
   description: Scalars['String'];
 };
 
-export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'NotASupplierInvoice';
-  description: Scalars['String'];
-};
+export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'NotASupplierInvoice';
+    description: Scalars['String'];
+  };
 
-export type NotEnoughStockForReduction = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'NotEnoughStockForReduction';
-  batch: StockLineResponse;
-  description: Scalars['String'];
-  line?: Maybe<InvoiceLineResponse>;
-};
+export type NotEnoughStockForReduction =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'NotEnoughStockForReduction';
+      batch: StockLineResponse;
+      description: Scalars['String'];
+      line?: Maybe<InvoiceLineResponse>;
+    };
 
-export type OtherPartyCannotBeThisStoreError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'OtherPartyCannotBeThisStoreError';
-  description: Scalars['String'];
-};
+export type OtherPartyCannotBeThisStoreError =
+  InsertCustomerInvoiceErrorInterface &
+    UpdateCustomerInvoiceErrorInterface & {
+      __typename?: 'OtherPartyCannotBeThisStoreError';
+      description: Scalars['String'];
+    };
 
-export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'OtherPartyNotACustomerError';
-  description: Scalars['String'];
-  otherParty: NameNode;
-};
+export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'OtherPartyNotACustomerError';
+    description: Scalars['String'];
+    otherParty: NameNode;
+  };
 
-export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface & UpdateSupplierInvoiceErrorInterface & {
-  __typename?: 'OtherPartyNotASupplier';
-  description: Scalars['String'];
-  otherParty: NameNode;
-};
+export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceErrorInterface & {
+    __typename?: 'OtherPartyNotASupplier';
+    description: Scalars['String'];
+    otherParty: NameNode;
+  };
 
 export type PaginationError = ConnectorErrorInterface & {
   __typename?: 'PaginationError';
@@ -590,11 +670,9 @@ export type Queries = {
   names: NamesResponse;
 };
 
-
 export type QueriesInvoiceArgs = {
   id: Scalars['String'];
 };
-
 
 export type QueriesInvoicesArgs = {
   filter?: Maybe<InvoiceFilterInput>;
@@ -602,13 +680,11 @@ export type QueriesInvoicesArgs = {
   sort?: Maybe<Array<InvoiceSortInput>>;
 };
 
-
 export type QueriesItemsArgs = {
   filter?: Maybe<ItemFilterInput>;
   page?: Maybe<PaginationInput>;
   sort?: Maybe<Array<ItemSortInput>>;
 };
-
 
 export type QueriesNamesArgs = {
   filter?: Maybe<NameFilterInput>;
@@ -616,40 +692,56 @@ export type QueriesNamesArgs = {
   sort?: Maybe<Array<NameSortInput>>;
 };
 
-export type RangeError = InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'RangeError';
-  description: Scalars['String'];
-  field: RangeField;
-  max?: Maybe<Scalars['Int']>;
-  min?: Maybe<Scalars['Int']>;
-};
+export type RangeError = InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'RangeError';
+    description: Scalars['String'];
+    field: RangeField;
+    max?: Maybe<Scalars['Int']>;
+    min?: Maybe<Scalars['Int']>;
+  };
 
 export enum RangeField {
   First = 'FIRST',
   NumberOfPacks = 'NUMBER_OF_PACKS',
-  PackSize = 'PACK_SIZE'
+  PackSize = 'PACK_SIZE',
 }
 
-export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & {
-  __typename?: 'RecordAlreadyExist';
-  description: Scalars['String'];
-};
+export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface & {
+    __typename?: 'RecordAlreadyExist';
+    description: Scalars['String'];
+  };
 
-export type RecordNotFound = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'RecordNotFound';
-  description: Scalars['String'];
-};
+export type RecordNotFound = DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  NodeErrorInterface &
+  UpdateCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'RecordNotFound';
+    description: Scalars['String'];
+  };
 
 export type SimpleStringFilterInput = {
   equalTo?: Maybe<Scalars['String']>;
   like?: Maybe<Scalars['String']>;
 };
 
-export type StockLineAlreadyExistsInInvoice = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'StockLineAlreadyExistsInInvoice';
-  description: Scalars['String'];
-  line: InvoiceLineResponse;
-};
+export type StockLineAlreadyExistsInInvoice =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'StockLineAlreadyExistsInInvoice';
+      description: Scalars['String'];
+      line: InvoiceLineResponse;
+    };
 
 export type StockLineConnector = {
   __typename?: 'StockLineConnector';
@@ -657,10 +749,12 @@ export type StockLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type StockLineDoesNotBelongToCurrentStore = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'StockLineDoesNotBelongToCurrentStore';
-  description: Scalars['String'];
-};
+export type StockLineDoesNotBelongToCurrentStore =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'StockLineDoesNotBelongToCurrentStore';
+      description: Scalars['String'];
+    };
 
 export type StockLineNode = {
   __typename?: 'StockLineNode';
@@ -716,9 +810,15 @@ export type UpdateCustomerInvoiceLineInput = {
   stockLineId?: Maybe<Scalars['String']>;
 };
 
-export type UpdateCustomerInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateCustomerInvoiceLineError;
+export type UpdateCustomerInvoiceLineResponse =
+  | InvoiceLineNode
+  | NodeError
+  | UpdateCustomerInvoiceLineError;
 
-export type UpdateCustomerInvoiceResponse = InvoiceNode | NodeError | UpdateCustomerInvoiceError;
+export type UpdateCustomerInvoiceResponse =
+  | InvoiceNode
+  | NodeError
+  | UpdateCustomerInvoiceError;
 
 export type UpdateSupplierInvoiceError = {
   __typename?: 'UpdateSupplierInvoiceError';
@@ -758,16 +858,74 @@ export type UpdateSupplierInvoiceLineInput = {
   sellPricePerPack?: Maybe<Scalars['Float']>;
 };
 
-export type UpdateSupplierInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateSupplierInvoiceLineError;
+export type UpdateSupplierInvoiceLineResponse =
+  | InvoiceLineNode
+  | NodeError
+  | UpdateSupplierInvoiceLineError;
 
-export type UpdateSupplierInvoiceResponse = InvoiceNode | NodeError | UpdateSupplierInvoiceError;
+export type UpdateSupplierInvoiceResponse =
+  | InvoiceNode
+  | NodeError
+  | UpdateSupplierInvoiceError;
 
 export type InvoiceQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-
-export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename?: 'InvoiceNode', id: string, comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, finalisedDatetime?: any | null | undefined, invoiceNumber: number, draftDatetime?: any | null | undefined, allocatedDatetime?: any | null | undefined, pickedDatetime?: any | null | undefined, shippedDatetime?: any | null | undefined, deliveredDatetime?: any | null | undefined, hold: boolean, color: string, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, lines: { __typename?: 'ConnectorError' } | { __typename?: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemCode: string, itemId: string, itemName: string, itemUnit: string, numberOfPacks: number, packSize: number, sellPricePerPack: number }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename?: 'NodeError' } } | { __typename: 'NodeError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'RecordNotFound', description: string } } };
+export type InvoiceQuery = {
+  __typename?: 'Queries';
+  invoice:
+    | {
+        __typename?: 'InvoiceNode';
+        id: string;
+        comment?: string | null | undefined;
+        confirmedDatetime?: any | null | undefined;
+        entryDatetime: any;
+        finalisedDatetime?: any | null | undefined;
+        invoiceNumber: number;
+        draftDatetime?: any | null | undefined;
+        allocatedDatetime?: any | null | undefined;
+        pickedDatetime?: any | null | undefined;
+        shippedDatetime?: any | null | undefined;
+        deliveredDatetime?: any | null | undefined;
+        hold: boolean;
+        color: string;
+        otherPartyId: string;
+        otherPartyName: string;
+        status: InvoiceNodeStatus;
+        theirReference?: string | null | undefined;
+        type: InvoiceNodeType;
+        lines:
+          | { __typename?: 'ConnectorError' }
+          | {
+              __typename?: 'InvoiceLineConnector';
+              totalCount: number;
+              nodes: Array<{
+                __typename?: 'InvoiceLineNode';
+                batch?: string | null | undefined;
+                costPricePerPack: number;
+                expiryDate?: any | null | undefined;
+                id: string;
+                itemCode: string;
+                itemId: string;
+                itemName: string;
+                itemUnit: string;
+                numberOfPacks: number;
+                packSize: number;
+                sellPricePerPack: number;
+              }>;
+            };
+        pricing:
+          | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
+          | { __typename?: 'NodeError' };
+      }
+    | {
+        __typename: 'NodeError';
+        error:
+          | { __typename?: 'DatabaseError'; description: string }
+          | { __typename?: 'RecordNotFound'; description: string };
+      };
+};
 
 export type InvoicesQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -776,8 +934,60 @@ export type InvoicesQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type InvoicesQuery = { __typename?: 'Queries', invoices: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceNode', comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, color: string, theirReference?: string | null | undefined, type: InvoiceNodeType, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } }> } };
+export type InvoicesQuery = {
+  __typename?: 'Queries';
+  invoices:
+    | {
+        __typename: 'ConnectorError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | {
+              __typename: 'PaginationError';
+              description: string;
+              rangeError: {
+                __typename?: 'RangeError';
+                description: string;
+                field: RangeField;
+                max?: number | null | undefined;
+                min?: number | null | undefined;
+              };
+            };
+      }
+    | {
+        __typename: 'InvoiceConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename?: 'InvoiceNode';
+          comment?: string | null | undefined;
+          confirmedDatetime?: any | null | undefined;
+          entryDatetime: any;
+          id: string;
+          invoiceNumber: number;
+          otherPartyId: string;
+          otherPartyName: string;
+          status: InvoiceNodeStatus;
+          color: string;
+          theirReference?: string | null | undefined;
+          type: InvoiceNodeType;
+          pricing:
+            | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
+            | {
+                __typename: 'NodeError';
+                error:
+                  | {
+                      __typename: 'DatabaseError';
+                      description: string;
+                      fullError: string;
+                    }
+                  | { __typename: 'RecordNotFound'; description: string };
+              };
+        }>;
+      };
+};
 
 export type NamesQueryVariables = Exact<{
   key: NameSortFieldInput;
@@ -786,8 +996,42 @@ export type NamesQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
 }>;
 
-
-export type NamesQuery = { __typename?: 'Queries', names: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'NameConnector', totalCount: number, nodes: Array<{ __typename?: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, name: string }> } };
+export type NamesQuery = {
+  __typename?: 'Queries';
+  names:
+    | {
+        __typename: 'ConnectorError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | {
+              __typename: 'PaginationError';
+              description: string;
+              rangeError: {
+                __typename?: 'RangeError';
+                description: string;
+                field: RangeField;
+                max?: number | null | undefined;
+                min?: number | null | undefined;
+              };
+            };
+      }
+    | {
+        __typename: 'NameConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename?: 'NameNode';
+          code: string;
+          id: string;
+          isCustomer: boolean;
+          isSupplier: boolean;
+          name: string;
+        }>;
+      };
+};
 
 export type ItemsQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -796,271 +1040,408 @@ export type ItemsQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type ItemsQuery = { __typename?: 'Queries', items: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, availableBatches: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename?: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean }> } }> } };
-
+export type ItemsQuery = {
+  __typename?: 'Queries';
+  items:
+    | {
+        __typename: 'ConnectorError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | {
+              __typename: 'PaginationError';
+              description: string;
+              rangeError: {
+                __typename?: 'RangeError';
+                description: string;
+                field: RangeField;
+                max?: number | null | undefined;
+                min?: number | null | undefined;
+              };
+            };
+      }
+    | {
+        __typename: 'ItemConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename: 'ItemNode';
+          code: string;
+          id: string;
+          isVisible: boolean;
+          name: string;
+          availableBatches:
+            | {
+                __typename: 'ConnectorError';
+                error:
+                  | {
+                      __typename: 'DatabaseError';
+                      description: string;
+                      fullError: string;
+                    }
+                  | {
+                      __typename: 'PaginationError';
+                      description: string;
+                      rangeError: {
+                        __typename?: 'RangeError';
+                        description: string;
+                        field: RangeField;
+                        max?: number | null | undefined;
+                        min?: number | null | undefined;
+                      };
+                    };
+              }
+            | {
+                __typename?: 'StockLineConnector';
+                totalCount: number;
+                nodes: Array<{
+                  __typename: 'StockLineNode';
+                  availableNumberOfPacks: number;
+                  batch?: string | null | undefined;
+                  costPricePerPack: number;
+                  expiryDate?: any | null | undefined;
+                  id: string;
+                  itemId: string;
+                  packSize: number;
+                  sellPricePerPack: number;
+                  storeId: string;
+                  totalNumberOfPacks: number;
+                  onHold: boolean;
+                }>;
+              };
+        }>;
+      };
+};
 
 export const InvoiceDocument = gql`
-    query invoice($id: String!) {
-  invoice(id: $id) {
-    ... on InvoiceNode {
-      id
-      comment
-      confirmedDatetime
-      entryDatetime
-      finalisedDatetime
-      invoiceNumber
-      draftDatetime
-      allocatedDatetime
-      pickedDatetime
-      shippedDatetime
-      deliveredDatetime
-      hold
-      color
-      lines {
-        ... on InvoiceLineConnector {
-          nodes {
-            batch
-            costPricePerPack
-            expiryDate
-            id
-            itemCode
-            itemId
-            itemName
-            itemUnit
-            numberOfPacks
-            packSize
-            sellPricePerPack
-          }
-          totalCount
-        }
-      }
-      otherPartyId
-      otherPartyName
-      pricing {
-        ... on InvoicePricingNode {
-          __typename
-          totalAfterTax
-        }
-      }
-      status
-      theirReference
-      type
-    }
-    ... on NodeError {
-      __typename
-      error {
-        description
-      }
-    }
-  }
-}
-    `;
-export const InvoicesDocument = gql`
-    query invoices($first: Int, $offset: Int, $key: InvoiceSortFieldInput!, $desc: Boolean) {
-  invoices(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
-    ... on ConnectorError {
-      __typename
-      error {
-        description
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        ... on PaginationError {
-          __typename
-          description
-          rangeError {
-            description
-            field
-            max
-            min
-          }
-        }
-      }
-    }
-    ... on InvoiceConnector {
-      __typename
-      nodes {
+  query invoice($id: String!) {
+    invoice(id: $id) {
+      ... on InvoiceNode {
+        id
         comment
         confirmedDatetime
         entryDatetime
-        id
+        finalisedDatetime
         invoiceNumber
+        draftDatetime
+        allocatedDatetime
+        pickedDatetime
+        shippedDatetime
+        deliveredDatetime
+        hold
+        color
+        lines {
+          ... on InvoiceLineConnector {
+            nodes {
+              batch
+              costPricePerPack
+              expiryDate
+              id
+              itemCode
+              itemId
+              itemName
+              itemUnit
+              numberOfPacks
+              packSize
+              sellPricePerPack
+            }
+            totalCount
+          }
+        }
         otherPartyId
         otherPartyName
-        status
-        color
-        theirReference
-        type
         pricing {
-          ... on NodeError {
-            __typename
-            error {
-              ... on RecordNotFound {
-                __typename
-                description
-              }
-              ... on DatabaseError {
-                __typename
-                description
-                fullError
-              }
-              description
-            }
-          }
           ... on InvoicePricingNode {
             __typename
             totalAfterTax
           }
         }
+        status
+        theirReference
+        type
       }
-      totalCount
-    }
-  }
-}
-    `;
-export const NamesDocument = gql`
-    query names($key: NameSortFieldInput!, $desc: Boolean, $first: Int, $offset: Int) {
-  names(
-    page: {first: $first, offset: $offset}
-    sort: {key: $key, desc: $desc}
-    filter: {isCustomer: true}
-  ) {
-    ... on ConnectorError {
-      __typename
-      error {
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        description
-        ... on PaginationError {
-          __typename
-          description
-          rangeError {
-            description
-            field
-            max
-            min
-          }
-        }
-      }
-    }
-    ... on NameConnector {
-      __typename
-      nodes {
-        code
-        id
-        isCustomer
-        isSupplier
-        name
-      }
-      totalCount
-    }
-  }
-}
-    `;
-export const ItemsDocument = gql`
-    query items($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean) {
-  items(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
-    ... on ConnectorError {
-      __typename
-      error {
-        description
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        ... on PaginationError {
-          __typename
-          description
-          rangeError {
-            description
-            field
-            max
-            min
-          }
-        }
-      }
-    }
-    ... on ItemConnector {
-      __typename
-      nodes {
+      ... on NodeError {
         __typename
-        availableBatches {
-          ... on ConnectorError {
+        error {
+          description
+        }
+      }
+    }
+  }
+`;
+export const InvoicesDocument = gql`
+  query invoices(
+    $first: Int
+    $offset: Int
+    $key: InvoiceSortFieldInput!
+    $desc: Boolean
+  ) {
+    invoices(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+    ) {
+      ... on ConnectorError {
+        __typename
+        error {
+          description
+          ... on DatabaseError {
             __typename
-            error {
+            description
+            fullError
+          }
+          ... on PaginationError {
+            __typename
+            description
+            rangeError {
               description
-              ... on DatabaseError {
-                __typename
-                description
-                fullError
-              }
-              ... on PaginationError {
-                __typename
-                description
-                rangeError {
+              field
+              max
+              min
+            }
+          }
+        }
+      }
+      ... on InvoiceConnector {
+        __typename
+        nodes {
+          comment
+          confirmedDatetime
+          entryDatetime
+          id
+          invoiceNumber
+          otherPartyId
+          otherPartyName
+          status
+          color
+          theirReference
+          type
+          pricing {
+            ... on NodeError {
+              __typename
+              error {
+                ... on RecordNotFound {
+                  __typename
                   description
-                  field
-                  max
-                  min
+                }
+                ... on DatabaseError {
+                  __typename
+                  description
+                  fullError
+                }
+                description
+              }
+            }
+            ... on InvoicePricingNode {
+              __typename
+              totalAfterTax
+            }
+          }
+        }
+        totalCount
+      }
+    }
+  }
+`;
+export const NamesDocument = gql`
+  query names(
+    $key: NameSortFieldInput!
+    $desc: Boolean
+    $first: Int
+    $offset: Int
+  ) {
+    names(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+      filter: { isCustomer: true }
+    ) {
+      ... on ConnectorError {
+        __typename
+        error {
+          ... on DatabaseError {
+            __typename
+            description
+            fullError
+          }
+          description
+          ... on PaginationError {
+            __typename
+            description
+            rangeError {
+              description
+              field
+              max
+              min
+            }
+          }
+        }
+      }
+      ... on NameConnector {
+        __typename
+        nodes {
+          code
+          id
+          isCustomer
+          isSupplier
+          name
+        }
+        totalCount
+      }
+    }
+  }
+`;
+export const ItemsDocument = gql`
+  query items(
+    $first: Int
+    $offset: Int
+    $key: ItemSortFieldInput!
+    $desc: Boolean
+  ) {
+    items(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+    ) {
+      ... on ConnectorError {
+        __typename
+        error {
+          description
+          ... on DatabaseError {
+            __typename
+            description
+            fullError
+          }
+          ... on PaginationError {
+            __typename
+            description
+            rangeError {
+              description
+              field
+              max
+              min
+            }
+          }
+        }
+      }
+      ... on ItemConnector {
+        __typename
+        nodes {
+          __typename
+          availableBatches {
+            ... on ConnectorError {
+              __typename
+              error {
+                description
+                ... on DatabaseError {
+                  __typename
+                  description
+                  fullError
+                }
+                ... on PaginationError {
+                  __typename
+                  description
+                  rangeError {
+                    description
+                    field
+                    max
+                    min
+                  }
                 }
               }
             }
-          }
-          ... on StockLineConnector {
-            nodes {
-              __typename
-              availableNumberOfPacks
-              batch
-              costPricePerPack
-              expiryDate
-              id
-              itemId
-              packSize
-              sellPricePerPack
-              storeId
-              totalNumberOfPacks
-              onHold
+            ... on StockLineConnector {
+              nodes {
+                __typename
+                availableNumberOfPacks
+                batch
+                costPricePerPack
+                expiryDate
+                id
+                itemId
+                packSize
+                sellPricePerPack
+                storeId
+                totalNumberOfPacks
+                onHold
+              }
+              totalCount
             }
-            totalCount
           }
+          code
+          id
+          isVisible
+          name
         }
-        code
-        id
-        isVisible
-        name
+        totalCount
       }
-      totalCount
     }
   }
-}
-    `;
+`;
 
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
-
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string
+) => Promise<T>;
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper
+) {
   return {
-    invoice(variables: InvoiceQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoiceQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<InvoiceQuery>(InvoiceDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoice');
+    invoice(
+      variables: InvoiceQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<InvoiceQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<InvoiceQuery>(InvoiceDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'invoice'
+      );
     },
-    invoices(variables: InvoicesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoicesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<InvoicesQuery>(InvoicesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoices');
+    invoices(
+      variables: InvoicesQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<InvoicesQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<InvoicesQuery>(InvoicesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'invoices'
+      );
     },
-    names(variables: NamesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<NamesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<NamesQuery>(NamesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'names');
+    names(
+      variables: NamesQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<NamesQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<NamesQuery>(NamesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'names'
+      );
     },
-    items(variables: ItemsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ItemsQuery>(ItemsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'items');
-    }
+    items(
+      variables: ItemsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ItemsQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<ItemsQuery>(ItemsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'items'
+      );
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -59,7 +59,7 @@ const BatchesRow: React.FC<BatchesRowProps> = ({ batch, label, onChange }) => {
     onChange: onChangeValue,
   });
 
-  const expiryDate = new Date(batch.expiryDate);
+  const expiryDate = new Date(batch.expiryDate ?? '');
   const isDisabled = batch.availableNumberOfPacks === 0 || batch.onHold;
 
   // TODO format currency correctly

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -95,7 +95,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
     setPackSize(newPackSize);
   };
 
-  selectedItem?.availableBatches.nodes.forEach(batch => {
+  selectedItem?.availableBatches.forEach(batch => {
     if (packSizes.every(pack => pack !== batch.packSize)) {
       packSizes.push(batch.packSize);
     }

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -27,7 +27,7 @@ interface ItemDetailsModalProps {
 export const getInvoiceLine = (
   id: string,
   item: Item,
-  line: { id: string; expiryDate: string },
+  line: { id: string; expiryDate?: string | null },
   quantity: number
 ): InvoiceLine => ({
   id,
@@ -99,8 +99,8 @@ const sortByDisabledThenExpiryDate = (a: BatchRow, b: BatchRow) => {
     return 1;
   }
 
-  const expiryA = new Date(a.expiryDate);
-  const expiryB = new Date(b.expiryDate);
+  const expiryA = new Date(a.expiryDate ?? '');
+  const expiryB = new Date(b.expiryDate ?? '');
 
   if (expiryA < expiryB) {
     return -1;
@@ -137,7 +137,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   ) => {
     setSelectedItem(value);
     setBatchRows(
-      (value?.availableBatches.nodes || [])
+      (value?.availableBatches || [])
         .map(batch => ({ ...batch, quantity: 0 }))
         .sort(sortByDisabledThenExpiryDate)
     );

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -5,12 +5,14 @@ import {
   Grid,
   InvoiceLine,
   Item,
-  gql,
-  request,
+  getSdk,
+  GraphQLClient,
   useForm,
   useQuery,
   useDialog,
   FormProvider,
+  SortBy,
+  ItemSortFieldInput,
 } from '@openmsupply-client/common';
 import { Environment } from '@openmsupply-client/config';
 import { BatchesTable } from './BatchesTable';
@@ -45,48 +47,49 @@ export const getInvoiceLine = (
   expiry: line.expiryDate,
 });
 
-const listQueryFn = async (): Promise<Item[]> => {
-  const { items } = await request(
-    Environment.API_URL,
-    gql`
-      query items {
-        items {
-          ... on ItemConnector {
-            nodes {
-              id
-              code
-              availableBatches {
-                ... on StockLineConnector {
-                  nodes {
-                    availableNumberOfPacks
-                    batch
-                    costPricePerPack
-                    expiryDate
-                    id
-                    itemId
-                    packSize
-                    sellPricePerPack
-                    storeId
-                    totalNumberOfPacks
-                  }
-                }
-                ... on ConnectorError {
-                  __typename
-                  error {
-                    description
-                  }
-                }
-              }
-              isVisible
-              name
-            }
-          }
-        }
-      }
-    `
-  );
+const client = new GraphQLClient(Environment.API_URL);
+const api = getSdk(client);
 
-  return items.nodes;
+const listQueryFn = async ({
+  first = 999,
+  offset,
+  sortBy,
+}: {
+  first?: number;
+  offset?: number;
+  sortBy?: SortBy<Item>;
+} = {}): Promise<{
+  nodes: Item[];
+  totalCount: number;
+}> => {
+  // TODO: Need to add a `sortByKey` to the Column type
+  const key =
+    sortBy?.key === 'name' ? ItemSortFieldInput.Name : ItemSortFieldInput.Code;
+
+  const { items } = await api.items({
+    first,
+    offset,
+    key,
+    desc: sortBy?.isDesc,
+  });
+
+  if (items.__typename === 'ItemConnector') {
+    const itemRows: Item[] = items.nodes.map(item => ({
+      ...item,
+      availableQuantity: 0,
+      unit: '',
+      availableBatches:
+        item.availableBatches.__typename === 'StockLineConnector'
+          ? item.availableBatches.nodes
+          : [],
+    }));
+
+    return {
+      totalCount: items.totalCount,
+      nodes: itemRows,
+    };
+  }
+  throw new Error(items.error.description);
 };
 
 const sortByDisabledThenExpiryDate = (a: BatchRow, b: BatchRow) => {
@@ -146,7 +149,8 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
     setValue('availableQuantity', value?.availableQuantity || 0);
   };
 
-  const { data, isLoading } = useQuery(['item', 'list'], listQueryFn);
+  const { data, isLoading } = useQuery(['item', 'list'], () => listQueryFn());
+
   const onReset = () => {
     reset();
     setBatchRows([]);
@@ -280,7 +284,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
           <Grid container gap={0.5}>
             <ItemDetailsForm
               invoiceLine={invoiceLine}
-              items={data}
+              items={data?.nodes ?? []}
               onChangeItem={onChangeItem}
               onChangeQuantity={setQuantity}
               register={register}

--- a/packages/mock-server/src/data/data.ts
+++ b/packages/mock-server/src/data/data.ts
@@ -181,6 +181,7 @@ export const createItems = (
       code,
       name,
       unit: takeRandomElementFrom(units),
+      onHold: faker.datatype.number(10) < 2,
       isVisible: faker.datatype.boolean(),
     };
 

--- a/packages/mock-server/src/data/types.ts
+++ b/packages/mock-server/src/data/types.ts
@@ -16,6 +16,7 @@ export interface Item {
   name: string;
   isVisible: boolean;
   unit: string;
+  onHold: boolean;
 }
 
 export interface Name {


### PR DESCRIPTION
This is the last of the query shifting.

This has ended up being so much bigger than I thought, sorry.

From here I would like to:
1. Create a more common way of creating the sdk/api object. I am thinking to make a `context` which the host can create the `sdk/api` object on load, and then each package can use a `useApi` hook. This also has the added bonus of allow the host to inject the credentials into the `api` object so each package doesn't need to worry about it (also the URL)
2. Sort the sorting out. I think if I get to it soon, I'm just going to add a `sortKey` to the `column` - I don't want to wait..
3. Organise the different enums and use them a bit better in our code - i.e. the statuses
4. Sort the mapping out. I'm sure there's a better pattern to be using here to map things, taking away the `nodes`..
5. Organise the errors- uh oh - betterer. '
6. Add as much as I can to the graphql schema of things we want
7. I know there's a better way to be generating with multiple packages in the yaml config, but it's going to take me some time to figure it out. I think it might be best to just skip this step.
8. Sort out the mutations. I can probably dig into remote server and find the schema and add it to ours
9. Finally, I think I might PR the graphql schema into the remote server repo. Unsure on this step though..