### PR TITLE
#368 map gql returns

### DIFF
--- a/packages/common/src/hooks/useDocument/types.ts
+++ b/packages/common/src/hooks/useDocument/types.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from 'react';
 
 export interface Api<ServerData, Document> {
-  onRead: () => Promise<ServerData>;
+  onRead: (id: string) => Promise<ServerData>;
   onUpdate: (val: Document) => Promise<ServerData>;
 }
 

--- a/packages/common/src/hooks/useDocument/useDocument.ts
+++ b/packages/common/src/hooks/useDocument/useDocument.ts
@@ -11,6 +11,7 @@ import {
   DocumentActionSet,
 } from './types';
 import { DomainObject } from '../../types';
+import { useParams } from 'react-router';
 
 export const DocumentAction = {
   init: (): DefaultDocumentAction => ({
@@ -48,6 +49,7 @@ export const useDocument = <
 ): DocumentState<Document, State, ServerData, DocumentActionSet<ActionSet>> => {
   // A query key which contains new, means it has not been created on the server yet.
   // TODO: Far more robust method needed here.
+  const { id } = useParams();
   const isNew = queryKey.includes('new');
 
   const queryClient = useQueryClient();
@@ -55,7 +57,7 @@ export const useDocument = <
   // Data is the current data on the server and our most up to date snapshot of the server state.
   // We're keeping it around, separate from our client state as to reference when needed and period
   // background re-fetches to keep an upto date reference to the server state.
-  const { data } = useQuery(queryKey, api.onRead, {
+  const { data } = useQuery(queryKey, () => api.onRead(String(id)), {
     enabled: !isNew,
   });
 

--- a/packages/common/src/hooks/useListData/useListData.test.tsx
+++ b/packages/common/src/hooks/useListData/useListData.test.tsx
@@ -30,7 +30,7 @@ describe('useListData', () => {
   );
 
   const ServerErrorApi: ListApi<Test> = {
-    onQuery: () => async () => {
+    onRead: () => async () => {
       return await request('http://localhost:4000', getServerErrorQuery());
     },
     onDelete: async () => {},
@@ -47,7 +47,7 @@ describe('useListData', () => {
   `;
 
   const PermissionErrorApi: ListApi<Test> = {
-    onQuery: () => async () => {
+    onRead: () => async () => {
       return await request(
         'http://localhost:4000',
         getPermissionErrorQuery(),

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -8,7 +8,7 @@ import { ClientError } from 'graphql-request';
 import { useNotification } from '../../hooks';
 
 export interface ListApi<T extends ObjectWithStringKeys> {
-  onQuery: ({
+  onRead: ({
     first,
     offset,
     sortBy,
@@ -53,7 +53,7 @@ export const useListData = <T extends ObjectWithStringKeys>(
 
   const { data, isLoading: isQueryLoading } = useQuery(
     fullQueryKey,
-    api.onQuery({ first, offset, sortBy }),
+    api.onRead({ first, offset, sortBy }),
     {
       onError: onError || defaultErrorHandler,
       useErrorBoundary: (error: ClientError): boolean =>

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -38,6 +38,22 @@ query invoice($id: String!) {
       otherPartyId
       otherPartyName
       pricing {
+        __typename
+        ... on NodeError {
+          __typename
+          error {
+            ... on RecordNotFound {
+              __typename
+              description
+            }
+            ... on DatabaseError {
+              __typename
+              description
+              fullError
+            }
+            description
+          }
+        }
         ... on InvoicePricingNode {
           __typename
           totalAfterTax
@@ -107,6 +123,7 @@ query invoices(
         type
 
         pricing {
+          __typename
           ... on NodeError {
             __typename
             error {

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -1,33 +1,60 @@
 query invoice($id: String!) {
   invoice(id: $id) {
+    __typename
+    ... on NodeError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on RecordNotFound {
+          __typename
+          description
+        }
+      }
+    }
     ... on InvoiceNode {
+      __typename
       id
       comment
       confirmedDatetime
       entryDatetime
       finalisedDatetime
       invoiceNumber
-
       draftDatetime
       allocatedDatetime
       pickedDatetime
       shippedDatetime
       deliveredDatetime
-
       hold
       color
-
       lines {
+        ... on ConnectorError {
+          __typename
+          error {
+            description
+            ... on DatabaseError {
+              __typename
+              description
+              fullError
+            }
+          }
+        }
         ... on InvoiceLineConnector {
+          __typename
           nodes {
+            __typename
             batch
             costPricePerPack
             expiryDate
             id
             itemCode
+            itemUnit
             itemId
             itemName
-            itemUnit
             numberOfPacks
             packSize
             sellPricePerPack
@@ -42,16 +69,16 @@ query invoice($id: String!) {
         ... on NodeError {
           __typename
           error {
-            ... on RecordNotFound {
-              __typename
-              description
-            }
+            description
             ... on DatabaseError {
               __typename
               description
               fullError
             }
-            description
+            ... on RecordNotFound {
+              __typename
+              description
+            }
           }
         }
         ... on InvoicePricingNode {
@@ -62,12 +89,6 @@ query invoice($id: String!) {
       status
       theirReference
       type
-    }
-    ... on NodeError {
-      __typename
-      error {
-        description
-      }
     }
   }
 }

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -69,9 +69,7 @@ export interface InvoiceLine extends DomainObject {
 
   batch?: string | null;
 
-  stockLine?: StockLine | null;
-
-  location?: string;
+  location?: string | null;
   comment?: string;
 }
 

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -31,8 +31,6 @@ export interface StockLine extends DomainObject {
   costPricePerPack: number;
   expiryDate?: string | null;
   batch?: string | null;
-  // item: Item;
-  name: string;
   packSize: number;
   sellPricePerPack: number;
   totalNumberOfPacks: number;

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -876,7 +876,7 @@ export type InvoiceQuery = {
   __typename?: 'Queries';
   invoice:
     | {
-        __typename?: 'InvoiceNode';
+        __typename: 'InvoiceNode';
         id: string;
         comment?: string | null | undefined;
         confirmedDatetime?: any | null | undefined;
@@ -896,20 +896,29 @@ export type InvoiceQuery = {
         theirReference?: string | null | undefined;
         type: InvoiceNodeType;
         lines:
-          | { __typename?: 'ConnectorError' }
           | {
-              __typename?: 'InvoiceLineConnector';
+              __typename: 'ConnectorError';
+              error:
+                | {
+                    __typename: 'DatabaseError';
+                    description: string;
+                    fullError: string;
+                  }
+                | { __typename?: 'PaginationError'; description: string };
+            }
+          | {
+              __typename: 'InvoiceLineConnector';
               totalCount: number;
               nodes: Array<{
-                __typename?: 'InvoiceLineNode';
+                __typename: 'InvoiceLineNode';
                 batch?: string | null | undefined;
                 costPricePerPack: number;
                 expiryDate?: any | null | undefined;
                 id: string;
                 itemCode: string;
+                itemUnit: string;
                 itemId: string;
                 itemName: string;
-                itemUnit: string;
                 numberOfPacks: number;
                 packSize: number;
                 sellPricePerPack: number;
@@ -931,8 +940,12 @@ export type InvoiceQuery = {
     | {
         __typename: 'NodeError';
         error:
-          | { __typename?: 'DatabaseError'; description: string }
-          | { __typename?: 'RecordNotFound'; description: string };
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | { __typename: 'RecordNotFound'; description: string };
       };
 };
 
@@ -1127,7 +1140,24 @@ export type ItemsQuery = {
 export const InvoiceDocument = gql`
   query invoice($id: String!) {
     invoice(id: $id) {
+      __typename
+      ... on NodeError {
+        __typename
+        error {
+          description
+          ... on DatabaseError {
+            __typename
+            description
+            fullError
+          }
+          ... on RecordNotFound {
+            __typename
+            description
+          }
+        }
+      }
       ... on InvoiceNode {
+        __typename
         id
         comment
         confirmedDatetime
@@ -1142,16 +1172,29 @@ export const InvoiceDocument = gql`
         hold
         color
         lines {
+          ... on ConnectorError {
+            __typename
+            error {
+              description
+              ... on DatabaseError {
+                __typename
+                description
+                fullError
+              }
+            }
+          }
           ... on InvoiceLineConnector {
+            __typename
             nodes {
+              __typename
               batch
               costPricePerPack
               expiryDate
               id
               itemCode
+              itemUnit
               itemId
               itemName
-              itemUnit
               numberOfPacks
               packSize
               sellPricePerPack
@@ -1166,16 +1209,16 @@ export const InvoiceDocument = gql`
           ... on NodeError {
             __typename
             error {
-              ... on RecordNotFound {
-                __typename
-                description
-              }
+              description
               ... on DatabaseError {
                 __typename
                 description
                 fullError
               }
-              description
+              ... on RecordNotFound {
+                __typename
+                description
+              }
             }
           }
           ... on InvoicePricingNode {
@@ -1186,12 +1229,6 @@ export const InvoiceDocument = gql`
         status
         theirReference
         type
-      }
-      ... on NodeError {
-        __typename
-        error {
-          description
-        }
       }
     }
   }

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -2,9 +2,15 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -16,36 +22,49 @@ export type Scalars = {
   NaiveDate: any;
 };
 
-export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'BatchIsReserved';
-  description: Scalars['String'];
-};
+export type BatchIsReserved = DeleteSupplierInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'BatchIsReserved';
+    description: Scalars['String'];
+  };
 
-export type CanOnlyEditInvoicesInLoggedInStoreError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
-  description: Scalars['String'];
-};
+export type CanOnlyEditInvoicesInLoggedInStoreError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'CanOnlyEditInvoicesInLoggedInStoreError';
+    description: Scalars['String'];
+  };
 
-export type CannotChangeInvoiceBackToDraft = UpdateSupplierInvoiceErrorInterface & {
-  __typename?: 'CannotChangeInvoiceBackToDraft';
-  description: Scalars['String'];
-};
+export type CannotChangeInvoiceBackToDraft =
+  UpdateSupplierInvoiceErrorInterface & {
+    __typename?: 'CannotChangeInvoiceBackToDraft';
+    description: Scalars['String'];
+  };
 
-export type CannotChangeStatusBackToDraftError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'CannotChangeStatusBackToDraftError';
-  description: Scalars['String'];
-};
+export type CannotChangeStatusBackToDraftError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'CannotChangeStatusBackToDraftError';
+    description: Scalars['String'];
+  };
 
-export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface & DeleteSupplierInvoiceErrorInterface & {
-  __typename?: 'CannotDeleteInvoiceWithLines';
-  description: Scalars['String'];
-  lines: InvoiceLineConnector;
-};
+export type CannotDeleteInvoiceWithLines = DeleteCustomerInvoiceErrorInterface &
+  DeleteSupplierInvoiceErrorInterface & {
+    __typename?: 'CannotDeleteInvoiceWithLines';
+    description: Scalars['String'];
+    lines: InvoiceLineConnector;
+  };
 
-export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'CannotEditFinalisedInvoice';
-  description: Scalars['String'];
-};
+export type CannotEditFinalisedInvoice = DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'CannotEditFinalisedInvoice';
+    description: Scalars['String'];
+  };
 
 export type ConnectorError = {
   __typename?: 'ConnectorError';
@@ -56,11 +75,24 @@ export type ConnectorErrorInterface = {
   description: Scalars['String'];
 };
 
-export type DatabaseError = ConnectorErrorInterface & DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'DatabaseError';
-  description: Scalars['String'];
-  fullError: Scalars['String'];
-};
+export type DatabaseError = ConnectorErrorInterface &
+  DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertCustomerInvoiceErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  NodeErrorInterface &
+  UpdateCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'DatabaseError';
+    description: Scalars['String'];
+    fullError: Scalars['String'];
+  };
 
 export type DatetimeFilterInput = {
   afterOrEqualTo?: Maybe<Scalars['DateTime']>;
@@ -91,9 +123,13 @@ export type DeleteCustomerInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteCustomerInvoiceLineResponse = DeleteCustomerInvoiceLineError | DeleteResponse;
+export type DeleteCustomerInvoiceLineResponse =
+  | DeleteCustomerInvoiceLineError
+  | DeleteResponse;
 
-export type DeleteCustomerInvoiceResponse = DeleteCustomerInvoiceError | DeleteResponse;
+export type DeleteCustomerInvoiceResponse =
+  | DeleteCustomerInvoiceError
+  | DeleteResponse;
 
 export type DeleteResponse = {
   __typename?: 'DeleteResponse';
@@ -127,9 +163,13 @@ export type DeleteSupplierInvoiceLineInput = {
   invoiceId: Scalars['String'];
 };
 
-export type DeleteSupplierInvoiceLineResponse = DeleteResponse | DeleteSupplierInvoiceLineError;
+export type DeleteSupplierInvoiceLineResponse =
+  | DeleteResponse
+  | DeleteSupplierInvoiceLineError;
 
-export type DeleteSupplierInvoiceResponse = DeleteResponse | DeleteSupplierInvoiceError;
+export type DeleteSupplierInvoiceResponse =
+  | DeleteResponse
+  | DeleteSupplierInvoiceError;
 
 export type EqualFilterBoolInput = {
   equalTo?: Maybe<Scalars['Boolean']>;
@@ -147,23 +187,33 @@ export type EqualFilterStringInput = {
   equalTo?: Maybe<Scalars['String']>;
 };
 
-export type FinalisedInvoiceIsNotEditableError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'FinalisedInvoiceIsNotEditableError';
-  description: Scalars['String'];
-};
+export type FinalisedInvoiceIsNotEditableError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'FinalisedInvoiceIsNotEditableError';
+    description: Scalars['String'];
+  };
 
 export enum ForeignKey {
   InvoiceId = 'INVOICE_ID',
   ItemId = 'ITEM_ID',
   OtherPartyId = 'OTHER_PARTY_ID',
-  StockLineId = 'STOCK_LINE_ID'
+  StockLineId = 'STOCK_LINE_ID',
 }
 
-export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'ForeignKeyError';
-  description: Scalars['String'];
-  key: ForeignKey;
-};
+export type ForeignKeyError = DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertCustomerInvoiceErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'ForeignKeyError';
+    description: Scalars['String'];
+    key: ForeignKey;
+  };
 
 export type InsertCustomerInvoiceError = {
   __typename?: 'InsertCustomerInvoiceError';
@@ -199,9 +249,15 @@ export type InsertCustomerInvoiceLineInput = {
   stockLineId: Scalars['String'];
 };
 
-export type InsertCustomerInvoiceLineResponse = InsertCustomerInvoiceLineError | InvoiceLineNode | NodeError;
+export type InsertCustomerInvoiceLineResponse =
+  | InsertCustomerInvoiceLineError
+  | InvoiceLineNode
+  | NodeError;
 
-export type InsertCustomerInvoiceResponse = InsertCustomerInvoiceError | InvoiceNode | NodeError;
+export type InsertCustomerInvoiceResponse =
+  | InsertCustomerInvoiceError
+  | InvoiceNode
+  | NodeError;
 
 export type InsertSupplierInvoiceError = {
   __typename?: 'InsertSupplierInvoiceError';
@@ -241,9 +297,15 @@ export type InsertSupplierInvoiceLineInput = {
   sellPricePerPack: Scalars['Float'];
 };
 
-export type InsertSupplierInvoiceLineResponse = InsertSupplierInvoiceLineError | InvoiceLineNode | NodeError;
+export type InsertSupplierInvoiceLineResponse =
+  | InsertSupplierInvoiceLineError
+  | InvoiceLineNode
+  | NodeError;
 
-export type InsertSupplierInvoiceResponse = InsertSupplierInvoiceError | InvoiceNode | NodeError;
+export type InsertSupplierInvoiceResponse =
+  | InsertSupplierInvoiceError
+  | InvoiceNode
+  | NodeError;
 
 export type InvoiceConnector = {
   __typename?: 'InvoiceConnector';
@@ -251,10 +313,19 @@ export type InvoiceConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceDoesNotBelongToCurrentStore = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'InvoiceDoesNotBelongToCurrentStore';
-  description: Scalars['String'];
-};
+export type InvoiceDoesNotBelongToCurrentStore =
+  DeleteCustomerInvoiceErrorInterface &
+    DeleteCustomerInvoiceLineErrorInterface &
+    DeleteSupplierInvoiceErrorInterface &
+    DeleteSupplierInvoiceLineErrorInterface &
+    InsertCustomerInvoiceLineErrorInterface &
+    InsertSupplierInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface &
+    UpdateSupplierInvoiceErrorInterface &
+    UpdateSupplierInvoiceLineErrorInterface & {
+      __typename?: 'InvoiceDoesNotBelongToCurrentStore';
+      description: Scalars['String'];
+    };
 
 export type InvoiceFilterInput = {
   comment?: Maybe<SimpleStringFilterInput>;
@@ -268,11 +339,15 @@ export type InvoiceFilterInput = {
   type?: Maybe<EqualFilterInvoiceTypeInput>;
 };
 
-export type InvoiceLineBelongsToAnotherInvoice = DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'InvoiceLineBelongsToAnotherInvoice';
-  description: Scalars['String'];
-  invoice: InvoiceResponse;
-};
+export type InvoiceLineBelongsToAnotherInvoice =
+  DeleteCustomerInvoiceLineErrorInterface &
+    DeleteSupplierInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface &
+    UpdateSupplierInvoiceLineErrorInterface & {
+      __typename?: 'InvoiceLineBelongsToAnotherInvoice';
+      description: Scalars['String'];
+      invoice: InvoiceResponse;
+    };
 
 export type InvoiceLineConnector = {
   __typename?: 'InvoiceLineConnector';
@@ -280,11 +355,12 @@ export type InvoiceLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type InvoiceLineHasNoStockLineError = UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'InvoiceLineHasNoStockLineError';
-  description: Scalars['String'];
-  invoiceLineId: Scalars['String'];
-};
+export type InvoiceLineHasNoStockLineError =
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'InvoiceLineHasNoStockLineError';
+    description: Scalars['String'];
+    invoiceLineId: Scalars['String'];
+  };
 
 export type InvoiceLineNode = {
   __typename?: 'InvoiceLineNode';
@@ -338,12 +414,12 @@ export enum InvoiceNodeStatus {
   Draft = 'DRAFT',
   Finalised = 'FINALISED',
   Picked = 'PICKED',
-  Shipped = 'SHIPPED'
+  Shipped = 'SHIPPED',
 }
 
 export enum InvoiceNodeType {
   CustomerInvoice = 'CUSTOMER_INVOICE',
-  SupplierInvoice = 'SUPPLIER_INVOICE'
+  SupplierInvoice = 'SUPPLIER_INVOICE',
 }
 
 export type InvoicePriceResponse = InvoicePricingNode | NodeError;
@@ -360,7 +436,7 @@ export enum InvoiceSortFieldInput {
   EntryDatetime = 'ENTRY_DATETIME',
   FinalisedDateTime = 'FINALISED_DATE_TIME',
   Status = 'STATUS',
-  Type = 'TYPE'
+  Type = 'TYPE',
 }
 
 export type InvoiceSortInput = {
@@ -376,10 +452,12 @@ export type ItemConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type ItemDoesNotMatchStockLine = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'ItemDoesNotMatchStockLine';
-  description: Scalars['String'];
-};
+export type ItemDoesNotMatchStockLine =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'ItemDoesNotMatchStockLine';
+      description: Scalars['String'];
+    };
 
 export type ItemFilterInput = {
   code?: Maybe<SimpleStringFilterInput>;
@@ -398,7 +476,7 @@ export type ItemNode = {
 
 export enum ItemSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME'
+  Name = 'NAME',
 }
 
 export type ItemSortInput = {
@@ -408,10 +486,11 @@ export type ItemSortInput = {
 
 export type ItemsResponse = ConnectorError | ItemConnector;
 
-export type LineDoesNotReferenceStockLine = UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'LineDoesNotReferenceStockLine';
-  description: Scalars['String'];
-};
+export type LineDoesNotReferenceStockLine =
+  UpdateCustomerInvoiceLineErrorInterface & {
+    __typename?: 'LineDoesNotReferenceStockLine';
+    description: Scalars['String'];
+  };
 
 export type Mutations = {
   __typename?: 'Mutations';
@@ -429,61 +508,49 @@ export type Mutations = {
   updateSupplierInvoiceLine: UpdateSupplierInvoiceLineResponse;
 };
 
-
 export type MutationsDeleteCustomerInvoiceArgs = {
   id: Scalars['String'];
 };
-
 
 export type MutationsDeleteCustomerInvoiceLineArgs = {
   input: DeleteCustomerInvoiceLineInput;
 };
 
-
 export type MutationsDeleteSupplierInvoiceArgs = {
   input: DeleteSupplierInvoiceInput;
 };
-
 
 export type MutationsDeleteSupplierInvoiceLineArgs = {
   input: DeleteSupplierInvoiceLineInput;
 };
 
-
 export type MutationsInsertCustomerInvoiceArgs = {
   input: InsertCustomerInvoiceInput;
 };
-
 
 export type MutationsInsertCustomerInvoiceLineArgs = {
   input: InsertCustomerInvoiceLineInput;
 };
 
-
 export type MutationsInsertSupplierInvoiceArgs = {
   input: InsertSupplierInvoiceInput;
 };
-
 
 export type MutationsInsertSupplierInvoiceLineArgs = {
   input: InsertSupplierInvoiceLineInput;
 };
 
-
 export type MutationsUpdateCustomerInvoiceArgs = {
   input: UpdateCustomerInvoiceInput;
 };
-
 
 export type MutationsUpdateCustomerInvoiceLineArgs = {
   input: UpdateCustomerInvoiceLineInput;
 };
 
-
 export type MutationsUpdateSupplierInvoiceArgs = {
   input: UpdateSupplierInvoiceInput;
 };
-
 
 export type MutationsUpdateSupplierInvoiceLineArgs = {
   input: UpdateSupplierInvoiceLineInput;
@@ -513,7 +580,7 @@ export type NameNode = {
 
 export enum NameSortFieldInput {
   Code = 'CODE',
-  Name = 'NAME'
+  Name = 'NAME',
 }
 
 export type NameSortInput = {
@@ -532,44 +599,57 @@ export type NodeErrorInterface = {
   description: Scalars['String'];
 };
 
-export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'NotACustomerInvoice';
-  description: Scalars['String'];
-};
+export type NotACustomerInvoice = DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface & {
+    __typename?: 'NotACustomerInvoice';
+    description: Scalars['String'];
+  };
 
 export type NotACustomerInvoiceError = UpdateCustomerInvoiceErrorInterface & {
   __typename?: 'NotACustomerInvoiceError';
   description: Scalars['String'];
 };
 
-export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'NotASupplierInvoice';
-  description: Scalars['String'];
-};
+export type NotASupplierInvoice = DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'NotASupplierInvoice';
+    description: Scalars['String'];
+  };
 
-export type NotEnoughStockForReduction = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'NotEnoughStockForReduction';
-  batch: StockLineResponse;
-  description: Scalars['String'];
-  line?: Maybe<InvoiceLineResponse>;
-};
+export type NotEnoughStockForReduction =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'NotEnoughStockForReduction';
+      batch: StockLineResponse;
+      description: Scalars['String'];
+      line?: Maybe<InvoiceLineResponse>;
+    };
 
-export type OtherPartyCannotBeThisStoreError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'OtherPartyCannotBeThisStoreError';
-  description: Scalars['String'];
-};
+export type OtherPartyCannotBeThisStoreError =
+  InsertCustomerInvoiceErrorInterface &
+    UpdateCustomerInvoiceErrorInterface & {
+      __typename?: 'OtherPartyCannotBeThisStoreError';
+      description: Scalars['String'];
+    };
 
-export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface & UpdateCustomerInvoiceErrorInterface & {
-  __typename?: 'OtherPartyNotACustomerError';
-  description: Scalars['String'];
-  otherParty: NameNode;
-};
+export type OtherPartyNotACustomerError = InsertCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceErrorInterface & {
+    __typename?: 'OtherPartyNotACustomerError';
+    description: Scalars['String'];
+    otherParty: NameNode;
+  };
 
-export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface & UpdateSupplierInvoiceErrorInterface & {
-  __typename?: 'OtherPartyNotASupplier';
-  description: Scalars['String'];
-  otherParty: NameNode;
-};
+export type OtherPartyNotASupplier = InsertSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceErrorInterface & {
+    __typename?: 'OtherPartyNotASupplier';
+    description: Scalars['String'];
+    otherParty: NameNode;
+  };
 
 export type PaginationError = ConnectorErrorInterface & {
   __typename?: 'PaginationError';
@@ -590,11 +670,9 @@ export type Queries = {
   names: NamesResponse;
 };
 
-
 export type QueriesInvoiceArgs = {
   id: Scalars['String'];
 };
-
 
 export type QueriesInvoicesArgs = {
   filter?: Maybe<InvoiceFilterInput>;
@@ -602,13 +680,11 @@ export type QueriesInvoicesArgs = {
   sort?: Maybe<Array<InvoiceSortInput>>;
 };
 
-
 export type QueriesItemsArgs = {
   filter?: Maybe<ItemFilterInput>;
   page?: Maybe<PaginationInput>;
   sort?: Maybe<Array<ItemSortInput>>;
 };
-
 
 export type QueriesNamesArgs = {
   filter?: Maybe<NameFilterInput>;
@@ -616,40 +692,56 @@ export type QueriesNamesArgs = {
   sort?: Maybe<Array<NameSortInput>>;
 };
 
-export type RangeError = InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'RangeError';
-  description: Scalars['String'];
-  field: RangeField;
-  max?: Maybe<Scalars['Int']>;
-  min?: Maybe<Scalars['Int']>;
-};
+export type RangeError = InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'RangeError';
+    description: Scalars['String'];
+    field: RangeField;
+    max?: Maybe<Scalars['Int']>;
+    min?: Maybe<Scalars['Int']>;
+  };
 
 export enum RangeField {
   First = 'FIRST',
   NumberOfPacks = 'NUMBER_OF_PACKS',
-  PackSize = 'PACK_SIZE'
+  PackSize = 'PACK_SIZE',
 }
 
-export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface & InsertCustomerInvoiceLineErrorInterface & InsertSupplierInvoiceErrorInterface & InsertSupplierInvoiceLineErrorInterface & {
-  __typename?: 'RecordAlreadyExist';
-  description: Scalars['String'];
-};
+export type RecordAlreadyExist = InsertCustomerInvoiceErrorInterface &
+  InsertCustomerInvoiceLineErrorInterface &
+  InsertSupplierInvoiceErrorInterface &
+  InsertSupplierInvoiceLineErrorInterface & {
+    __typename?: 'RecordAlreadyExist';
+    description: Scalars['String'];
+  };
 
-export type RecordNotFound = DeleteCustomerInvoiceErrorInterface & DeleteCustomerInvoiceLineErrorInterface & DeleteSupplierInvoiceErrorInterface & DeleteSupplierInvoiceLineErrorInterface & NodeErrorInterface & UpdateCustomerInvoiceErrorInterface & UpdateCustomerInvoiceLineErrorInterface & UpdateSupplierInvoiceErrorInterface & UpdateSupplierInvoiceLineErrorInterface & {
-  __typename?: 'RecordNotFound';
-  description: Scalars['String'];
-};
+export type RecordNotFound = DeleteCustomerInvoiceErrorInterface &
+  DeleteCustomerInvoiceLineErrorInterface &
+  DeleteSupplierInvoiceErrorInterface &
+  DeleteSupplierInvoiceLineErrorInterface &
+  NodeErrorInterface &
+  UpdateCustomerInvoiceErrorInterface &
+  UpdateCustomerInvoiceLineErrorInterface &
+  UpdateSupplierInvoiceErrorInterface &
+  UpdateSupplierInvoiceLineErrorInterface & {
+    __typename?: 'RecordNotFound';
+    description: Scalars['String'];
+  };
 
 export type SimpleStringFilterInput = {
   equalTo?: Maybe<Scalars['String']>;
   like?: Maybe<Scalars['String']>;
 };
 
-export type StockLineAlreadyExistsInInvoice = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'StockLineAlreadyExistsInInvoice';
-  description: Scalars['String'];
-  line: InvoiceLineResponse;
-};
+export type StockLineAlreadyExistsInInvoice =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'StockLineAlreadyExistsInInvoice';
+      description: Scalars['String'];
+      line: InvoiceLineResponse;
+    };
 
 export type StockLineConnector = {
   __typename?: 'StockLineConnector';
@@ -657,10 +749,12 @@ export type StockLineConnector = {
   totalCount: Scalars['Int'];
 };
 
-export type StockLineDoesNotBelongToCurrentStore = InsertCustomerInvoiceLineErrorInterface & UpdateCustomerInvoiceLineErrorInterface & {
-  __typename?: 'StockLineDoesNotBelongToCurrentStore';
-  description: Scalars['String'];
-};
+export type StockLineDoesNotBelongToCurrentStore =
+  InsertCustomerInvoiceLineErrorInterface &
+    UpdateCustomerInvoiceLineErrorInterface & {
+      __typename?: 'StockLineDoesNotBelongToCurrentStore';
+      description: Scalars['String'];
+    };
 
 export type StockLineNode = {
   __typename?: 'StockLineNode';
@@ -716,9 +810,15 @@ export type UpdateCustomerInvoiceLineInput = {
   stockLineId?: Maybe<Scalars['String']>;
 };
 
-export type UpdateCustomerInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateCustomerInvoiceLineError;
+export type UpdateCustomerInvoiceLineResponse =
+  | InvoiceLineNode
+  | NodeError
+  | UpdateCustomerInvoiceLineError;
 
-export type UpdateCustomerInvoiceResponse = InvoiceNode | NodeError | UpdateCustomerInvoiceError;
+export type UpdateCustomerInvoiceResponse =
+  | InvoiceNode
+  | NodeError
+  | UpdateCustomerInvoiceError;
 
 export type UpdateSupplierInvoiceError = {
   __typename?: 'UpdateSupplierInvoiceError';
@@ -758,16 +858,83 @@ export type UpdateSupplierInvoiceLineInput = {
   sellPricePerPack?: Maybe<Scalars['Float']>;
 };
 
-export type UpdateSupplierInvoiceLineResponse = InvoiceLineNode | NodeError | UpdateSupplierInvoiceLineError;
+export type UpdateSupplierInvoiceLineResponse =
+  | InvoiceLineNode
+  | NodeError
+  | UpdateSupplierInvoiceLineError;
 
-export type UpdateSupplierInvoiceResponse = InvoiceNode | NodeError | UpdateSupplierInvoiceError;
+export type UpdateSupplierInvoiceResponse =
+  | InvoiceNode
+  | NodeError
+  | UpdateSupplierInvoiceError;
 
 export type InvoiceQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
-
-export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename?: 'InvoiceNode', id: string, comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, finalisedDatetime?: any | null | undefined, invoiceNumber: number, draftDatetime?: any | null | undefined, allocatedDatetime?: any | null | undefined, pickedDatetime?: any | null | undefined, shippedDatetime?: any | null | undefined, deliveredDatetime?: any | null | undefined, hold: boolean, color: string, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, lines: { __typename?: 'ConnectorError' } | { __typename?: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemCode: string, itemId: string, itemName: string, itemUnit: string, numberOfPacks: number, packSize: number, sellPricePerPack: number }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename?: 'NodeError' } } | { __typename: 'NodeError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'RecordNotFound', description: string } } };
+export type InvoiceQuery = {
+  __typename?: 'Queries';
+  invoice:
+    | {
+        __typename?: 'InvoiceNode';
+        id: string;
+        comment?: string | null | undefined;
+        confirmedDatetime?: any | null | undefined;
+        entryDatetime: any;
+        finalisedDatetime?: any | null | undefined;
+        invoiceNumber: number;
+        draftDatetime?: any | null | undefined;
+        allocatedDatetime?: any | null | undefined;
+        pickedDatetime?: any | null | undefined;
+        shippedDatetime?: any | null | undefined;
+        deliveredDatetime?: any | null | undefined;
+        hold: boolean;
+        color: string;
+        otherPartyId: string;
+        otherPartyName: string;
+        status: InvoiceNodeStatus;
+        theirReference?: string | null | undefined;
+        type: InvoiceNodeType;
+        lines:
+          | { __typename?: 'ConnectorError' }
+          | {
+              __typename?: 'InvoiceLineConnector';
+              totalCount: number;
+              nodes: Array<{
+                __typename?: 'InvoiceLineNode';
+                batch?: string | null | undefined;
+                costPricePerPack: number;
+                expiryDate?: any | null | undefined;
+                id: string;
+                itemCode: string;
+                itemId: string;
+                itemName: string;
+                itemUnit: string;
+                numberOfPacks: number;
+                packSize: number;
+                sellPricePerPack: number;
+              }>;
+            };
+        pricing:
+          | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
+          | {
+              __typename: 'NodeError';
+              error:
+                | {
+                    __typename: 'DatabaseError';
+                    description: string;
+                    fullError: string;
+                  }
+                | { __typename: 'RecordNotFound'; description: string };
+            };
+      }
+    | {
+        __typename: 'NodeError';
+        error:
+          | { __typename?: 'DatabaseError'; description: string }
+          | { __typename?: 'RecordNotFound'; description: string };
+      };
+};
 
 export type InvoicesQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -776,8 +943,60 @@ export type InvoicesQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type InvoicesQuery = { __typename?: 'Queries', invoices: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename?: 'InvoiceNode', comment?: string | null | undefined, confirmedDatetime?: any | null | undefined, entryDatetime: any, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, color: string, theirReference?: string | null | undefined, type: InvoiceNodeType, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } }> } };
+export type InvoicesQuery = {
+  __typename?: 'Queries';
+  invoices:
+    | {
+        __typename: 'ConnectorError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | {
+              __typename: 'PaginationError';
+              description: string;
+              rangeError: {
+                __typename?: 'RangeError';
+                description: string;
+                field: RangeField;
+                max?: number | null | undefined;
+                min?: number | null | undefined;
+              };
+            };
+      }
+    | {
+        __typename: 'InvoiceConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename?: 'InvoiceNode';
+          comment?: string | null | undefined;
+          confirmedDatetime?: any | null | undefined;
+          entryDatetime: any;
+          id: string;
+          invoiceNumber: number;
+          otherPartyId: string;
+          otherPartyName: string;
+          status: InvoiceNodeStatus;
+          color: string;
+          theirReference?: string | null | undefined;
+          type: InvoiceNodeType;
+          pricing:
+            | { __typename: 'InvoicePricingNode'; totalAfterTax: number }
+            | {
+                __typename: 'NodeError';
+                error:
+                  | {
+                      __typename: 'DatabaseError';
+                      description: string;
+                      fullError: string;
+                    }
+                  | { __typename: 'RecordNotFound'; description: string };
+              };
+        }>;
+      };
+};
 
 export type NamesQueryVariables = Exact<{
   key: NameSortFieldInput;
@@ -786,8 +1005,42 @@ export type NamesQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
 }>;
 
-
-export type NamesQuery = { __typename?: 'Queries', names: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'NameConnector', totalCount: number, nodes: Array<{ __typename?: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, name: string }> } };
+export type NamesQuery = {
+  __typename?: 'Queries';
+  names:
+    | {
+        __typename: 'ConnectorError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | {
+              __typename: 'PaginationError';
+              description: string;
+              rangeError: {
+                __typename?: 'RangeError';
+                description: string;
+                field: RangeField;
+                max?: number | null | undefined;
+                min?: number | null | undefined;
+              };
+            };
+      }
+    | {
+        __typename: 'NameConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename?: 'NameNode';
+          code: string;
+          id: string;
+          isCustomer: boolean;
+          isSupplier: boolean;
+          name: string;
+        }>;
+      };
+};
 
 export type ItemsQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -796,105 +1049,120 @@ export type ItemsQueryVariables = Exact<{
   desc?: Maybe<Scalars['Boolean']>;
 }>;
 
-
-export type ItemsQuery = { __typename?: 'Queries', items: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, availableBatches: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean }> } }> } };
-
+export type ItemsQuery = {
+  __typename?: 'Queries';
+  items:
+    | {
+        __typename: 'ConnectorError';
+        error:
+          | {
+              __typename: 'DatabaseError';
+              description: string;
+              fullError: string;
+            }
+          | {
+              __typename: 'PaginationError';
+              description: string;
+              rangeError: {
+                __typename?: 'RangeError';
+                description: string;
+                field: RangeField;
+                max?: number | null | undefined;
+                min?: number | null | undefined;
+              };
+            };
+      }
+    | {
+        __typename: 'ItemConnector';
+        totalCount: number;
+        nodes: Array<{
+          __typename: 'ItemNode';
+          code: string;
+          id: string;
+          isVisible: boolean;
+          name: string;
+          availableBatches:
+            | {
+                __typename: 'ConnectorError';
+                error:
+                  | {
+                      __typename: 'DatabaseError';
+                      description: string;
+                      fullError: string;
+                    }
+                  | {
+                      __typename: 'PaginationError';
+                      description: string;
+                      rangeError: {
+                        __typename?: 'RangeError';
+                        description: string;
+                        field: RangeField;
+                        max?: number | null | undefined;
+                        min?: number | null | undefined;
+                      };
+                    };
+              }
+            | {
+                __typename: 'StockLineConnector';
+                totalCount: number;
+                nodes: Array<{
+                  __typename: 'StockLineNode';
+                  availableNumberOfPacks: number;
+                  batch?: string | null | undefined;
+                  costPricePerPack: number;
+                  expiryDate?: any | null | undefined;
+                  id: string;
+                  itemId: string;
+                  packSize: number;
+                  sellPricePerPack: number;
+                  storeId: string;
+                  totalNumberOfPacks: number;
+                  onHold: boolean;
+                }>;
+              };
+        }>;
+      };
+};
 
 export const InvoiceDocument = gql`
-    query invoice($id: String!) {
-  invoice(id: $id) {
-    ... on InvoiceNode {
-      id
-      comment
-      confirmedDatetime
-      entryDatetime
-      finalisedDatetime
-      invoiceNumber
-      draftDatetime
-      allocatedDatetime
-      pickedDatetime
-      shippedDatetime
-      deliveredDatetime
-      hold
-      color
-      lines {
-        ... on InvoiceLineConnector {
-          nodes {
-            batch
-            costPricePerPack
-            expiryDate
-            id
-            itemCode
-            itemId
-            itemName
-            itemUnit
-            numberOfPacks
-            packSize
-            sellPricePerPack
-          }
-          totalCount
-        }
-      }
-      otherPartyId
-      otherPartyName
-      pricing {
-        ... on InvoicePricingNode {
-          __typename
-          totalAfterTax
-        }
-      }
-      status
-      theirReference
-      type
-    }
-    ... on NodeError {
-      __typename
-      error {
-        description
-      }
-    }
-  }
-}
-    `;
-export const InvoicesDocument = gql`
-    query invoices($first: Int, $offset: Int, $key: InvoiceSortFieldInput!, $desc: Boolean) {
-  invoices(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
-    ... on ConnectorError {
-      __typename
-      error {
-        description
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        ... on PaginationError {
-          __typename
-          description
-          rangeError {
-            description
-            field
-            max
-            min
-          }
-        }
-      }
-    }
-    ... on InvoiceConnector {
-      __typename
-      nodes {
+  query invoice($id: String!) {
+    invoice(id: $id) {
+      ... on InvoiceNode {
+        id
         comment
         confirmedDatetime
         entryDatetime
-        id
+        finalisedDatetime
         invoiceNumber
+        draftDatetime
+        allocatedDatetime
+        pickedDatetime
+        shippedDatetime
+        deliveredDatetime
+        hold
+        color
+        lines {
+          ... on InvoiceLineConnector {
+            nodes {
+              batch
+              costPricePerPack
+              expiryDate
+              id
+              itemCode
+              itemId
+              itemName
+              itemUnit
+              numberOfPacks
+              packSize
+              sellPricePerPack
+            }
+            totalCount
+          }
+        }
         otherPartyId
         otherPartyName
-        status
-        color
-        theirReference
-        type
         pricing {
+          __typename
           ... on NodeError {
             __typename
             error {
@@ -915,154 +1183,293 @@ export const InvoicesDocument = gql`
             totalAfterTax
           }
         }
+        status
+        theirReference
+        type
       }
-      totalCount
-    }
-  }
-}
-    `;
-export const NamesDocument = gql`
-    query names($key: NameSortFieldInput!, $desc: Boolean, $first: Int, $offset: Int) {
-  names(
-    page: {first: $first, offset: $offset}
-    sort: {key: $key, desc: $desc}
-    filter: {isCustomer: true}
-  ) {
-    ... on ConnectorError {
-      __typename
-      error {
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        description
-        ... on PaginationError {
-          __typename
-          description
-          rangeError {
-            description
-            field
-            max
-            min
-          }
-        }
-      }
-    }
-    ... on NameConnector {
-      __typename
-      nodes {
-        code
-        id
-        isCustomer
-        isSupplier
-        name
-      }
-      totalCount
-    }
-  }
-}
-    `;
-export const ItemsDocument = gql`
-    query items($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean) {
-  items(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
-    ... on ConnectorError {
-      __typename
-      error {
-        description
-        ... on DatabaseError {
-          __typename
-          description
-          fullError
-        }
-        ... on PaginationError {
-          __typename
-          description
-          rangeError {
-            description
-            field
-            max
-            min
-          }
-        }
-      }
-    }
-    ... on ItemConnector {
-      __typename
-      nodes {
+      ... on NodeError {
         __typename
-        availableBatches {
-          __typename
-          ... on ConnectorError {
+        error {
+          description
+        }
+      }
+    }
+  }
+`;
+export const InvoicesDocument = gql`
+  query invoices(
+    $first: Int
+    $offset: Int
+    $key: InvoiceSortFieldInput!
+    $desc: Boolean
+  ) {
+    invoices(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+    ) {
+      ... on ConnectorError {
+        __typename
+        error {
+          description
+          ... on DatabaseError {
             __typename
-            error {
+            description
+            fullError
+          }
+          ... on PaginationError {
+            __typename
+            description
+            rangeError {
               description
-              ... on DatabaseError {
-                __typename
-                description
-                fullError
-              }
-              ... on PaginationError {
-                __typename
-                description
-                rangeError {
+              field
+              max
+              min
+            }
+          }
+        }
+      }
+      ... on InvoiceConnector {
+        __typename
+        nodes {
+          comment
+          confirmedDatetime
+          entryDatetime
+          id
+          invoiceNumber
+          otherPartyId
+          otherPartyName
+          status
+          color
+          theirReference
+          type
+          pricing {
+            __typename
+            ... on NodeError {
+              __typename
+              error {
+                ... on RecordNotFound {
+                  __typename
                   description
-                  field
-                  max
-                  min
+                }
+                ... on DatabaseError {
+                  __typename
+                  description
+                  fullError
+                }
+                description
+              }
+            }
+            ... on InvoicePricingNode {
+              __typename
+              totalAfterTax
+            }
+          }
+        }
+        totalCount
+      }
+    }
+  }
+`;
+export const NamesDocument = gql`
+  query names(
+    $key: NameSortFieldInput!
+    $desc: Boolean
+    $first: Int
+    $offset: Int
+  ) {
+    names(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+      filter: { isCustomer: true }
+    ) {
+      ... on ConnectorError {
+        __typename
+        error {
+          ... on DatabaseError {
+            __typename
+            description
+            fullError
+          }
+          description
+          ... on PaginationError {
+            __typename
+            description
+            rangeError {
+              description
+              field
+              max
+              min
+            }
+          }
+        }
+      }
+      ... on NameConnector {
+        __typename
+        nodes {
+          code
+          id
+          isCustomer
+          isSupplier
+          name
+        }
+        totalCount
+      }
+    }
+  }
+`;
+export const ItemsDocument = gql`
+  query items(
+    $first: Int
+    $offset: Int
+    $key: ItemSortFieldInput!
+    $desc: Boolean
+  ) {
+    items(
+      page: { first: $first, offset: $offset }
+      sort: { key: $key, desc: $desc }
+    ) {
+      ... on ConnectorError {
+        __typename
+        error {
+          description
+          ... on DatabaseError {
+            __typename
+            description
+            fullError
+          }
+          ... on PaginationError {
+            __typename
+            description
+            rangeError {
+              description
+              field
+              max
+              min
+            }
+          }
+        }
+      }
+      ... on ItemConnector {
+        __typename
+        nodes {
+          __typename
+          availableBatches {
+            __typename
+            ... on ConnectorError {
+              __typename
+              error {
+                description
+                ... on DatabaseError {
+                  __typename
+                  description
+                  fullError
+                }
+                ... on PaginationError {
+                  __typename
+                  description
+                  rangeError {
+                    description
+                    field
+                    max
+                    min
+                  }
                 }
               }
             }
-          }
-          ... on StockLineConnector {
-            __typename
-            nodes {
+            ... on StockLineConnector {
               __typename
-              availableNumberOfPacks
-              batch
-              costPricePerPack
-              expiryDate
-              id
-              itemId
-              packSize
-              sellPricePerPack
-              storeId
-              totalNumberOfPacks
-              onHold
+              nodes {
+                __typename
+                availableNumberOfPacks
+                batch
+                costPricePerPack
+                expiryDate
+                id
+                itemId
+                packSize
+                sellPricePerPack
+                storeId
+                totalNumberOfPacks
+                onHold
+              }
+              totalCount
             }
-            totalCount
           }
+          code
+          id
+          isVisible
+          name
         }
-        code
-        id
-        isVisible
-        name
+        totalCount
       }
-      totalCount
     }
   }
-}
-    `;
+`;
 
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
-
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string
+) => Promise<T>;
 
 const defaultWrapper: SdkFunctionWrapper = (action, _operationName) => action();
 
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper
+) {
   return {
-    invoice(variables: InvoiceQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoiceQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<InvoiceQuery>(InvoiceDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoice');
+    invoice(
+      variables: InvoiceQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<InvoiceQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<InvoiceQuery>(InvoiceDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'invoice'
+      );
     },
-    invoices(variables: InvoicesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InvoicesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<InvoicesQuery>(InvoicesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'invoices');
+    invoices(
+      variables: InvoicesQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<InvoicesQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<InvoicesQuery>(InvoicesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'invoices'
+      );
     },
-    names(variables: NamesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<NamesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<NamesQuery>(NamesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'names');
+    names(
+      variables: NamesQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<NamesQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<NamesQuery>(NamesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'names'
+      );
     },
-    items(variables: ItemsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ItemsQuery>(ItemsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'items');
-    }
+    items(
+      variables: ItemsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ItemsQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<ItemsQuery>(ItemsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'items'
+      );
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/host/src/bootstrap.tsx
+++ b/packages/host/src/bootstrap.tsx
@@ -8,6 +8,7 @@ if (process.env.NODE_ENV === 'development') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
   } = require('@openmsupply-client/mock-server/src/worker/client');
   const worker = setupMockWorker();
+
   worker.start();
 }
 

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -12,7 +12,7 @@ import {
   getRowExpandColumn,
 } from '@openmsupply-client/common';
 import { reducer, OutboundAction } from './reducer';
-import { getOutboundShipmentDetailViewApi } from '../../api';
+import { OutboundShipmentDetailViewApi } from '../../api';
 import { GeneralTab } from './tabs/GeneralTab';
 import { ItemDetailsModal } from './modals/ItemDetailsModal';
 
@@ -29,7 +29,7 @@ const useDraftOutbound = () => {
   const { draft, save, dispatch, state } = useDocument(
     ['invoice', id],
     reducer,
-    getOutboundShipmentDetailViewApi(id ?? '')
+    OutboundShipmentDetailViewApi
   );
 
   const onChangeSortBy = (column: Column<InvoiceLineRow>) => {

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -26,7 +26,7 @@ import {
   Grid,
   OutboundShipmentStatus,
 } from '@openmsupply-client/common';
-import { OutboundShipmentListViewApi } from '../../api';
+import { OutboundShipmentListViewApi } from './api';
 import { ExternalURL } from '@openmsupply-client/config';
 import { CustomerSearch } from './CustomerSearch';
 import { getStatusTranslation } from '../utils';

--- a/packages/invoices/src/OutboundShipment/ListView/api.ts
+++ b/packages/invoices/src/OutboundShipment/ListView/api.ts
@@ -1,0 +1,158 @@
+import {
+  ObjectWithStringKeys,
+  InvoicesQuery,
+  request,
+  gql,
+  batchRequests,
+  SortBy,
+  ListApi,
+  Invoice,
+  GraphQLClient,
+  getSdk,
+  InvoiceSortFieldInput,
+  InvoiceRow,
+  InvoicePriceResponse,
+} from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
+
+const client = new GraphQLClient(Environment.API_URL);
+const api = getSdk(client);
+
+const pricingGuard = (pricing: InvoicePriceResponse) => {
+  if (pricing.__typename === 'InvoicePricingNode') {
+    return pricing;
+  } else if (pricing.__typename === 'NodeError') {
+    throw new Error(pricing.error.description);
+  } else {
+    throw new Error('Unknown');
+  }
+};
+
+const invoicesGuard = (invoicesQuery: InvoicesQuery) => {
+  if (invoicesQuery.invoices.__typename === 'InvoiceConnector') {
+    return invoicesQuery.invoices;
+  }
+
+  throw new Error(invoicesQuery.invoices.error.description);
+};
+
+export const onUpdate = async (updated: InvoiceRow): Promise<InvoiceRow> => {
+  const invoicePatch: Partial<Invoice> = { ...updated };
+  delete invoicePatch['lines'];
+
+  const patch = { invoicePatch };
+
+  const result = await request(Environment.API_URL, getMutation(), patch);
+
+  const { updateInvoice } = result;
+  return updateInvoice;
+};
+
+export const getInsertInvoiceQuery = (): string => gql`
+  mutation insertInvoice($id: String!, $otherPartyId: String!) {
+    insertOutboundShipment(input: { id: $id, otherPartyId: $otherPartyId }) {
+      __typename
+      ... on InvoiceNode {
+        id
+        comment
+        confirmedDatetime
+        entryDatetime
+        finalisedDatetime
+        invoiceNumber
+      }
+      ... on NodeError {
+        __typename
+        error {
+          description
+        }
+      }
+      ... on InsertCustomerInvoiceError {
+        __typename
+        error {
+          description
+        }
+      }
+    }
+  }
+`;
+
+export const onCreate = async (invoice: Partial<Invoice>): Promise<Invoice> => {
+  const result = await request(Environment.API_URL, getInsertInvoiceQuery(), {
+    id: invoice.id,
+    otherPartyId: invoice['nameId'],
+  });
+  const { insertCustomerInvoice } = result;
+
+  return insertCustomerInvoice;
+};
+
+export const getMutation = (): string => gql`
+  mutation updateInvoice($invoicePatch: InvoicePatch) {
+    updateInvoice(invoice: $invoicePatch) {
+      id
+      comment
+      status
+      type
+      entered
+      confirmed
+      invoiceNumber
+      total
+    }
+  }
+`;
+
+export const getDeleteMutation = (): string => gql`
+  mutation deleteInvoice($invoiceId: String) {
+    deleteInvoice(invoiceId: $invoiceId) {
+      id
+    }
+  }
+`;
+
+export const onDelete = async (invoices: InvoiceRow[]) => {
+  await batchRequests(
+    Environment.API_URL,
+    invoices.map(invoice => ({
+      document: getDeleteMutation(),
+      variables: { invoiceId: invoice.id },
+    }))
+  );
+};
+
+export const onRead = async <T extends ObjectWithStringKeys>(queryParams: {
+  first: number;
+  offset: number;
+  sortBy: SortBy<T>;
+}): Promise<{ nodes: InvoiceRow[]; totalCount: number }> => {
+  const {
+    first = 20,
+    offset = 0,
+    sortBy = { key: 'TYPE', isDesc: false },
+  } = queryParams;
+
+  const result = await api.invoices({
+    first,
+    offset,
+    key: InvoiceSortFieldInput.Type,
+    desc: sortBy.isDesc,
+  });
+
+  const invoices = invoicesGuard(result);
+
+  const nodes = invoices.nodes.map(invoice => ({
+    ...invoice,
+    pricing: pricingGuard(invoice.pricing),
+  }));
+
+  return { nodes, totalCount: invoices.totalCount };
+};
+
+export const OutboundShipmentListViewApi: ListApi<InvoiceRow> = {
+  onQuery:
+    ({ first, offset, sortBy }) =>
+    () =>
+      onRead({ first, offset, sortBy }),
+  onDelete,
+  onUpdate,
+  onCreate,
+};

--- a/packages/invoices/src/OutboundShipment/ListView/api.ts
+++ b/packages/invoices/src/OutboundShipment/ListView/api.ts
@@ -130,21 +130,26 @@ export const onRead = async <T extends ObjectWithStringKeys>(queryParams: {
     sortBy = { key: 'TYPE', isDesc: false },
   } = queryParams;
 
-  const result = await api.invoices({
-    first,
-    offset,
-    key: InvoiceSortFieldInput.Type,
-    desc: sortBy.isDesc,
-  });
+  try {
+    const result = await api.invoices({
+      first,
+      offset,
+      key: InvoiceSortFieldInput.Type,
+      desc: sortBy.isDesc,
+    });
 
-  const invoices = invoicesGuard(result);
+    const invoices = invoicesGuard(result);
 
-  const nodes = invoices.nodes.map(invoice => ({
-    ...invoice,
-    pricing: pricingGuard(invoice.pricing),
-  }));
+    const nodes = invoices.nodes.map(invoice => ({
+      ...invoice,
+      pricing: pricingGuard(invoice.pricing),
+    }));
 
-  return { nodes, totalCount: invoices.totalCount };
+    return { nodes, totalCount: invoices.totalCount };
+  } catch (e) {
+    // TODO: Handle error statuses from API nicely
+    throw e;
+  }
 };
 
 export const OutboundShipmentListViewApi: ListApi<InvoiceRow> = {

--- a/packages/system/src/Customer/ListView/ListView.tsx
+++ b/packages/system/src/Customer/ListView/ListView.tsx
@@ -48,7 +48,7 @@ const listQueryFn = async ({
 };
 
 const Api: ListApi<Name> = {
-  onQuery:
+  onRead:
     ({ first, offset, sortBy }) =>
     () =>
       listQueryFn({ first, offset, sortBy }),

--- a/packages/system/src/Customer/ListView/ListView.tsx
+++ b/packages/system/src/Customer/ListView/ListView.tsx
@@ -1,4 +1,3 @@
-import { Environment } from '@openmsupply-client/config';
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -7,61 +6,10 @@ import {
   useListData,
   Name,
   useColumns,
-  ListApi,
   createTableStore,
-  SortBy,
-  getSdk,
-  GraphQLClient,
   NameSortFieldInput,
 } from '@openmsupply-client/common';
-
-const client = new GraphQLClient(Environment.API_URL);
-const api = getSdk(client);
-
-const listQueryFn = async ({
-  first,
-  offset,
-  sortBy,
-}: {
-  first: number;
-  offset: number;
-  sortBy: SortBy<Name>;
-}): Promise<{
-  nodes: Name[];
-  totalCount: number;
-}> => {
-  const key =
-    sortBy.key === 'name' ? NameSortFieldInput.Name : NameSortFieldInput.Code;
-
-  const { names } = await api.names({
-    first,
-    offset,
-    key,
-    desc: sortBy.isDesc,
-  });
-
-  if (names.__typename === 'NameConnector') {
-    return names;
-  }
-
-  throw new Error(names.error.description);
-};
-
-const Api: ListApi<Name> = {
-  onRead:
-    ({ first, offset, sortBy }) =>
-    () =>
-      listQueryFn({ first, offset, sortBy }),
-  // TODO: Mutations!
-  onDelete: async () => {},
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  onUpdate: async () => {},
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  onCreate: async () => {},
-};
+import { CustomerListViewApi } from './api';
 
 export const ListView: FC = () => {
   const {
@@ -72,7 +20,11 @@ export const ListView: FC = () => {
     pagination,
     sortBy,
     onChangeSortBy,
-  } = useListData({ key: NameSortFieldInput.Name }, ['names', 'list'], Api);
+  } = useListData(
+    { key: NameSortFieldInput.Name },
+    ['names', 'list'],
+    CustomerListViewApi
+  );
   const navigate = useNavigate();
 
   const columns = useColumns<Name>(['name', 'code'], {

--- a/packages/system/src/Customer/ListView/api.ts
+++ b/packages/system/src/Customer/ListView/api.ts
@@ -1,0 +1,61 @@
+import { Environment } from '@openmsupply-client/config';
+import {
+  Name,
+  ListApi,
+  SortBy,
+  getSdk,
+  GraphQLClient,
+  NameSortFieldInput,
+  NamesQuery,
+} from '@openmsupply-client/common';
+
+const client = new GraphQLClient(Environment.API_URL);
+const api = getSdk(client);
+
+const namesGuard = (namesQuery: NamesQuery) => {
+  if (namesQuery.names.__typename === 'NameConnector') {
+    return namesQuery.names;
+  }
+  throw new Error(namesQuery.names.error.description);
+};
+
+const listQueryFn = async ({
+  first,
+  offset,
+  sortBy,
+}: {
+  first: number;
+  offset: number;
+  sortBy: SortBy<Name>;
+}): Promise<{
+  nodes: Name[];
+  totalCount: number;
+}> => {
+  const key =
+    sortBy.key === 'name' ? NameSortFieldInput.Name : NameSortFieldInput.Code;
+
+  const result = await api.names({
+    first,
+    offset,
+    key,
+    desc: sortBy.isDesc,
+  });
+
+  return namesGuard(result);
+};
+
+export const CustomerListViewApi: ListApi<Name> = {
+  onRead:
+    ({ first, offset, sortBy }) =>
+    () =>
+      listQueryFn({ first, offset, sortBy }),
+  // TODO: Mutations!
+  onDelete: async () => {},
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  onUpdate: async () => {},
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  onCreate: async () => {},
+};

--- a/packages/system/src/Item/ListView/ListView.tsx
+++ b/packages/system/src/Item/ListView/ListView.tsx
@@ -61,7 +61,7 @@ const listQueryFn = async ({
 };
 
 const Api: ListApi<Item> = {
-  onQuery:
+  onRead:
     ({ first, offset, sortBy }) =>
     () =>
       listQueryFn({ first, offset, sortBy }),

--- a/packages/system/src/Item/ListView/ListView.tsx
+++ b/packages/system/src/Item/ListView/ListView.tsx
@@ -1,4 +1,3 @@
-import { Environment } from '@openmsupply-client/config';
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -7,68 +6,9 @@ import {
   useListData,
   Item,
   useColumns,
-  ListApi,
   createTableStore,
-  SortBy,
-  getSdk,
-  GraphQLClient,
-  ItemSortFieldInput,
 } from '@openmsupply-client/common';
-
-const client = new GraphQLClient(Environment.API_URL);
-const api = getSdk(client);
-
-const listQueryFn = async ({
-  first,
-  offset,
-  sortBy,
-}: {
-  first: number;
-  offset: number;
-  sortBy: SortBy<Item>;
-}): Promise<{
-  nodes: Item[];
-  totalCount: number;
-}> => {
-  // TODO: Need to add a `sortByKey` to the Column type
-  const key =
-    sortBy.key === 'name' ? ItemSortFieldInput.Name : ItemSortFieldInput.Code;
-
-  const { items } = await api.items({
-    first,
-    offset,
-    key,
-    desc: sortBy.isDesc,
-  });
-
-  if (items.__typename === 'ItemConnector') {
-    const itemRows: Item[] = items.nodes.map(item => ({
-      ...item,
-      availableQuantity: 0,
-      unit: '',
-      availableBatches:
-        item.availableBatches.__typename === 'StockLineConnector'
-          ? item.availableBatches.nodes
-          : [],
-    }));
-
-    return {
-      totalCount: items.totalCount,
-      nodes: itemRows,
-    };
-  }
-  throw new Error(items.error.description);
-};
-
-const Api: ListApi<Item> = {
-  onRead:
-    ({ first, offset, sortBy }) =>
-    () =>
-      listQueryFn({ first, offset, sortBy }),
-  onDelete: () => null,
-  onUpdate: () => null,
-  onCreate: () => null,
-};
+import { ItemListViewApi } from './api';
 
 export const ListView: FC = () => {
   const {
@@ -79,7 +19,7 @@ export const ListView: FC = () => {
     pagination,
     sortBy,
     onChangeSortBy,
-  } = useListData({ key: 'NAME' }, ['items', 'list'], Api);
+  } = useListData({ key: 'NAME' }, ['items', 'list'], ItemListViewApi);
   const navigate = useNavigate();
 
   const columns = useColumns<Item>(['name', 'code'], {

--- a/packages/system/src/Item/ListView/api.ts
+++ b/packages/system/src/Item/ListView/api.ts
@@ -1,0 +1,78 @@
+import { Environment } from '@openmsupply-client/config';
+import {
+  Item,
+  ListApi,
+  SortBy,
+  getSdk,
+  GraphQLClient,
+  ItemSortFieldInput,
+  ItemsQuery,
+  StockLineConnector,
+  ConnectorError,
+} from '@openmsupply-client/common';
+
+const client = new GraphQLClient(Environment.API_URL);
+const api = getSdk(client);
+
+const itemsGuard = (itemsQuery: ItemsQuery) => {
+  if (itemsQuery.items.__typename === 'ItemConnector') {
+    return itemsQuery.items;
+  }
+
+  throw new Error(itemsQuery.items.error.description);
+};
+
+const availableBatchesGuard = (
+  availableBatches: StockLineConnector | ConnectorError
+) => {
+  if (availableBatches.__typename === 'StockLineConnector') {
+    return availableBatches.nodes;
+  }
+
+  throw new Error(availableBatches.error.description);
+};
+
+const onRead = async ({
+  first,
+  offset,
+  sortBy,
+}: {
+  first: number;
+  offset: number;
+  sortBy: SortBy<Item>;
+}): Promise<{
+  nodes: Item[];
+  totalCount: number;
+}> => {
+  // TODO: Need to add a `sortByKey` to the Column type
+  const key =
+    sortBy.key === 'name' ? ItemSortFieldInput.Name : ItemSortFieldInput.Code;
+
+  const result = await api.items({
+    first,
+    offset,
+    key,
+    desc: sortBy.isDesc,
+  });
+
+  const items = itemsGuard(result);
+
+  const nodes: Item[] = items.nodes.map(item => ({
+    ...item,
+    availableQuantity: 0,
+    unit: '',
+    availableBatches: availableBatchesGuard(item.availableBatches),
+  }));
+
+  return { totalCount: items.totalCount, nodes };
+};
+
+export const ItemListViewApi: ListApi<Item> = {
+  onRead:
+    ({ first, offset, sortBy }) =>
+    () =>
+      onRead({ first, offset, sortBy }),
+  onDelete: () => null,
+  onUpdate: () => null,
+  onCreate: () => null,
+};


### PR DESCRIPTION
Fixes #368 

*Sigh* cool diff..

Wondering what you think of this...

I wanted to make some sort of generic transformer which gets rid of all the 'nodes' but it ended up being way to messy. So went with the simpler duplicate a bunch of stuff approach..

currently if you have an error in one the guarded fields, an error is thrown - i.e.

```
    context.data({
      invoices: {
        ...result,
        error: { description: 'Error!' },
        __typename: 'NotInvoiceConnector',
      },
    })
```

will show "no records found" with a toast of the description..

I think it needs more work, handling all the different errors, but if there are errors in any of these guarded fields, I think   there's basically a big fuck up..