### PR TITLE
#389 make buttons responsive

### DIFF
--- a/packages/common/src/hooks/useDetailPanel.tsx
+++ b/packages/common/src/hooks/useDetailPanel.tsx
@@ -25,7 +25,7 @@ export const useDetailPanel = (): DetailPanel => {
     <ButtonWithIcon
       Icon={<SidebarIcon />}
       labelKey="button.more"
-      onClick={() => open()}
+      onClick={open}
     />
   );
 

--- a/packages/common/src/hooks/useIsScreen/index.ts
+++ b/packages/common/src/hooks/useIsScreen/index.ts
@@ -2,3 +2,4 @@ export * from './useIsLargeScreen';
 export * from './useIsMediumScreen';
 export * from './useIsExtraLargeScreen';
 export * from './useIsSmallScreen';
+export * from './useIsScreen';

--- a/packages/common/src/hooks/useIsScreen/useIsExtraLargeScreen.test.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsExtraLargeScreen.test.ts
@@ -14,6 +14,17 @@ describe('useIsExtraLargeScreen', () => {
     expect(current).toBe(true);
   });
 
+  it('Returns false when the screen is 1536', () => {
+    setScreenSize_ONLY_FOR_TESTING(1536);
+
+    const { result } = renderHook(useIsExtraLargeScreen, {
+      wrapper: TestingProvider,
+    });
+    const { current } = result;
+
+    expect(current).toBe(false);
+  });
+
   it('Returns false when the screen is less than 1536', () => {
     setScreenSize_ONLY_FOR_TESTING(1535);
 

--- a/packages/common/src/hooks/useIsScreen/useIsExtraLargeScreen.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsExtraLargeScreen.ts
@@ -1,7 +1,6 @@
-import { useMediaQuery, useTheme } from '@mui/material';
+import { useTheme, useMediaQuery } from '@mui/material';
 
 export const useIsExtraLargeScreen = (): boolean => {
   const theme = useTheme();
-
   return useMediaQuery(theme.breakpoints.up('xl'));
 };

--- a/packages/common/src/hooks/useIsScreen/useIsLargeScreen.test.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsLargeScreen.test.ts
@@ -14,6 +14,17 @@ describe('useIsLargeScreen', () => {
     expect(current).toBe(true);
   });
 
+  it('Returns true when the screen is 1536', () => {
+    setScreenSize_ONLY_FOR_TESTING(1536);
+
+    const { result } = renderHook(useIsLargeScreen, {
+      wrapper: TestingProvider,
+    });
+    const { current } = result;
+
+    expect(current).toBe(true);
+  });
+
   it('Returns false when the screen is greater than 1536', () => {
     setScreenSize_ONLY_FOR_TESTING(1537);
 

--- a/packages/common/src/hooks/useIsScreen/useIsLargeScreen.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsLargeScreen.ts
@@ -1,7 +1,5 @@
-import { useMediaQuery, useTheme } from '@mui/material';
+import { useIsScreen } from './useIsScreen';
 
 export const useIsLargeScreen = (): boolean => {
-  const theme = useTheme();
-
-  return useMediaQuery(theme.breakpoints.down('xl'));
+  return useIsScreen('xl');
 };

--- a/packages/common/src/hooks/useIsScreen/useIsMediumScreen.test.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsMediumScreen.test.ts
@@ -13,6 +13,16 @@ describe('useIsMediumScreen', () => {
     expect(current).toBe(true);
   });
 
+  it('Returns true when the screen is 1440', () => {
+    setScreenSize_ONLY_FOR_TESTING(1440);
+    const { result } = renderHook(useIsMediumScreen, {
+      wrapper: TestingProvider,
+    });
+    const { current } = result;
+
+    expect(current).toBe(true);
+  });
+
   it('Returns false when the screen is greater than 1440', () => {
     setScreenSize_ONLY_FOR_TESTING(1441);
 

--- a/packages/common/src/hooks/useIsScreen/useIsMediumScreen.tsx
+++ b/packages/common/src/hooks/useIsScreen/useIsMediumScreen.tsx
@@ -1,6 +1,5 @@
-import { useMediaQuery, useTheme } from '@mui/material';
+import { useIsScreen } from './useIsScreen';
 
 export const useIsMediumScreen = (): boolean => {
-  const theme = useTheme();
-  return useMediaQuery(theme.breakpoints.down('lg'));
+  return useIsScreen('lg');
 };

--- a/packages/common/src/hooks/useIsScreen/useIsScreen.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsScreen.ts
@@ -1,0 +1,9 @@
+import { useMediaQuery, Breakpoint } from '@mui/material';
+import { useAppTheme } from './../../styles/useAppTheme';
+
+export { Breakpoint } from '@mui/material';
+
+export const useIsScreen = (breakpoint: Breakpoint): boolean => {
+  const theme = useAppTheme();
+  return useMediaQuery(theme.breakpoints.down(breakpoint));
+};

--- a/packages/common/src/hooks/useIsScreen/useIsSmallScreen.test.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsSmallScreen.test.ts
@@ -13,6 +13,16 @@ describe('useIsSmallScreen', () => {
     expect(current).toBe(true);
   });
 
+  it('Returns true when the screen is 1024', () => {
+    setScreenSize_ONLY_FOR_TESTING(1024);
+    const { result } = renderHook(useIsSmallScreen, {
+      wrapper: TestingProvider,
+    });
+    const { current } = result;
+
+    expect(current).toBe(true);
+  });
+
   it('Returns false when the screen is greater than 1024', () => {
     setScreenSize_ONLY_FOR_TESTING(1025);
 

--- a/packages/common/src/hooks/useIsScreen/useIsSmallScreen.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsSmallScreen.ts
@@ -1,6 +1,5 @@
-import { useMediaQuery, useTheme } from '@mui/material';
+import { useIsScreen } from './useIsScreen';
 
 export const useIsSmallScreen = (): boolean => {
-  const theme = useTheme();
-  return useMediaQuery(theme.breakpoints.down('md'));
+  return useIsScreen('md');
 };

--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -82,7 +82,7 @@ const themeOptions = {
       sm: 599,
       md: 1025,
       lg: 1441,
-      xl: 1535,
+      xl: 1537,
     },
   },
   direction: 'rtl' as Direction,

--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -79,10 +79,10 @@ const themeOptions = {
   breakpoints: {
     values: {
       xs: 0,
-      sm: 600,
-      md: 1024,
-      lg: 1440,
-      xl: 1536,
+      sm: 599,
+      md: 1025,
+      lg: 1441,
+      xl: 1535,
     },
   },
   direction: 'rtl' as Direction,

--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -79,7 +79,7 @@ const themeOptions = {
   breakpoints: {
     values: {
       xs: 0,
-      sm: 599,
+      sm: 601,
       md: 1025,
       lg: 1441,
       xl: 1537,

--- a/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
@@ -53,6 +53,7 @@ export const ButtonWithIcon: React.FC<ButtonWithIconProps> = ({
           color={color}
           size="small"
           startIcon={startIcon}
+          aria-label={t(labelKey, labelProps)}
           {...buttonProps}
         >
           {centeredIcon}

--- a/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
@@ -5,8 +5,8 @@ import {
   LocaleProps,
   useTranslation,
 } from '../../../../intl/intlHelpers';
-import { useIsSmallScreen } from '../../../../hooks';
 import { ShrinkableBaseButton } from './ShrinkableBaseButton';
+import { useIsScreen } from '../../../../hooks/useIsScreen';
 
 interface ButtonWithIconProps extends ButtonProps {
   Icon: React.ReactNode;
@@ -17,6 +17,7 @@ interface ButtonWithIconProps extends ButtonProps {
   variant?: 'outlined' | 'contained';
   color?: 'primary' | 'secondary';
   disabled?: boolean;
+  shrinkThreshold?: 'sm' | 'md' | 'lg' | 'xl';
 }
 
 export const ButtonWithIcon: React.FC<ButtonWithIconProps> = ({
@@ -28,14 +29,15 @@ export const ButtonWithIcon: React.FC<ButtonWithIconProps> = ({
   color = 'primary',
   disabled,
   labelProps,
+  shrinkThreshold = 'md',
   ...buttonProps
 }) => {
   const t = useTranslation();
-  const isSmallScreen = useIsSmallScreen();
+  const isShrinkThreshold = useIsScreen(shrinkThreshold);
 
   // On small screens, if the button shouldShrink, then
   // only display a centered icon, with no text.
-  const shrink = isSmallScreen && shouldShrink;
+  const shrink = isShrinkThreshold && shouldShrink;
   const startIcon = shrink ? null : Icon;
   const centeredIcon = shrink ? Icon : null;
   const text = shrink ? null : t(labelKey, labelProps);

--- a/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.tsx
+++ b/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.tsx
@@ -10,12 +10,19 @@ import {
 } from '../../../../intl/intlHelpers';
 import { VerticalStepper } from '../../steppers/VerticalStepper';
 import { PaperPopover, PaperPopoverSection } from '../../popover';
+import { useIsSmallScreen } from '../../../..';
+import { styled } from '@mui/system';
 
 interface StatusCrumbsProps<StatusType extends string> {
   statuses: StatusType[];
   statusLog: Record<StatusType, string | null | undefined>;
   statusFormatter: (status: StatusType) => LocaleKey;
 }
+
+const StyledText = styled(Typography)({
+  fontWeight: 700,
+  fontSize: '12px',
+});
 
 const useSteps = <StatusType extends string>({
   statuses,
@@ -31,9 +38,10 @@ const useSteps = <StatusType extends string>({
 
 export const StatusCrumbs = <StatusType extends string>(
   props: StatusCrumbsProps<StatusType>
-): JSX.Element => {
+): JSX.Element | null => {
   const { statuses, statusLog, statusFormatter } = props;
   const t = useTranslation();
+  const isSmallScreen = useIsSmallScreen();
 
   const steps = useSteps(props);
 
@@ -41,6 +49,30 @@ export const StatusCrumbs = <StatusType extends string>(
     if (statusLog[status]) return idx;
     return acc;
   }, 0);
+
+  let Crumbs = null;
+  if (isSmallScreen) {
+    const stepKey = statuses[currentStep];
+    if (!stepKey) return null;
+    Crumbs = (
+      <Box flexDirection="row" display="flex" gap={1} justifyContent="center">
+        <StyledText>{t('label.status')}</StyledText>
+        <StyledText color={'secondary'}>
+          {t(statusFormatter(stepKey))}
+        </StyledText>
+      </Box>
+    );
+  } else {
+    Crumbs = statuses.map(status => {
+      const date = statusLog[status];
+
+      return (
+        <StyledText color={date ? 'secondary' : 'gray.main'} key={status}>
+          {t(statusFormatter(status))}
+        </StyledText>
+      );
+    });
+  }
 
   return (
     <PaperPopover
@@ -73,19 +105,7 @@ export const StatusCrumbs = <StatusType extends string>(
             />
           }
         >
-          {statuses.map(status => {
-            const date = statusLog[status];
-
-            return (
-              <Typography
-                color={date ? 'secondary' : 'gray.main'}
-                key={status}
-                sx={{ fontWeight: 700, fontSize: '12px' }}
-              >
-                {t(statusFormatter(status))}
-              </Typography>
-            );
-          })}
+          {Crumbs}
         </Breadcrumbs>
       </Box>
     </PaperPopover>

--- a/packages/invoices/src/OutboundShipment/DetailView/Footer.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Footer.tsx
@@ -76,6 +76,7 @@ export const Footer: FC<OutboundDetailFooterProps> = ({ draft, save }) => {
 
           <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
             <ButtonWithIcon
+              shrinkThreshold="lg"
               Icon={<XCircleIcon />}
               labelKey="button.cancel"
               color="secondary"
@@ -85,6 +86,7 @@ export const Footer: FC<OutboundDetailFooterProps> = ({ draft, save }) => {
             {isInvoiceEditable(draft) && (
               <>
                 <ButtonWithIcon
+                  shrinkThreshold="lg"
                   Icon={<SaveIcon />}
                   labelKey="button.save"
                   variant="contained"
@@ -96,6 +98,7 @@ export const Footer: FC<OutboundDetailFooterProps> = ({ draft, save }) => {
                   }}
                 />
                 <ButtonWithIcon
+                  shrinkThreshold="lg"
                   disabled={draft.hold}
                   Icon={<ArrowRightIcon />}
                   labelKey="button.save-and-confirm-status"


### PR DESCRIPTION
Fixes #389 

- Made the buttons shrink slightly earlier
![image](https://user-images.githubusercontent.com/35858975/140631743-23f655fc-6cef-4ff3-a35c-432c71a13c96.png)
- Went off road and made the status crumb component just a single crumb when the screens too small:
![image](https://user-images.githubusercontent.com/35858975/140631757-d08475d9-9f20-41de-9a20-3c268cb79064.png)


which is trying to handle this situation

![image](https://user-images.githubusercontent.com/35858975/140631774-a31b8caa-0b70-447a-afc0-833563e7bb15.png)

(And as I look at this, I notice we will need to also sort out the normal breadcrumbs for when we add the invoice number)

Not ideal, but more ideal than taking more vertical space by adding even more to the footer

