### PR TITLE
#367 sort out sorting

### DIFF
--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -11,7 +11,7 @@ describe('HeaderRow', () => {
     sortBy: { key: keyof Item; direction: 'asc' | 'desc' };
   }> = ({ onChangeSortBy, sortBy }) => {
     const [column1, column2] = useColumns(
-      ['name', ['packSize', { sortable: false }]],
+      ['status', ['packSize', { sortable: false }]],
       { onChangeSortBy, sortBy },
       [sortBy]
     );
@@ -40,7 +40,7 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const nameHeader = getByRole('columnheader', { name: /name/i });
+    const nameHeader = getByRole('columnheader', { name: /status/i });
     const packSizeHeader = getByRole('columnheader', { name: /packSize/i });
 
     expect(nameHeader).toBeInTheDocument();
@@ -57,7 +57,7 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const nameHeader = getByRole('button', { name: /name/i });
+    const nameHeader = getByRole('button', { name: /status/i });
     const packSizeHeader = queryByRole('button', { name: /pack size/i });
 
     expect(nameHeader).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const nameHeader = getByRole('button', { name: /name/i });
+    const nameHeader = getByRole('button', { name: /status/i });
 
     userEvent.click(nameHeader);
 
@@ -91,12 +91,14 @@ describe('HeaderRow', () => {
       </TestingProvider>
     );
 
-    const nameHeader = getByRole('button', { name: /name/i });
+    const nameHeader = getByRole('button', { name: /status/i });
 
     userEvent.click(nameHeader);
 
     waitFor(() => {
-      expect(onSortBy).toBeCalledWith(expect.objectContaining({ key: 'name' }));
+      expect(onSortBy).toBeCalledWith(
+        expect.objectContaining({ key: 'status' })
+      );
     });
   });
 });

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -65,11 +65,13 @@ const getColumnLookup = <T extends DomainObject>(): Record<
     key: 'name',
     label: 'label.name',
     width: 75,
