### PR TITLE
#327 add filtering

### DIFF
--- a/packages/common/src/hooks/useFilterBy/index.ts
+++ b/packages/common/src/hooks/useFilterBy/index.ts
@@ -1,0 +1,1 @@
+export * from './useFilterBy';

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
@@ -1,0 +1,118 @@
+import { act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useFilterBy } from './useFilterBy';
+
+describe('useFilterBy', () => {
+  it('is truthy', () => {
+    expect(useFilterBy).toBeTruthy();
+  });
+
+  it('returns the correct initial state', () => {
+    const { result } = renderHook(() =>
+      useFilterBy({
+        comment: { equalTo: 'a' },
+        confirmedDatetime: { equalTo: '1/1/2020' },
+      })
+    );
+
+    expect(result.current.filterBy).toEqual({
+      comment: { equalTo: 'a' },
+      confirmedDatetime: { equalTo: '1/1/2020' },
+    });
+  });
+
+  it('updates date filter values', () => {
+    const { result } = renderHook(() =>
+      useFilterBy({
+        comment: { equalTo: 'a' },
+        confirmedDatetime: { equalTo: '1/1/2020' },
+      })
+    );
+
+    const now = new Date();
+
+    act(() => {
+      result.current.onChangeDateFilterRule(
+        'confirmedDatetime',
+        'beforeOrEqualTo',
+        now
+      );
+    });
+
+    expect(result.current.filterBy.confirmedDatetime.beforeOrEqualTo).toEqual(
+      now
+    );
+  });
+
+  it('updates date filters', () => {
+    const { result } = renderHook(() =>
+      useFilterBy({
+        comment: { equalTo: 'a' },
+        confirmedDatetime: { equalTo: '1/1/2020' },
+      })
+    );
+
+    const now = new Date();
+
+    act(() => {
+      result.current.onChangeDateFilterRule(
+        'confirmedDatetime',
+        'beforeOrEqualTo',
+        now
+      );
+    });
+
+    expect(result.current.filterBy).toEqual({
+      comment: { equalTo: 'a' },
+      confirmedDatetime: { beforeOrEqualTo: now },
+    });
+  });
+
+  it('updates string filter values', () => {
+    const { result } = renderHook(() =>
+      useFilterBy({ comment: { equalTo: 'a' } })
+    );
+
+    act(() => {
+      result.current.onChangeStringFilterRule('comment', 'equalTo', 'josh');
+    });
+
+    expect(result.current.filterBy.comment.equalTo).toEqual('josh');
+  });
+
+  it('updates string filters', () => {
+    const { result } = renderHook(() =>
+      useFilterBy({
+        comment: { equalTo: 'a' },
+        confirmedDatetime: { equalTo: '1/1/2020' },
+      })
+    );
+
+    act(() => {
+      result.current.onChangeStringFilterRule('comment', 'like', 'josh');
+    });
+
+    expect(result.current.filterBy).toEqual({
+      comment: { like: 'josh' },
+      confirmedDatetime: { equalTo: '1/1/2020' },
+    });
+  });
+
+  it('updates string filters', () => {
+    const { result } = renderHook(() =>
+      useFilterBy({
+        comment: { equalTo: 'a' },
+        confirmedDatetime: { equalTo: '1/1/2020' },
+      })
+    );
+
+    act(() => {
+      result.current.onClearFilterRule('comment');
+    });
+
+    expect(result.current.filterBy).toEqual({
+      comment: null,
+      confirmedDatetime: { equalTo: '1/1/2020' },
+    });
+  });
+});

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
@@ -99,20 +99,19 @@ describe('useFilterBy', () => {
   });
 
   it('updates string filters', () => {
-    const { result } = renderHook(() =>
-      useFilterBy({
-        comment: { equalTo: 'a' },
-        confirmedDatetime: { equalTo: '1/1/2020' },
-      })
-    );
+    const { result } = renderHook(() => useFilterBy<X>());
 
     act(() => {
       result.current.onClearFilterRule('comment');
     });
 
-    expect(result.current.filterBy).toEqual({
+    expect(result.current.filterBy?.comment?.like).toEqual({
       comment: null,
       confirmedDatetime: { equalTo: '1/1/2020' },
     });
   });
 });
+
+interface X {
+  comment: string;
+}

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
@@ -39,7 +39,7 @@ describe('useFilterBy', () => {
       );
     });
 
-    expect(result.current.filterBy.confirmedDatetime.beforeOrEqualTo).toEqual(
+    expect(result.current.filterBy?.confirmedDatetime?.beforeOrEqualTo).toEqual(
       now
     );
   });
@@ -77,7 +77,7 @@ describe('useFilterBy', () => {
       result.current.onChangeStringFilterRule('comment', 'equalTo', 'josh');
     });
 
-    expect(result.current.filterBy.comment.equalTo).toEqual('josh');
+    expect(result.current.filterBy?.comment?.equalTo).toEqual('josh');
   });
 
   it('updates string filters', () => {

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
@@ -110,7 +110,7 @@ describe('useFilterBy', () => {
       result.current.onClearFilterRule('comment');
     });
 
-    expect(result.current.filterBy?.comment?.like).toEqual({
+    expect(result.current.filterBy).toEqual({
       comment: null,
       confirmedDatetime: { equalTo: '1/1/2020' },
     });

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.test.tsx
@@ -99,7 +99,12 @@ describe('useFilterBy', () => {
   });
 
   it('updates string filters', () => {
-    const { result } = renderHook(() => useFilterBy<X>());
+    const { result } = renderHook(() =>
+      useFilterBy({
+        comment: { equalTo: 'a' },
+        confirmedDatetime: { equalTo: '1/1/2020' },
+      })
+    );
 
     act(() => {
       result.current.onClearFilterRule('comment');
@@ -111,7 +116,3 @@ describe('useFilterBy', () => {
     });
   });
 });
-
-interface X {
-  comment: string;
-}

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
@@ -13,7 +13,7 @@ type FilterRule = {
 
 export type FilterBy<T> = Partial<Record<Partial<keyof T>, FilterRule>>;
 
-interface UseFilterByControl<T> {
+export interface FilterState<T> {
   filterBy: FilterBy<T> | null;
 
   onChangeDateFilterRule: (
@@ -33,7 +33,7 @@ interface UseFilterByControl<T> {
 
 export const useFilterBy = <T extends unknown>(
   initialFilterBy?: FilterBy<T> | null
-): UseFilterByControl<T> => {
+): FilterState<T> => {
   const [filterBy, setFilterBy] = useState<FilterBy<T> | null>(
     initialFilterBy ?? null
   );

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
@@ -11,55 +11,52 @@ type FilterRule = {
     | FilterByConditionByType['date']]?: unknown;
 };
 
-type FilterBy<PossibleFilterKey extends string> = Record<
-  PossibleFilterKey,
-  FilterRule
->;
+export type FilterBy<T> = Partial<Record<Partial<keyof T>, FilterRule>>;
 
-interface UseFilterByControl<PossibleFilterKey extends string> {
-  filterBy: FilterBy<PossibleFilterKey>;
+interface UseFilterByControl<T> {
+  filterBy: FilterBy<T> | null;
 
   onChangeDateFilterRule: (
-    key: PossibleFilterKey,
+    key: keyof T,
     condition: FilterByConditionByType['date'],
     value: Date
   ) => void;
 
   onChangeStringFilterRule: (
-    key: PossibleFilterKey,
+    key: keyof T,
     condition: FilterByConditionByType['string'],
     value: string
   ) => void;
 
-  onClearFilterRule: (key: PossibleFilterKey) => void;
+  onClearFilterRule: (key: keyof T) => void;
 }
 
-export const useFilterBy = <PossibleFilterKey extends string>(
-  initialFilterBy: FilterBy<PossibleFilterKey>
-): UseFilterByControl<PossibleFilterKey> => {
-  const [filterBy, setFilterBy] =
-    useState<FilterBy<PossibleFilterKey>>(initialFilterBy);
+export const useFilterBy = <T extends unknown>(
+  initialFilterBy?: FilterBy<T> | null
+): UseFilterByControl<T> => {
+  const [filterBy, setFilterBy] = useState<FilterBy<T> | null>(
+    initialFilterBy ?? null
+  );
 
   const onChangeStringFilterRule = (
-    key: PossibleFilterKey,
+    key: keyof T,
     condition: FilterByConditionByType['string'],
     value: string
   ) => {
-    const newFilterRule = { [key]: { [condition]: value } };
-
-    setFilterBy({ ...filterBy, ...newFilterRule });
+    const newFilter = { [key]: { [condition]: value } };
+    setFilterBy({ ...filterBy, ...newFilter });
   };
 
   const onChangeDateFilterRule = (
-    key: PossibleFilterKey,
+    key: keyof T,
     condition: FilterByConditionByType['date'],
     value: Date
   ) => {
-    const newFilterRule = { [key]: { [condition]: value } };
-    setFilterBy({ ...filterBy, ...newFilterRule });
+    const newFilter = { [key]: { [condition]: value } };
+    setFilterBy({ ...filterBy, ...newFilter });
   };
 
-  const onClearFilterRule = (key: PossibleFilterKey) => {
+  const onClearFilterRule = (key: keyof T) => {
     setFilterBy({ ...filterBy, [key]: null });
   };
 

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+interface FilterByConditionByType {
+  string: 'equalTo' | 'like';
+  date: 'beforeOrEqualTo' | 'afterOrEqualTo' | 'equalTo';
+}
+
+type FilterRule = {
+  [P in
+    | FilterByConditionByType['string']
+    | FilterByConditionByType['date']]?: unknown;
+};
+
+type FilterBy<PossibleFilterKey extends string> = Record<
+  PossibleFilterKey,
+  FilterRule
+>;
+
+interface UseFilterByControl<PossibleFilterKey extends string> {
+  filterBy: FilterBy<PossibleFilterKey>;
+
+  onChangeDateFilterRule: (
+    key: PossibleFilterKey,
+    condition: FilterByConditionByType['date'],
+    value: Date
+  ) => void;
+
+  onChangeStringFilterRule: (
+    key: PossibleFilterKey,
+    condition: FilterByConditionByType['string'],
+    value: string
+  ) => void;
+
+  onClearFilterRule: (key: PossibleFilterKey) => void;
+}
+
+export const useFilterBy = <PossibleFilterKey extends string>(
+  initialFilterBy: FilterBy<PossibleFilterKey>
+): UseFilterByControl<PossibleFilterKey> => {
+  const [filterBy, setFilterBy] =
+    useState<FilterBy<PossibleFilterKey>>(initialFilterBy);
+
+  const onChangeStringFilterRule = (
+    key: PossibleFilterKey,
+    condition: FilterByConditionByType['string'],
+    value: string
+  ) => {
+    const newFilterRule = { [key]: { [condition]: value } };
+
+    setFilterBy({ ...filterBy, ...newFilterRule });
+  };
+
+  const onChangeDateFilterRule = (
+    key: PossibleFilterKey,
+    condition: FilterByConditionByType['date'],
+    value: Date
+  ) => {
+    const newFilterRule = { [key]: { [condition]: value } };
+    setFilterBy({ ...filterBy, ...newFilterRule });
+  };
+
+  const onClearFilterRule = (key: PossibleFilterKey) => {
+    setFilterBy({ ...filterBy, [key]: null });
+  };
+
+  return {
+    filterBy,
+    onChangeStringFilterRule,
+    onChangeDateFilterRule,
+    onClearFilterRule,
+  };
+};

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
@@ -11,9 +11,14 @@ type FilterRule = {
     | FilterByConditionByType['date']]?: unknown;
 };
 
+// type FilterRule = Record<
+//   FilterByConditionByType['string'] | FilterByConditionByType['date'],
+//   unknown
+// >;
+
 export type FilterBy<T> = Partial<Record<Partial<keyof T>, FilterRule>>;
 
-export interface FilterState<T> {
+export interface FilterController<T> {
   filterBy: FilterBy<T> | null;
 
   onChangeDateFilterRule: (
@@ -29,6 +34,10 @@ export interface FilterState<T> {
   ) => void;
 
   onClearFilterRule: (key: keyof T) => void;
+}
+
+export interface FilterState<T> extends FilterController<T> {
+  filter: FilterController<T>;
 }
 
 export const useFilterBy = <T extends unknown>(
@@ -60,10 +69,12 @@ export const useFilterBy = <T extends unknown>(
     setFilterBy({ ...filterBy, [key]: null });
   };
 
-  return {
+  const filterState = {
     filterBy,
     onChangeStringFilterRule,
     onChangeDateFilterRule,
     onClearFilterRule,
   };
+
+  return { ...filterState, filter: filterState };
 };

--- a/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
@@ -11,11 +11,6 @@ type FilterRule = {
     | FilterByConditionByType['date']]?: unknown;
 };
 
-// type FilterRule = Record<
-//   FilterByConditionByType['string'] | FilterByConditionByType['date'],
-//   unknown
-// >;
-
 export type FilterBy<T> = Partial<Record<Partial<keyof T>, FilterRule>>;
 
 export interface FilterController<T> {

--- a/packages/common/src/hooks/useListData/useListData.test.tsx
+++ b/packages/common/src/hooks/useListData/useListData.test.tsx
@@ -78,7 +78,7 @@ describe('useListData', () => {
     const onError = jest.fn();
     const ErrorTest = () => {
       const { data } = useListData(
-        { key: 'message' },
+        { initialSortBy: { key: 'message' } },
         '401test',
         PermissionErrorApi,
         onError
@@ -102,7 +102,7 @@ describe('useListData', () => {
   it('calls error boundary on server error', async () => {
     const ErrorTest = () => {
       const { data } = useListData(
-        { key: 'message' },
+        { initialSortBy: { key: 'message' } },
         '500test',
         ServerErrorApi
       );

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -1,10 +1,8 @@
-import { useFilterBy } from './../useFilterBy/useFilterBy';
 import { ObjectWithStringKeys } from './../../types/utility';
-import { SortBy } from './../useSortBy/useSortBy';
+import { SortRule, SortBy } from './../useSortBy/useSortBy';
 import { UseMutateAsyncFunction } from 'react-query';
 import { useQueryClient, useMutation, useQuery } from 'react-query';
 import { QueryParams, useQueryParams } from '../useQueryParams';
-import { SortRule } from '../useSortBy';
 import { FilterBy } from '../useFilterBy';
 import { ClientError } from 'graphql-request';
 import { useNotification } from '../../hooks';
@@ -44,17 +42,17 @@ interface ListDataState<T extends ObjectWithStringKeys> extends QueryParams<T> {
 
 export const useListData = <T extends ObjectWithStringKeys>(
   initialListParameters: {
+    initialFilterBy?: FilterBy<T>;
     initialSortBy: SortRule<T>;
-    initialFilterBy?: FilterBy<T> | null;
   },
   queryKey: string | readonly unknown[],
   api: ListApi<T>,
   onError?: (e: ClientError) => void
 ): ListDataState<T> => {
-  const { initialSortBy, initialFilterBy } = initialListParameters;
   const queryClient = useQueryClient();
-  const { filterBy } = useFilterBy<T>(initialFilterBy);
-  const { queryParams, first, offset, sortBy } = useQueryParams(initialSortBy);
+  const { filterBy, queryParams, first, offset, sortBy } = useQueryParams(
+    initialListParameters
+  );
   const fullQueryKey = [queryKey, 'list', queryParams];
   const { error } = useNotification();
   const defaultErrorHandler = (e: ClientError) =>

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -91,10 +91,6 @@ export const useListData = <T extends ObjectWithStringKeys>(
     { onSuccess: invalidate }
   );
 
-  console.log('-------------------------------------------');
-  console.log('queryParams', queryParams);
-  console.log('-------------------------------------------');
-
   return {
     ...queryParams,
     totalCount: data?.totalCount,

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -91,6 +91,10 @@ export const useListData = <T extends ObjectWithStringKeys>(
     { onSuccess: invalidate }
   );
 
+  console.log('-------------------------------------------');
+  console.log('queryParams', queryParams);
+  console.log('-------------------------------------------');
+
   return {
     ...queryParams,
     totalCount: data?.totalCount,

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
@@ -68,7 +68,7 @@ describe('useQueryParams', () => {
     window.resizeTo(1000, 1000);
 
     const { result } = renderHook(
-      () => useQueryParams<TestSortBy>({ key: 'id' }),
+      () => useQueryParams<TestSortBy>({ initialSortBy: { key: 'id' } }),
       {
         wrapper: getWrapper(),
       }

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.ts
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.ts
@@ -33,6 +33,8 @@ export const useQueryParams = <T extends ObjectWithStringKeys>({
     ...pagination,
     ...filter,
     ...sort,
+    filter,
+    sort,
     pagination,
   };
 

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.ts
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.ts
@@ -1,31 +1,48 @@
 import { ObjectWithStringKeys } from './../../types/utility';
 import { usePagination, PaginationState } from '../usePagination';
 import { useSortBy, SortState, SortRule } from '../useSortBy';
+import { useFilterBy, FilterState, FilterBy } from '../useFilterBy';
 
 export interface QueryParams<T extends ObjectWithStringKeys>
   extends SortState<T>,
+    FilterState<T>,
     PaginationState {}
 
 export interface QueryParamsState<T extends ObjectWithStringKeys>
   extends SortState<T>,
+    FilterState<T>,
     PaginationState {
   pagination: PaginationState;
+  sort: SortState<T>;
+  filter: FilterState<T>;
   queryParams: QueryParams<T>;
 }
 
-export const useQueryParams = <T extends ObjectWithStringKeys>(
-  initialSortBy: SortRule<T>
-): QueryParamsState<T> => {
+export const useQueryParams = <T extends ObjectWithStringKeys>({
+  initialSortBy,
+  initialFilterBy,
+}: {
+  initialSortBy: SortRule<T>;
+  initialFilterBy?: FilterBy<T>;
+}): QueryParamsState<T> => {
+  const filter = useFilterBy(initialFilterBy);
+  const sort = useSortBy(initialSortBy);
   const pagination = usePagination();
-  const { sortBy, onChangeSortBy } = useSortBy<T>(initialSortBy);
 
-  const queryParams = { ...pagination, pagination, sortBy, onChangeSortBy };
+  const queryParams: QueryParams<T> = {
+    ...pagination,
+    ...filter,
+    ...sort,
+    pagination,
+  };
 
   return {
     ...pagination,
+    ...sort,
+    ...filter,
+    sort,
+    filter,
     pagination,
-    sortBy,
-    onChangeSortBy,
     queryParams,
   };
 };

--- a/packages/common/src/hooks/useSortBy/useSortBy.ts
+++ b/packages/common/src/hooks/useSortBy/useSortBy.ts
@@ -9,9 +9,14 @@ export interface SortRule<T extends ObjectWithStringKeys> {
 export interface SortBy<T extends ObjectWithStringKeys> extends SortRule<T> {
   direction: 'asc' | 'desc';
 }
-export interface SortState<T extends ObjectWithStringKeys> {
+export interface SortController<T extends ObjectWithStringKeys> {
   sortBy: SortBy<T>;
   onChangeSortBy: (newSortRule: SortRule<T>) => SortBy<T>;
+}
+
+export interface SortState<T extends ObjectWithStringKeys>
+  extends SortController<T> {
+  sort: SortController<T>;
 }
 
 const getDirection = (isDesc: boolean): 'asc' | 'desc' =>
@@ -46,5 +51,5 @@ export const useSortBy = <T extends ObjectWithStringKeys>({
     return { ...newSortBy, direction: getDirection(!!newSortBy?.isDesc) };
   }, []);
 
-  return { sortBy, onChangeSortBy };
+  return { sortBy, onChangeSortBy, sort: { sortBy, onChangeSortBy } };
 };

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -136,10 +136,12 @@ query invoices(
   $offset: Int
   $key: InvoiceSortFieldInput!
   $desc: Boolean
+  $filter: InvoiceFilterInput
 ) {
   invoices(
     page: { first: $first, offset: $offset }
     sort: { key: $key, desc: $desc }
+    filter: $filter
   ) {
     ... on ConnectorError {
       __typename

--- a/packages/common/src/schema.graphql
+++ b/packages/common/src/schema.graphql
@@ -271,12 +271,13 @@ type InvoiceDoesNotBelongToCurrentStore implements InsertCustomerInvoiceLineErro
 }
 
 input InvoiceFilterInput {
-  nameId: EqualFilterStringInput
-  storeId: EqualFilterStringInput
-  type: EqualFilterInvoiceTypeInput
-  status: EqualFilterInvoiceStatusInput
+  otherPartyName: SimpleStringFilterInput
+  nameId: SimpleStringFilterInput
+  storeId: SimpleStringFilterInput
+  type: SimpleStringFilterInput
+  status: SimpleStringFilterInput
   comment: SimpleStringFilterInput
-  theirReference: EqualFilterStringInput
+  theirReference: SimpleStringFilterInput
   entryDatetime: DatetimeFilterInput
   confirmDatetime: DatetimeFilterInput
   finalisedDatetime: DatetimeFilterInput

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -332,11 +332,12 @@ export type InvoiceFilterInput = {
   confirmDatetime?: Maybe<DatetimeFilterInput>;
   entryDatetime?: Maybe<DatetimeFilterInput>;
   finalisedDatetime?: Maybe<DatetimeFilterInput>;
-  nameId?: Maybe<EqualFilterStringInput>;
-  status?: Maybe<EqualFilterInvoiceStatusInput>;
-  storeId?: Maybe<EqualFilterStringInput>;
-  theirReference?: Maybe<EqualFilterStringInput>;
-  type?: Maybe<EqualFilterInvoiceTypeInput>;
+  nameId?: Maybe<SimpleStringFilterInput>;
+  otherPartyName?: Maybe<SimpleStringFilterInput>;
+  status?: Maybe<SimpleStringFilterInput>;
+  storeId?: Maybe<SimpleStringFilterInput>;
+  theirReference?: Maybe<SimpleStringFilterInput>;
+  type?: Maybe<SimpleStringFilterInput>;
 };
 
 export type InvoiceLineBelongsToAnotherInvoice =
@@ -1015,6 +1016,7 @@ export type InvoicesQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
   key: InvoiceSortFieldInput;
   desc?: Maybe<Scalars['Boolean']>;
+  filter?: Maybe<InvoiceFilterInput>;
 }>;
 
 export type InvoicesQuery = {
@@ -1386,10 +1388,12 @@ export const InvoicesDocument = gql`
     $offset: Int
     $key: InvoiceSortFieldInput!
     $desc: Boolean
+    $filter: InvoiceFilterInput
   ) {
     invoices(
       page: { first: $first, offset: $offset }
       sort: { key: $key, desc: $desc }
+      filter: $filter
     ) {
       ... on ConnectorError {
         __typename

--- a/packages/dashboard/src/widgets/OutboundShipmentsWidget.tsx
+++ b/packages/dashboard/src/widgets/OutboundShipmentsWidget.tsx
@@ -19,7 +19,7 @@ export const OutboundShipmentsWidget: React.FC = () => {
 
   const { api } = useOmSupplyApi();
   const { onCreate, invalidate } = useListData(
-    { key: 'otherPartyName' },
+    { initialSortBy: { key: 'otherPartyName' } },
     'invoice',
     getOutboundShipmentListViewApi(api)
   );

--- a/packages/host/public/config.js
+++ b/packages/host/public/config.js
@@ -1,3 +1,4 @@
 window.env = {
   API_URL: 'http://localhost:4000',
+  // API_URL: 'http://localhost:8000/graphql',
 };

--- a/packages/host/src/AppDrawer.test.tsx
+++ b/packages/host/src/AppDrawer.test.tsx
@@ -11,6 +11,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 describe('AppDrawer', () => {
   it('Collapses when clicking the drawer open/close button for the first time on a large screen', async () => {
+    setScreenSize_ONLY_FOR_TESTING(1441);
     const { getByRole, getByTestId } = render(
       <TestingProvider>
         <BrowserRouter>
@@ -51,7 +52,8 @@ describe('AppDrawer', () => {
       expect(drawer).toHaveAttribute('aria-expanded', 'true');
     });
   });
-  it('Text is visibility when the menu is expanded', async () => {
+  it('has visible text when the menu is expanded', async () => {
+    setScreenSize_ONLY_FOR_TESTING(1441);
     const { getByText } = render(
       <TestingProvider>
         <BrowserRouter>
@@ -71,6 +73,7 @@ describe('AppDrawer', () => {
     });
   });
   it('Text is invisible when the menu is collapsed', async () => {
+    setScreenSize_ONLY_FOR_TESTING(1442);
     const { getByText } = render(
       <TestingProvider>
         <BrowserRouter>

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -36,7 +36,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
     pagination,
     invalidate,
   } = useListData(
-    { key: 'otherPartyName' },
+    { initialSortBy: { key: 'otherPartyName' } },
     'invoice',
     getOutboundShipmentListViewApi(api)
   );

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -34,6 +34,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
     onCreate,
     onChangePage,
     pagination,
+    filter,
     invalidate,
   } = useListData(
     { initialSortBy: { key: 'otherPartyName' } },
@@ -92,7 +93,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
         }}
       />
 
-      <Toolbar onDelete={onDelete} data={data} />
+      <Toolbar onDelete={onDelete} data={data} filter={filter} />
       <AppBarButtons onCreate={setOpen} />
 
       <DataTable

--- a/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
@@ -9,12 +9,15 @@ import {
   DeleteIcon,
   useTableStore,
   AppBarContentPortal,
+  BasicTextInput,
 } from '@openmsupply-client/common';
+import { FilterController } from '@openmsupply-client/common/src/hooks/useFilterBy';
 
 export const Toolbar: FC<{
   onDelete: (toDelete: InvoiceRow[]) => void;
+  filter: FilterController<InvoiceRow>;
   data?: InvoiceRow[];
-}> = ({ onDelete, data }) => {
+}> = ({ onDelete, data, filter }) => {
   const t = useTranslation();
 
   const { success, info } = useNotification();
@@ -41,8 +44,28 @@ export const Toolbar: FC<{
     ref.current = deleteAction;
   }, [selectedRows]);
 
+  const key = 'otherPartyName' as keyof InvoiceRow;
+  const filterString = filter.filterBy?.[key]?.like;
+
   return (
-    <AppBarContentPortal sx={{ paddingBottom: '16px' }}>
+    <AppBarContentPortal
+      sx={{
+        paddingBottom: '16px',
+        flex: 1,
+        justifyContent: 'space-between',
+        display: 'flex',
+      }}
+    >
+      <BasicTextInput
+        value={filterString}
+        onChange={e =>
+          filter.onChangeStringFilterRule(
+            'otherPartyName',
+            'like',
+            e.target.value
+          )
+        }
+      />
       <DropdownMenu label="Select">
         <DropdownMenuItem IconComponent={DeleteIcon} onClick={deleteAction}>
           {t('button.delete-lines')}

--- a/packages/invoices/src/OutboundShipment/ListView/api.ts
+++ b/packages/invoices/src/OutboundShipment/ListView/api.ts
@@ -172,12 +172,13 @@ const getSortDesc = (sortBy: SortBy<OutboundShipment>): boolean => {
 export const getOutboundShipmentListViewApi = (
   omSupplyApi: OmSupplyApi
 ): ListApi<InvoiceRow> => ({
-  onRead: ({ first, offset, sortBy }) => {
+  onRead: ({ first, offset, sortBy, filterBy }) => {
     const queryParams: InvoicesQueryVariables = {
       first,
       offset,
       key: getSortKey(sortBy),
       desc: getSortDesc(sortBy),
+      filter: filterBy,
     };
 
     const onReadFn = onRead(omSupplyApi);

--- a/packages/mock-server/src/api/resolvers.ts
+++ b/packages/mock-server/src/api/resolvers.ts
@@ -128,6 +128,7 @@ export const ResolverService = {
       offset = 0,
       key,
       desc,
+      filter,
     }: InvoicesQueryVariables): ListResponse<ResolvedInvoice> => {
       const invoices = db.get.all.invoice();
 
@@ -141,7 +142,26 @@ export const ResolverService = {
         data.sort(sortData);
       }
 
-      return createListResponse(invoices.length, data, 'InvoiceConnector');
+      let filteredData = data;
+      if (filter) {
+        filteredData = data.filter(({ otherPartyName }) => {
+          if (filter.otherPartyName?.equalTo) {
+            return otherPartyName === filter.otherPartyName.equalTo;
+          }
+
+          if (filter.otherPartyName?.like) {
+            return otherPartyName.includes(filter.otherPartyName.like ?? '');
+          }
+
+          return true;
+        });
+      }
+
+      return createListResponse(
+        invoices.length,
+        filteredData,
+        'InvoiceConnector'
+      );
     },
     item: ({
       first = 50,

--- a/packages/mock-server/src/schema/Invoice.ts
+++ b/packages/mock-server/src/schema/Invoice.ts
@@ -1,4 +1,7 @@
-import { InvoiceSortFieldInput } from '@openmsupply-client/common/src/types/schema';
+import {
+  InvoiceSortFieldInput,
+  InvoiceFilterInput,
+} from '@openmsupply-client/common/src/types/schema';
 import { Api } from '../api';
 
 import { ListResponse, Invoice as InvoiceType } from '../data/types';
@@ -9,6 +12,7 @@ const QueryResolvers = {
     vars: {
       page?: { first?: number; offset?: number };
       sort: [{ key: InvoiceSortFieldInput; desc: boolean }];
+      filter?: InvoiceFilterInput;
     }
   ): ListResponse<InvoiceType> => {
     return Api.ResolverService.list.invoice({
@@ -16,6 +20,7 @@ const QueryResolvers = {
       offset: vars.page?.offset ?? 0,
       desc: vars.sort[0].desc ?? false,
       key: vars.sort[0].key ?? InvoiceSortFieldInput.Status,
+      filter: vars.filter,
     });
   },
 

--- a/packages/system/src/Item/ListView/ListView.tsx
+++ b/packages/system/src/Item/ListView/ListView.tsx
@@ -21,7 +21,11 @@ export const ListView: FC = () => {
     pagination,
     sortBy,
     onChangeSortBy,
-  } = useListData({ key: 'name' }, ['items', 'list'], getItemListViewApi(api));
+  } = useListData(
+    { initialSortBy: { key: 'name' } },
+    ['items', 'list'],
+    getItemListViewApi(api)
+  );
   const navigate = useNavigate();
 
   const columns = useColumns<ItemRow>(

--- a/packages/system/src/Name/ListView/ListView.tsx
+++ b/packages/system/src/Name/ListView/ListView.tsx
@@ -22,7 +22,11 @@ export const ListView: FC = () => {
     pagination,
     sortBy,
     onChangeSortBy,
-  } = useListData({ key: 'name' }, ['names', 'list'], getNameListViewApi(api));
+  } = useListData(
+    { initialSortBy: { key: 'name' } },
+    ['names', 'list'],
+    getNameListViewApi(api)
+  );
 
   const columns = useColumns<Name>(
     ['name', 'code'],


### PR DESCRIPTION
Fixes #327 - or starts

- Added a `useFilterBy` hook to help with filtering. I was really unsure of the api for this hook and the types are still struggling
- Added a small text box in the outbound shipment area for filtering to test this out - will build on that to make a better ui, which i have no idea what it would look like - but will add debouncing etc etc