+    sortable: false,
   },
   invoiceNumber: {
     key: 'invoiceNumber',
     label: 'label.invoice-number',
     width: 50,
+    sortable: false,
   },
   type: {
     label: 'label.type',
@@ -100,11 +102,13 @@ const getColumnLookup = <T extends DomainObject>(): Record<
     width: 100,
     format: ColumnFormat.Currency,
     align: ColumnAlign.Right,
+    sortable: false,
   },
   comment: {
     label: 'label.comment',
     key: 'comment',
     width: 250,
+    sortable: false,
   },
   selection: getCheckboxSelectionColumn(),
   code: {

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -86,7 +86,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
     onChangePage,
     pagination,
     invalidate,
-  } = useListData({ key: 'TYPE' }, 'invoice', OutboundShipmentListViewApi);
+  } = useListData({ key: 'status' }, 'invoice', OutboundShipmentListViewApi);
 
   const onColorUpdate = (row: InvoiceRow, color: Color) => {
     onUpdate({ ...row, color: color.hex });

--- a/packages/invoices/src/OutboundShipment/ListView/api.ts
+++ b/packages/invoices/src/OutboundShipment/ListView/api.ts
@@ -138,9 +138,6 @@ export const onUpdate = async (updated: InvoiceRow): Promise<InvoiceRow> => {
 const getSortKey = (
   sortBy: SortBy<OutboundShipment>
 ): InvoiceSortFieldInput => {
-  console.log('-------------------------------------------');
-  console.log('sortBy.key', sortBy.key);
-  console.log('-------------------------------------------');
   switch (sortBy.key) {
     case 'confirmedDatetime': {
       return InvoiceSortFieldInput.ConfirmDatetime;

--- a/packages/invoices/src/OutboundShipment/ListView/api.ts
+++ b/packages/invoices/src/OutboundShipment/ListView/api.ts
@@ -1,5 +1,5 @@
+import { OutboundShipment } from './../DetailView/types';
 import {
-  ObjectWithStringKeys,
   InvoicesQuery,
   request,
   gql,
@@ -10,6 +10,7 @@ import {
   GraphQLClient,
   getSdk,
   InvoiceSortFieldInput,
+  InvoicesQueryVariables,
   InvoiceRow,
   InvoicePriceResponse,
 } from '@openmsupply-client/common';
@@ -107,23 +108,10 @@ export const onDelete = async (invoices: InvoiceRow[]) => {
   );
 };
 
-export const onRead = async <T extends ObjectWithStringKeys>(queryParams: {
-  first: number;
-  offset: number;
-  sortBy: SortBy<T>;
-}): Promise<{ nodes: InvoiceRow[]; totalCount: number }> => {
-  const {
-    first = 20,
-    offset = 0,
-    sortBy = { key: 'TYPE', isDesc: false },
-  } = queryParams;
-
-  const result = await api.invoices({
-    first,
-    offset,
-    key: InvoiceSortFieldInput.Type,
-    desc: sortBy.isDesc,
-  });
+export const onRead = async (
+  queryParams: InvoicesQueryVariables
+): Promise<{ nodes: InvoiceRow[]; totalCount: number }> => {
+  const result = await api.invoices(queryParams);
 
   const invoices = invoicesGuard(result);
 
@@ -147,11 +135,44 @@ export const onUpdate = async (updated: InvoiceRow): Promise<InvoiceRow> => {
   return updateInvoice;
 };
 
+const getSortKey = (
+  sortBy: SortBy<OutboundShipment>
+): InvoiceSortFieldInput => {
+  console.log('-------------------------------------------');
+  console.log('sortBy.key', sortBy.key);
+  console.log('-------------------------------------------');
+  switch (sortBy.key) {
+    case 'confirmedDatetime': {
+      return InvoiceSortFieldInput.ConfirmDatetime;
+    }
+    case 'entryDatetime': {
+      return InvoiceSortFieldInput.EntryDatetime;
+    }
+    case 'finalisedDateTime': {
+      return InvoiceSortFieldInput.FinalisedDateTime;
+    }
+    case 'status':
+    default: {
+      return InvoiceSortFieldInput.Status;
+    }
+  }
+};
+
+const getSortDesc = (sortBy: SortBy<OutboundShipment>): boolean => {
+  return !!sortBy.isDesc;
+};
+
 export const OutboundShipmentListViewApi: ListApi<InvoiceRow> = {
-  onRead:
-    ({ first, offset, sortBy }) =>
-    () =>
-      onRead({ first, offset, sortBy }),
+  onRead: ({ first, offset, sortBy }) => {
+    const queryParams: InvoicesQueryVariables = {
+      first,
+      offset,
+      key: getSortKey(sortBy),
+      desc: getSortDesc(sortBy),
+    };
+
+    return () => onRead(queryParams);
+  },
   onDelete,
   onUpdate,
   onCreate,

--- a/packages/mock-server/src/data/types.ts
+++ b/packages/mock-server/src/data/types.ts
@@ -108,13 +108,6 @@ export interface ResolvedInvoice extends Invoice {
   otherPartyName: string;
 }
 
-export interface PaginationOptions {
-  first: number;
-  offset: number;
-  sort?: string;
-  desc: boolean;
-}
-
 export interface ListResponse<T> {
   totalCount: number;
   nodes: T[];

--- a/packages/mock-server/src/schema/Invoice.ts
+++ b/packages/mock-server/src/schema/Invoice.ts
@@ -1,3 +1,4 @@
+import { InvoiceSortFieldInput } from '@openmsupply-client/common/src/types/schema';
 import { Api } from '../api';
 
 import { ListResponse, Invoice as InvoiceType } from '../data/types';
@@ -5,19 +6,16 @@ import { ListResponse, Invoice as InvoiceType } from '../data/types';
 const QueryResolvers = {
   invoices: (
     _: any,
-    {
-      page = { first: 10, offset: 0 },
-      sort = { key: 'TYPE', desc: false },
-    }: {
-      page: { first: number; offset: number };
-      sort: { key: string; desc: boolean };
+    vars: {
+      page?: { first?: number; offset?: number };
+      sort: [{ key: InvoiceSortFieldInput; desc: boolean }];
     }
   ): ListResponse<InvoiceType> => {
     return Api.ResolverService.list.invoice({
-      first: page.first,
-      offset: page.offset,
-      desc: sort.desc,
-      sort: sort.key,
+      first: vars.page?.first ?? 20,
+      offset: vars.page?.offset ?? 0,
+      desc: vars.sort[0].desc ?? false,
+      key: vars.sort[0].key ?? InvoiceSortFieldInput.Status,
     });
   },
 

--- a/packages/mock-server/src/schema/Item.ts
+++ b/packages/mock-server/src/schema/Item.ts
@@ -1,22 +1,20 @@
+import { ItemSortFieldInput } from '@openmsupply-client/common/src/types/schema';
 import { Api } from '../api';
 import { ListResponse, Item as ItemType } from '../data/types';
 
 const QueryResolvers = {
   items: (
     _: any,
-    {
-      page = { first: 100, offset: 0 },
-      sort = [{ key: 'NAME', desc: false }],
-    }: {
-      page: { first: number; offset: number };
-      sort: { key: string; desc: boolean }[];
+    vars: {
+      page?: { first?: number; offset?: number };
+      sort: [{ key: ItemSortFieldInput; desc: boolean }];
     }
   ): ListResponse<ItemType> => {
     return Api.ResolverService.list.item({
-      first: page.first,
-      offset: page.offset,
-      desc: sort[0]?.desc ?? false,
-      sort: sort[0]?.key ?? 'NAME',
+      first: vars?.page?.first ?? 20,
+      offset: vars?.page?.offset ?? 0,
+      desc: vars.sort[0]?.desc ?? false,
+      key: vars.sort[0]?.key ?? ItemSortFieldInput.Name,
     });
   },
 };

--- a/packages/mock-server/src/schema/Name.ts
+++ b/packages/mock-server/src/schema/Name.ts
@@ -3,7 +3,7 @@ import { Api } from '../api';
 import { ListResponse, Name as NameType } from '../data/types';
 
 const QueryResolvers = {
-  items: (
+  names: (
     _: any,
     vars: {
       page?: { first?: number; offset?: number };

--- a/packages/mock-server/src/schema/Name.ts
+++ b/packages/mock-server/src/schema/Name.ts
@@ -1,22 +1,20 @@
+import { NameSortFieldInput } from '@openmsupply-client/common/src/types/schema';
 import { Api } from '../api';
 import { ListResponse, Name as NameType } from '../data/types';
 
 const QueryResolvers = {
-  names: (
+  items: (
     _: any,
-    {
-      page = { first: 100, offset: 0 },
-      sort = [{ key: 'NAME', desc: false }],
-    }: {
-      page: { first: number; offset: number };
-      sort: { key: string; desc: boolean }[];
+    vars: {
+      page?: { first?: number; offset?: number };
+      sort: [{ key: NameSortFieldInput; desc: boolean }];
     }
   ): ListResponse<NameType> => {
-    return Api.ResolverService.list.name('customer', {
-      first: page.first,
-      offset: page.offset,
-      desc: sort[0]?.desc ?? false,
-      sort: sort[0]?.key ?? 'NAME',
+    return Api.ResolverService.list.name({
+      first: vars?.page?.first,
+      offset: vars?.page?.offset,
+      desc: vars?.sort[0]?.desc ?? false,
+      key: vars?.sort[0]?.key ?? NameSortFieldInput.Name,
     });
   },
 };

--- a/packages/mock-server/src/worker/handlers.ts
+++ b/packages/mock-server/src/worker/handlers.ts
@@ -1,6 +1,11 @@
-import { PaginationOptions, Invoice } from './../data/types';
+import { Invoice } from './../data/types';
 import { graphql, rest } from 'msw';
 import { Api } from '../api';
+import {
+  InvoicesQueryVariables,
+  ItemsQueryVariables,
+  NamesQueryVariables,
+} from '@openmsupply-client/common';
 
 const updateInvoice = graphql.mutation(
   'updateInvoice',
@@ -43,42 +48,22 @@ const deleteInvoice = graphql.mutation(
 
 export const namesList = graphql.query<
   Record<string, unknown>,
-  PaginationOptions & { key: string }
+  NamesQueryVariables
 >('names', (request, response, context) => {
-  const {
-    variables = {
-      first: 50,
-      offset: 0,
-      key: 'NAME',
-      desc: false,
-    },
-  } = request;
+  const { variables } = request;
 
-  const result = Api.ResolverService.list.name('customer', {
-    ...variables,
-    sort: variables.key,
-  });
+  const result = Api.ResolverService.list.name(variables);
 
   return response(context.data({ names: result }));
 });
 
 export const invoiceList = graphql.query<
-  Record<string, unknown>,
-  PaginationOptions & { key: string }
+  Record<string, any>,
+  InvoicesQueryVariables
 >('invoices', (request, response, context) => {
-  const {
-    variables = {
-      first: 50,
-      offset: 0,
-      key: 'STATUS',
-      desc: false,
-    },
-  } = request;
+  const { variables } = request;
 
-  const result = Api.ResolverService.list.invoice({
-    ...variables,
-    sort: variables.key,
-  });
+  const result = Api.ResolverService.list.invoice(variables);
 
   return response(context.data({ invoices: result }));
 });
@@ -111,20 +96,10 @@ export const invoiceDetailByInvoiceNumber = graphql.query(
 
 export const itemList = graphql.query<
   Record<string, unknown>,
-  PaginationOptions & { key: string }
+  ItemsQueryVariables
 >('items', (request, response, context) => {
-  const {
-    variables = {
-      first: 50,
-      offset: 0,
-      key: 'NAME',
-      desc: false,
-    },
-  } = request;
-  const result = Api.ResolverService.list.item({
-    ...variables,
-    sort: variables.key,
-  });
+  const { variables } = request;
+  const result = Api.ResolverService.list.item(variables);
 
   return response(context.data({ items: result }));
 });

--- a/packages/system/src/Customer/ListView/ListView.tsx
+++ b/packages/system/src/Customer/ListView/ListView.tsx
@@ -7,7 +7,6 @@ import {
   Name,
   useColumns,
   createTableStore,
-  NameSortFieldInput,
 } from '@openmsupply-client/common';
 import { CustomerListViewApi } from './api';
 
@@ -20,11 +19,7 @@ export const ListView: FC = () => {
     pagination,
     sortBy,
     onChangeSortBy,
-  } = useListData(
-    { key: NameSortFieldInput.Name },
-    ['names', 'list'],
-    CustomerListViewApi
-  );
+  } = useListData({ key: 'name' }, ['names', 'list'], CustomerListViewApi);
   const navigate = useNavigate();
 
   const columns = useColumns<Name>(['name', 'code'], {

--- a/packages/system/src/Item/ListView/ListView.tsx
+++ b/packages/system/src/Item/ListView/ListView.tsx
@@ -19,7 +19,7 @@ export const ListView: FC = () => {
     pagination,
     sortBy,
     onChangeSortBy,
-  } = useListData({ key: 'NAME' }, ['items', 'list'], ItemListViewApi);
+  } = useListData({ key: 'name' }, ['items', 'list'], ItemListViewApi);
   const navigate = useNavigate();
 
   const columns = useColumns<Item>(['name', 'code'], {


### PR DESCRIPTION
Fixes #367 

- This aligns with the backend sorting
- I've just made it so we map the sort key to the enum of what the backend provides in the api layer. I was going to add a `sortKey` to the column, but then I would need to add another generic to a bunch of stuff which defines the set of sort keys, and then also we would have the client side sorting needing to use different types.. I figured to just do this, which isn't as 'safe' in terms of ensuring that a columns sort key is guaranteed to be sortable but is simpler and easier, I think