### PR TITLE
#273 mutations 5

### DIFF
--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -529,3 +529,20 @@ query stockCounts {
     }
   }
 }
+
+mutation upsertOutboundShipment(
+  $insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!]
+  $updateOutboundShipments: [UpdateOutboundShipmentInput!]
+) {
+  batchOutboundShipment(
+    insertOutboundShipmentLines: $insertOutboundShipmentLines
+    updateOutboundShipments: $updateOutboundShipments
+  ) {
+    insertOutboundShipmentLines {
+      id
+    }
+    updateOutboundShipments {
+      id
+    }
+  }
+}

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -538,10 +538,13 @@ mutation upsertOutboundShipment(
     insertOutboundShipmentLines: $insertOutboundShipmentLines
     updateOutboundShipments: $updateOutboundShipments
   ) {
+    __typename
     insertOutboundShipmentLines {
+      __typename
       id
     }
     updateOutboundShipments {
+      __typename
       id
     }
   }

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -64,6 +64,7 @@ export interface InvoiceLine extends DomainObject {
   numberOfPacks: number;
   costPricePerPack: number;
   sellPricePerPack: number;
+  stockLineId: string;
 
   expiryDate?: string | null;
 

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1613,17 +1613,17 @@ export type UpsertOutboundShipmentMutationVariables = Exact<{
 export type UpsertOutboundShipmentMutation = {
   __typename?: 'Mutations';
   batchOutboundShipment: {
-    __typename?: 'BatchOutboundShipmentResponse';
+    __typename: 'BatchOutboundShipmentResponse';
     insertOutboundShipmentLines?:
       | Array<{
-          __typename?: 'InsertOutboundShipmentLineResponseWithId';
+          __typename: 'InsertOutboundShipmentLineResponseWithId';
           id: string;
         }>
       | null
       | undefined;
     updateOutboundShipments?:
       | Array<{
-          __typename?: 'UpdateOutboundShipmentResponseWithId';
+          __typename: 'UpdateOutboundShipmentResponseWithId';
           id: string;
         }>
       | null
@@ -2173,10 +2173,13 @@ export const UpsertOutboundShipmentDocument = gql`
       insertOutboundShipmentLines: $insertOutboundShipmentLines
       updateOutboundShipments: $updateOutboundShipments
     ) {
+      __typename
       insertOutboundShipmentLines {
+        __typename
         id
       }
       updateOutboundShipments {
+        __typename
         id
       }
     }

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1601,6 +1601,36 @@ export type StockCountsQuery = {
       };
 };
 
+export type UpsertOutboundShipmentMutationVariables = Exact<{
+  insertOutboundShipmentLines?: Maybe<
+    Array<InsertOutboundShipmentLineInput> | InsertOutboundShipmentLineInput
+  >;
+  updateOutboundShipments?: Maybe<
+    Array<UpdateOutboundShipmentInput> | UpdateOutboundShipmentInput
+  >;
+}>;
+
+export type UpsertOutboundShipmentMutation = {
+  __typename?: 'Mutations';
+  batchOutboundShipment: {
+    __typename?: 'BatchOutboundShipmentResponse';
+    insertOutboundShipmentLines?:
+      | Array<{
+          __typename?: 'InsertOutboundShipmentLineResponseWithId';
+          id: string;
+        }>
+      | null
+      | undefined;
+    updateOutboundShipments?:
+      | Array<{
+          __typename?: 'UpdateOutboundShipmentResponseWithId';
+          id: string;
+        }>
+      | null
+      | undefined;
+  };
+};
+
 export const InvoiceDocument = gql`
   query invoice($id: String!) {
     invoice(id: $id) {
@@ -2134,6 +2164,24 @@ export const StockCountsDocument = gql`
     }
   }
 `;
+export const UpsertOutboundShipmentDocument = gql`
+  mutation upsertOutboundShipment(
+    $insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!]
+    $updateOutboundShipments: [UpdateOutboundShipmentInput!]
+  ) {
+    batchOutboundShipment(
+      insertOutboundShipmentLines: $insertOutboundShipmentLines
+      updateOutboundShipments: $updateOutboundShipments
+    ) {
+      insertOutboundShipmentLines {
+        id
+      }
+      updateOutboundShipments {
+        id
+      }
+    }
+  }
+`;
 
 export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
@@ -2279,6 +2327,20 @@ export function getSdk(
             ...wrappedRequestHeaders,
           }),
         'stockCounts'
+      );
+    },
+    upsertOutboundShipment(
+      variables?: UpsertOutboundShipmentMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpsertOutboundShipmentMutation> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<UpsertOutboundShipmentMutation>(
+            UpsertOutboundShipmentDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertOutboundShipment'
       );
     },
   };

--- a/packages/host/src/bootstrap.tsx
+++ b/packages/host/src/bootstrap.tsx
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === 'development') {
   } = require('@openmsupply-client/mock-server/src/worker/client');
   const worker = setupMockWorker();
 
-  worker.start();
+  // worker.start();
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/host/src/bootstrap.tsx
+++ b/packages/host/src/bootstrap.tsx
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV === 'development') {
   } = require('@openmsupply-client/mock-server/src/worker/client');
   const worker = setupMockWorker();
 
-  // worker.start();
+  worker.start();
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -17,7 +17,7 @@ import { getOutboundShipmentDetailViewApi } from '../../api';
 import { GeneralTab } from './tabs/GeneralTab';
 import { ItemDetailsModal } from './modals/ItemDetailsModal';
 
-import { InvoiceLineRow } from './types';
+import { OutboundShipmentRow } from './types';
 import { Toolbar } from './Toolbar';
 import { isInvoiceEditable } from '../utils';
 import { Footer } from './Footer';
@@ -34,7 +34,7 @@ const useDraftOutbound = () => {
     getOutboundShipmentDetailViewApi(api)
   );
 
-  const onChangeSortBy = (column: Column<InvoiceLineRow>) => {
+  const onChangeSortBy = (column: Column<OutboundShipmentRow>) => {
     dispatch(OutboundAction.onSortBy(column));
   };
 
@@ -48,7 +48,7 @@ export const DetailView: FC = () => {
 
   const columns = useColumns(
     [
-      getNotePopoverColumn<InvoiceLineRow>(),
+      getNotePopoverColumn<OutboundShipmentRow>(),
       'itemCode',
       'itemName',
       'batch',
@@ -59,7 +59,7 @@ export const DetailView: FC = () => {
       'itemUnit',
       'unitQuantity',
       'numberOfPacks',
-      getRowExpandColumn<InvoiceLineRow>(),
+      getRowExpandColumn<OutboundShipmentRow>(),
       GenericColumnKey.Selection,
     ],
     { onChangeSortBy, sortBy },

--- a/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -13,7 +13,7 @@ import {
   useTableStore,
 } from '@openmsupply-client/common';
 import { NameSearchInput } from '@openmsupply-client/system/src/Name';
-import { InvoiceLineRow, OutboundShipment } from './types';
+import { OutboundShipmentRow, OutboundShipment } from './types';
 import { isInvoiceEditable } from '../utils';
 
 interface ToolbarProps {
@@ -28,7 +28,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
     selectedRows: Object.keys(state.rowState)
       .filter(id => state.rowState[id]?.isSelected)
       .map(selectedId => draft.lines.find(({ id }) => selectedId === id))
-      .filter(Boolean) as InvoiceLineRow[],
+      .filter(Boolean) as OutboundShipmentRow[],
   }));
 
   const deleteAction = () => {

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
   DialogButton,
   Grid,
-  InvoiceLine,
   Item,
   useForm,
   useDialog,
@@ -12,13 +11,13 @@ import {
 
 import { BatchesTable } from './BatchesTable';
 import { ItemDetailsForm } from './ItemDetailsForm';
-import { BatchRow } from '../types';
+import { BatchRow, InvoiceLineRow } from '../types';
 
 interface ItemDetailsModalProps {
-  invoiceLine?: InvoiceLine;
+  invoiceLine?: InvoiceLineRow;
   isOpen: boolean;
   onClose: () => void;
-  upsertInvoiceLine: (invoiceLine: InvoiceLine) => void;
+  upsertInvoiceLine: (invoiceLine: InvoiceLineRow) => void;
 }
 
 export const getInvoiceLine = (
@@ -26,7 +25,7 @@ export const getInvoiceLine = (
   item: Item,
   line: { id: string; expiryDate?: string | null },
   quantity: number
-): InvoiceLine => ({
+): InvoiceLineRow => ({
   id,
   itemId: '',
   itemName: item.name,

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -27,12 +27,12 @@ export const getInvoiceLine = (
   quantity: number
 ): OutboundShipmentRow => ({
   id,
-  itemId: '',
+  itemId: item.id,
   itemName: item.name,
   itemCode: '',
   itemUnit: '',
   packSize: 0,
-  numberOfPacks: 0,
+  numberOfPacks: quantity,
   costPricePerPack: 0,
   sellPricePerPack: 0,
   stockLineId: line.id,
@@ -113,6 +113,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
     const invoiceLines = batchRows.map(batch =>
       getInvoiceLine('', selectedItem, batch, Number(values[batch.id] || 0))
     );
+
     invoiceLines
       .filter(line => line.numberOfPacks > 0)
       .forEach(upsertInvoiceLine);

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -11,13 +11,13 @@ import {
 
 import { BatchesTable } from './BatchesTable';
 import { ItemDetailsForm } from './ItemDetailsForm';
-import { BatchRow, InvoiceLineRow } from '../types';
+import { BatchRow, OutboundShipmentRow } from '../types';
 
 interface ItemDetailsModalProps {
-  invoiceLine?: InvoiceLineRow;
+  invoiceLine?: OutboundShipmentRow;
   isOpen: boolean;
   onClose: () => void;
-  upsertInvoiceLine: (invoiceLine: InvoiceLineRow) => void;
+  upsertInvoiceLine: (invoiceLine: OutboundShipmentRow) => void;
 }
 
 export const getInvoiceLine = (
@@ -25,7 +25,7 @@ export const getInvoiceLine = (
   item: Item,
   line: { id: string; expiryDate?: string | null },
   quantity: number
-): InvoiceLineRow => ({
+): OutboundShipmentRow => ({
   id,
   itemId: '',
   itemName: item.name,

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -20,6 +20,8 @@ describe('DetailView reducer', () => {
       costPricePerPack: 0,
       sellPricePerPack: 0,
       itemName: 'a',
+      stockLineId: '',
+      invoiceId: '',
     },
     {
       id: '3',
@@ -32,6 +34,8 @@ describe('DetailView reducer', () => {
       costPricePerPack: 0,
       sellPricePerPack: 0,
       itemName: 'c',
+      stockLineId: '',
+      invoiceId: '',
     },
     {
       id: '5',
@@ -44,6 +48,8 @@ describe('DetailView reducer', () => {
       costPricePerPack: 0,
       sellPricePerPack: 0,
       itemName: 'b',
+      stockLineId: '',
+      invoiceId: '',
     },
     {
       id: '2',
@@ -56,6 +62,8 @@ describe('DetailView reducer', () => {
       costPricePerPack: 0,
       sellPricePerPack: 0,
       itemName: 'e',
+      stockLineId: '',
+      invoiceId: '',
     },
     {
       id: '4',
@@ -68,6 +76,8 @@ describe('DetailView reducer', () => {
       costPricePerPack: 0,
       sellPricePerPack: 0,
       itemName: 'f',
+      stockLineId: '',
+      invoiceId: '',
     },
     {
       id: '2',
@@ -80,6 +90,8 @@ describe('DetailView reducer', () => {
       costPricePerPack: 0,
       sellPricePerPack: 0,
       itemName: 'd',
+      stockLineId: '',
+      invoiceId: '',
     },
   ];
 

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -173,7 +173,7 @@ describe('DetailView reducer', () => {
 
     const reducerResult = reducer(undefined, null)(
       state,
-      OutboundAction.updateNumberOfPacks('1', 10)
+      OutboundAction.updateNumberOfPacks?.('1', 10)
     );
 
     const line = reducerResult.draft.lines.find(({ id }) => id === '1');

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -5,10 +5,10 @@ import {
 } from '@openmsupply-client/common';
 import { placeholderInvoice } from './index';
 import { reducer, OutboundShipmentStateShape, OutboundAction } from './reducer';
-import { InvoiceLineRow } from './types';
+import { OutboundShipmentRow } from './types';
 
 describe('DetailView reducer', () => {
-  const lines: InvoiceLineRow[] = [
+  const lines: OutboundShipmentRow[] = [
     {
       id: '1',
       updateNumberOfPacks: () => {},
@@ -90,7 +90,7 @@ describe('DetailView reducer', () => {
       deletedLines: [],
     };
 
-    const [numberOfPacksColumn] = createColumns<InvoiceLineRow>([
+    const [numberOfPacksColumn] = createColumns<OutboundShipmentRow>([
       'numberOfPacks',
     ]);
     if (!numberOfPacksColumn) throw new Error('This test is broken!');
@@ -117,7 +117,7 @@ describe('DetailView reducer', () => {
       deletedLines: [],
     };
 
-    const [numberOfPacksColumn] = createColumns<InvoiceLineRow>([
+    const [numberOfPacksColumn] = createColumns<OutboundShipmentRow>([
       'numberOfPacks',
     ]);
     if (!numberOfPacksColumn) throw new Error('This test is broken!');
@@ -146,7 +146,7 @@ describe('DetailView reducer', () => {
       deletedLines: [],
     };
 
-    const [itemNameColumn] = createColumns<InvoiceLineRow>(['itemName']);
+    const [itemNameColumn] = createColumns<OutboundShipmentRow>(['itemName']);
     if (!itemNameColumn) throw new Error('This test is broken!');
 
     const reducerResult = reducer(undefined, null)(
@@ -235,7 +235,7 @@ describe('DetailView reducer', () => {
       deletedLines: [],
     };
 
-    const lineToDelete = lines[0] as InvoiceLineRow;
+    const lineToDelete = lines[0] as OutboundShipmentRow;
     const reducerResult = reducer({ ...state.draft }, null)(
       state,
       OutboundAction.deleteLine(lineToDelete)
@@ -257,7 +257,7 @@ describe('DetailView reducer', () => {
   //     deletedLines: [],
   //   };
 
-  //   const lineToDelete = { ...lines[0], numberOfPacks: 999 } as InvoiceLineRow;
+  //   const lineToDelete = { ...lines[0], numberOfPacks: 999 } as OutboundShipmentRow;
   //   const reducerResult = reducer({ ...state.draft }, null)(
   //     state,
   //     OutboundAction.upsertLine(lineToDelete)
@@ -278,7 +278,7 @@ describe('DetailView reducer', () => {
       deletedLines: [],
     };
 
-    const lineToInsert = { ...lines[0], id: '999' } as InvoiceLineRow;
+    const lineToInsert = { ...lines[0], id: '999' } as OutboundShipmentRow;
     const reducerResult = reducer({ ...state.draft }, null)(
       state,
       OutboundAction.upsertLine(lineToInsert)

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -42,11 +42,11 @@ const getDataSorter = (sortKey: any, desc: boolean) => (a: any, b: any) => {
 };
 
 export const OutboundAction = {
-  upsertLine: (invoiceLine: InvoiceLine): OutboundShipmentAction => ({
+  upsertLine: (invoiceLine: InvoiceLineRow): OutboundShipmentAction => ({
     type: ActionType.UpsertLine,
     payload: { invoiceLine },
   }),
-  deleteLine: (invoiceLine: InvoiceLine): OutboundShipmentAction => ({
+  deleteLine: (invoiceLine: InvoiceLineRow): OutboundShipmentAction => ({
     type: ActionType.DeleteLine,
     payload: { invoiceLine },
   }),

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -13,7 +13,7 @@ import {
   ActionType,
   OutboundShipment,
   OutboundShipmentAction,
-  InvoiceLineRow,
+  OutboundShipmentRow,
 } from './types';
 
 const parseValue = (object: any, key: string) => {
@@ -42,11 +42,11 @@ const getDataSorter = (sortKey: any, desc: boolean) => (a: any, b: any) => {
 };
 
 export const OutboundAction = {
-  upsertLine: (invoiceLine: InvoiceLineRow): OutboundShipmentAction => ({
+  upsertLine: (invoiceLine: OutboundShipmentRow): OutboundShipmentAction => ({
     type: ActionType.UpsertLine,
     payload: { invoiceLine },
   }),
-  deleteLine: (invoiceLine: InvoiceLineRow): OutboundShipmentAction => ({
+  deleteLine: (invoiceLine: OutboundShipmentRow): OutboundShipmentAction => ({
     type: ActionType.DeleteLine,
     payload: { invoiceLine },
   }),
@@ -64,7 +64,7 @@ export const OutboundAction = {
     type: ActionType.UpdateNumberOfPacks,
     payload: { rowKey, numberOfPacks },
   }),
-  onSortBy: (column: Column<InvoiceLineRow>): OutboundShipmentAction => ({
+  onSortBy: (column: Column<OutboundShipmentRow>): OutboundShipmentAction => ({
     type: ActionType.SortBy,
     payload: { column },
   }),
@@ -72,7 +72,7 @@ export const OutboundAction = {
 
 export interface OutboundShipmentStateShape {
   draft: OutboundShipment;
-  sortBy: SortBy<InvoiceLineRow>;
+  sortBy: SortBy<OutboundShipmentRow>;
   deletedLines: InvoiceLine[];
 }
 

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -246,7 +246,6 @@ const createLine = (
 ): OutboundShipmentRow => {
   return {
     ...line,
-    stockLineId: '',
     invoiceId: draft.id,
     updateNumberOfPacks: (numberOfPacks: number) =>
       dispatch?.(OutboundAction.updateNumberOfPacks(line.id, numberOfPacks)),

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -108,14 +108,16 @@ export const reducer = (
             draft[key] = data[key];
           });
 
-          draft.lines = draft.lines?.map(item => {
-            const serverLine = data.lines.find(line => line.id === item.id);
+          draft.lines = data.lines?.map(serverLine => {
+            const draftLine = draft.lines.find(
+              line => line.id === serverLine.id
+            );
 
-            if (serverLine) {
-              return mergeLines(serverLine, item);
+            if (draftLine) {
+              return mergeLines(serverLine, draftLine);
             }
 
-            return item;
+            return createLine(serverLine, draft, dispatch);
           });
 
           draft.update = (key, value) => {
@@ -238,12 +240,13 @@ const mergeLines = (
 };
 
 const createLine = (
-  line: OutboundShipmentRow,
+  line: InvoiceLine,
   draft: OutboundShipment,
   dispatch: Dispatch<DocumentActionSet<OutboundShipmentAction>> | null
-) => {
+): OutboundShipmentRow => {
   return {
     ...line,
+    stockLineId: '',
     invoiceId: draft.id,
     updateNumberOfPacks: (numberOfPacks: number) =>
       dispatch?.(OutboundAction.updateNumberOfPacks(line.id, numberOfPacks)),

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -175,19 +175,21 @@ export const reducer = (
 
           const { lines } = draft;
 
-          const existingLine = lines.find(({ id }) => id === line.id);
+          const existingLineIdx = lines.findIndex(({ id }) => id === line.id);
 
-          if (existingLine) {
-            line.isCreated = false;
-            line.isUpdated = true;
-            line.isDeleted = false;
+          if (existingLineIdx >= 0) {
+            lines[existingLineIdx] = {
+              ...lines[existingLineIdx],
+              ...line,
+              isUpdated: true,
+              isDeleted: false,
+            };
           } else {
             line.isCreated = true;
             line.isUpdated = true;
             line.isDeleted = false;
+            draft.lines.push(createLine(line, draft, dispatch));
           }
-
-          draft.lines.push(createLine(line, draft, dispatch));
 
           draft.update = (key, value) => {
             dispatch?.(OutboundAction.updateInvoice(key, value));

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { TestingProvider, useColumns } from '@openmsupply-client/common';
 import { render, waitFor, within } from '@testing-library/react';
 import { GeneralTab } from './GeneralTab';
-import { InvoiceLineRow } from '../types';
+import { OutboundShipmentRow } from '../types';
 
-const lines: InvoiceLineRow[] = [
+const lines: OutboundShipmentRow[] = [
   {
     id: '1',
     itemId: '1',
@@ -39,7 +39,7 @@ const lines: InvoiceLineRow[] = [
 
 describe('GeneralTab', () => {
   const Example = () => {
-    const columns = useColumns<InvoiceLineRow>(
+    const columns = useColumns<OutboundShipmentRow>(
       ['itemCode', 'itemName', 'numberOfPacks'],
       {
         onChangeSortBy: () => {},

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -7,7 +7,7 @@ import {
   DomainObject,
   Box,
 } from '@openmsupply-client/common';
-import { InvoiceLineRow } from '../types';
+import { OutboundShipmentRow } from '../types';
 
 interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   data: T[];
@@ -28,7 +28,7 @@ const Expand: FC = () => {
   );
 };
 
-export const GeneralTabComponent: FC<GeneralTabProps<InvoiceLineRow>> = ({
+export const GeneralTabComponent: FC<GeneralTabProps<OutboundShipmentRow>> = ({
   data,
   columns,
 }) => {

--- a/packages/invoices/src/OutboundShipment/DetailView/types.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/types.ts
@@ -6,13 +6,12 @@ import {
   OutboundShipmentStatus,
 } from '@openmsupply-client/common';
 
-export interface InvoiceLineRow extends InvoiceLine {
+export interface OutboundShipmentRow extends InvoiceLine {
   updateNumberOfPacks?: (quantity: number) => void;
   isUpdated?: boolean;
   isDeleted?: boolean;
   isCreated?: boolean;
 }
-
 export interface BatchRow extends StockLine {
   quantity: number;
 }
@@ -26,11 +25,11 @@ export interface InvoiceStatusLog {
 }
 
 export interface OutboundShipment extends Invoice {
-  lines: InvoiceLineRow[];
+  lines: OutboundShipmentRow[];
   status: OutboundShipmentStatus;
   update?: <K extends keyof Invoice>(key: K, value: Invoice[K]) => void;
-  upsertLine?: (line: InvoiceLineRow) => void;
-  deleteLine?: (line: InvoiceLineRow) => void;
+  upsertLine?: (line: OutboundShipmentRow) => void;
+  deleteLine?: (line: OutboundShipmentRow) => void;
 }
 
 export enum ActionType {
@@ -53,7 +52,7 @@ export type OutboundShipmentAction =
     }
   | {
       type: ActionType.SortBy;
-      payload: { column: Column<InvoiceLineRow> };
+      payload: { column: Column<OutboundShipmentRow> };
     }
   | OutboundShipmentUpdateInvoice
   | {

--- a/packages/invoices/src/OutboundShipment/DetailView/types.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/types.ts
@@ -8,6 +8,11 @@ import {
 
 export interface OutboundShipmentRow extends InvoiceLine {
   updateNumberOfPacks?: (quantity: number) => void;
+
+  stockLineId: string;
+  invoiceId: string;
+  itemId: string;
+
   isUpdated?: boolean;
   isDeleted?: boolean;
   isCreated?: boolean;
@@ -57,9 +62,9 @@ export type OutboundShipmentAction =
   | OutboundShipmentUpdateInvoice
   | {
       type: ActionType.UpsertLine;
-      payload: { invoiceLine: InvoiceLine };
+      payload: { line: OutboundShipmentRow };
     }
   | {
       type: ActionType.DeleteLine;
-      payload: { invoiceLine: InvoiceLine };
+      payload: { line: OutboundShipmentRow };
     };

--- a/packages/invoices/src/OutboundShipment/DetailView/types.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/types.ts
@@ -7,7 +7,10 @@ import {
 } from '@openmsupply-client/common';
 
 export interface InvoiceLineRow extends InvoiceLine {
-  updateNumberOfPacks: (quantity: number) => void;
+  updateNumberOfPacks?: (quantity: number) => void;
+  isUpdated?: boolean;
+  isDeleted?: boolean;
+  isCreated?: boolean;
 }
 
 export interface BatchRow extends StockLine {
@@ -26,8 +29,8 @@ export interface OutboundShipment extends Invoice {
   lines: InvoiceLineRow[];
   status: OutboundShipmentStatus;
   update?: <K extends keyof Invoice>(key: K, value: Invoice[K]) => void;
-  upsertLine?: (line: InvoiceLine) => void;
-  deleteLine?: (line: InvoiceLine) => void;
+  upsertLine?: (line: InvoiceLineRow) => void;
+  deleteLine?: (line: InvoiceLineRow) => void;
 }
 
 export enum ActionType {

--- a/packages/invoices/src/api.ts
+++ b/packages/invoices/src/api.ts
@@ -118,7 +118,10 @@ export const onRead =
 
     return {
       ...invoice,
-      lines: linesGuard(invoice.lines),
+      lines: linesGuard(invoice.lines).map(line => ({
+        ...line,
+        stockLineId: '',
+      })),
       pricing: pricingGuard(invoice.pricing),
       otherParty: otherPartyGuard(invoice.otherParty),
     };

--- a/packages/mock-server/src/api/mutations.ts
+++ b/packages/mock-server/src/api/mutations.ts
@@ -1,3 +1,4 @@
+import { InsertOutboundShipmentLineInput } from './../../../common/src/types/schema';
 import { ResolverService } from './resolvers';
 import { createInvoice } from './../data/data';
 import { Api } from './index';
@@ -48,7 +49,9 @@ export const insert = {
 
     return { ...createdInvoice, __typename: 'InvoiceNode' };
   },
-  invoiceLine: (invoiceLine: InvoiceLine): InvoiceLine => {
+  invoiceLine: (
+    invoiceLine: InsertOutboundShipmentLineInput
+  ): InsertOutboundShipmentLineInput => {
     const existing = db.get.byId.invoiceLine(invoiceLine.id);
 
     if (existing.id) {
@@ -57,7 +60,10 @@ export const insert = {
       );
     }
 
-    adjustStockLineQuantity(invoiceLine.stockLineId, -invoiceLine.quantity);
+    adjustStockLineQuantity(
+      invoiceLine.stockLineId,
+      -invoiceLine.numberOfPacks
+    );
 
     return db.insert.invoiceLine(invoiceLine);
   },

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -7,7 +7,10 @@ import {
   NameData,
   removeElement,
 } from './data';
-import { UpdateOutboundShipmentInput } from '@openmsupply-client/common';
+import {
+  UpdateOutboundShipmentInput,
+  InsertOutboundShipmentLineInput,
+} from '@openmsupply-client/common';
 import {
   isAlmostExpired,
   isExpired,
@@ -160,9 +163,27 @@ export const insert = {
 
     return invoice;
   },
-  invoiceLine: (invoiceLine: InvoiceLine): InvoiceLine => {
-    InvoiceLineData.push(invoiceLine);
-    return invoiceLine;
+  invoiceLine: (invoiceLine: InsertOutboundShipmentLineInput): InvoiceLine => {
+    const item = db.get.byId.item(invoiceLine.itemId);
+    const stockLine = db.get.byId.stockLine(invoiceLine.stockLineId);
+
+    const newInvoiceLine: InvoiceLine = {
+      ...invoiceLine,
+      itemName: item.name,
+      itemCode: item.code,
+      itemUnit: item.unitName,
+      itemId: item.id,
+      expiryDate: stockLine.expiryDate,
+      stockLineId: stockLine.id,
+      costPricePerPack: stockLine.costPricePerPack,
+      sellPricePerPack: stockLine.sellPricePerPack,
+      location: stockLine.location,
+      quantity: invoiceLine.numberOfPacks,
+      packSize: stockLine.packSize,
+    };
+
+    InvoiceLineData.push(newInvoiceLine);
+    return newInvoiceLine;
   },
 };
 

--- a/packages/mock-server/src/schema/Invoice.ts
+++ b/packages/mock-server/src/schema/Invoice.ts
@@ -53,6 +53,7 @@ const MutationResolvers = {
       __typename: 'BatchOutboundShipmentResponse',
       deleteOutboundShipments: [] as { id: string }[],
       insertOutboundShipmentLines: [] as { id: string }[],
+      updateOutboundShipments: [] as { id: string }[],
     };
 
     if (vars.deleteOutboundShipments) {
@@ -61,6 +62,14 @@ const MutationResolvers = {
           id: MutationResolvers.deleteOutboundShipment(null, id),
         })
       );
+    }
+
+    if (vars.updateOutboundShipments) {
+      response.updateOutboundShipments = [
+        Api.MutationService.update.invoice(
+          vars.updateOutboundShipments[0] as UpdateOutboundShipmentInput
+        ),
+      ];
     }
 
     if (vars.insertOutboundShipmentLines) {

--- a/packages/mock-server/src/schema/Invoice.ts
+++ b/packages/mock-server/src/schema/Invoice.ts
@@ -1,3 +1,4 @@
+import { MutationService } from './../api/mutations';
 import { UpdateOutboundShipmentInput } from './../../../common/src/types/schema';
 import {
   InvoiceSortFieldInput,
@@ -51,13 +52,22 @@ const MutationResolvers = {
     const response = {
       __typename: 'BatchOutboundShipmentResponse',
       deleteOutboundShipments: [] as { id: string }[],
+      insertOutboundShipmentLines: [] as { id: string }[],
     };
+
     if (vars.deleteOutboundShipments) {
       response.deleteOutboundShipments = vars.deleteOutboundShipments.map(
         id => ({
           id: MutationResolvers.deleteOutboundShipment(null, id),
         })
       );
+    }
+
+    if (vars.insertOutboundShipmentLines) {
+      response.insertOutboundShipmentLines =
+        vars.insertOutboundShipmentLines.map(line => {
+          return MutationService.insert.invoiceLine(line);
+        });
     }
 
     return response;

--- a/packages/mock-server/src/schema/invoiceLine.ts
+++ b/packages/mock-server/src/schema/invoiceLine.ts
@@ -16,12 +16,6 @@ const MutationResolvers = {
   ): string => {
     return Api.MutationService.remove.invoiceLine(invoiceLineId);
   },
-  insertOutboundShipmentLine: (
-    _: any,
-    { invoiceLine }: { invoiceLine: InvoiceLineType }
-  ): InvoiceLineType => {
-    return Api.MutationService.insert.invoiceLine(invoiceLine);
-  },
 };
 
 export const InvoiceLine = {

--- a/packages/mock-server/src/worker/handlers.ts
+++ b/packages/mock-server/src/worker/handlers.ts
@@ -170,23 +170,26 @@ export const upsertOutboundShipment = graphql.mutation(
     const queryResponse = {
       __typename: 'BatchOutboundShipmentResponse',
       insertOutboundShipmentLines: [] as { id: string }[],
-      updateOutboundShipments: [] as { id: string }[],
+      updateOutboundShipments: [] as { id: string; __typename: string }[],
     };
 
     if (updateOutboundShipments.length > 0) {
       queryResponse.updateOutboundShipments = [
-        MutationService.update.invoice(updateOutboundShipments[0]),
+        {
+          ...MutationService.update.invoice(updateOutboundShipments[0]),
+          __typename: 'UpdateOutboundShipmentResponseWithId',
+        },
       ];
     }
 
     if (insertOutboundShipmentLines.length > 0) {
       queryResponse.insertOutboundShipmentLines =
-        insertOutboundShipmentLines.forEach((line: InvoiceLine) => {
+        insertOutboundShipmentLines.map((line: InvoiceLine) => {
           MutationService.insert.invoiceLine(line);
         });
     }
 
-    return response(context.data({ upsertOutboundShipment: queryResponse }));
+    return response(context.data({ batchOutboundShipment: queryResponse }));
   }
 );
 

--- a/packages/mock-server/src/worker/handlers.ts
+++ b/packages/mock-server/src/worker/handlers.ts
@@ -1,9 +1,10 @@
-import { Invoice as InvoiceSchema } from './../schema/Invoice';
-import { UpdateOutboundShipmentInput } from './../../../common/src/types/schema';
-import { Invoice, InvoiceLine } from './../data/types';
 import { graphql } from 'msw';
-import { Api } from '../api';
+import { Invoice as InvoiceSchema } from './../schema/Invoice';
+import { Invoice, InvoiceLine } from './../data/types';
+import { MutationService } from './../api/mutations';
+import { ResolverService } from './../api/resolvers';
 import {
+  UpdateOutboundShipmentInput,
   InvoiceNodeType,
   InvoicesQueryVariables,
   ItemsListViewQueryVariables,
@@ -15,7 +16,8 @@ const updateInvoice = graphql.mutation<
   { input: UpdateOutboundShipmentInput }
 >('updateOutboundShipment', (request, response, context) => {
   const { variables } = request;
-  const result = Api.MutationService.update.invoice(variables.input);
+
+  const result = MutationService.update.invoice(variables.input);
   return response(context.data({ updateOutboundShipment: result }));
 });
 
@@ -25,7 +27,7 @@ const insertInvoice = graphql.mutation(
     const { variables } = request;
     const { id, otherPartyId } = variables;
 
-    const result = Api.MutationService.insert.invoice({
+    const result = MutationService.insert.invoice({
       id,
       otherPartyId,
     } as unknown as Invoice);
@@ -59,7 +61,7 @@ export const namesList = graphql.query<
 >('names', (request, response, context) => {
   const { variables } = request;
 
-  const result = Api.ResolverService.list.name(variables);
+  const result = ResolverService.list.name(variables);
 
   return response(context.data({ names: result }));
 });
@@ -70,7 +72,7 @@ export const invoiceList = graphql.query<
 >('invoices', (request, response, context) => {
   const { variables } = request;
 
-  const result = Api.ResolverService.list.invoice(variables);
+  const result = ResolverService.list.invoice(variables);
 
   return response(context.data({ invoices: result }));
 });
@@ -81,7 +83,7 @@ export const invoiceDetail = graphql.query(
     const { variables } = request;
     const { id } = variables;
 
-    const invoice = Api.ResolverService.byId.invoice(id as string);
+    const invoice = ResolverService.byId.invoice(id as string);
 
     return response(context.data({ invoice }));
   }
@@ -93,7 +95,7 @@ export const invoiceDetailByInvoiceNumber = graphql.query(
     const { variables } = request;
     const { invoiceNumber } = variables;
 
-    const invoice = Api.ResolverService.invoice.get.byInvoiceNumber(
+    const invoice = ResolverService.invoice.get.byInvoiceNumber(
       invoiceNumber as number
     );
 
@@ -106,7 +108,7 @@ export const itemsWithStockLines = graphql.query<
   ItemsListViewQueryVariables
 >('itemsWithStockLines', (request, response, context) => {
   const { variables } = request;
-  const result = Api.ResolverService.list.item(variables);
+  const result = ResolverService.list.item(variables);
 
   return response(context.data({ items: result }));
 });
@@ -116,7 +118,7 @@ export const itemsListView = graphql.query<
   ItemsListViewQueryVariables
 >('itemsListView', (request, response, context) => {
   const { variables } = request;
-  const result = Api.ResolverService.list.item(variables);
+  const result = ResolverService.list.item(variables);
 
   return response(context.data({ items: result }));
 });
@@ -145,7 +147,7 @@ export const invoiceCounts = graphql.query<
 >('invoiceCounts', (request, response, context) => {
   const { variables } = request;
   const { type } = variables;
-  const invoiceCounts = Api.ResolverService.statistics.invoice(type);
+  const invoiceCounts = ResolverService.statistics.invoice(type);
 
   return response(context.data({ invoiceCounts }));
 });
@@ -153,7 +155,7 @@ export const invoiceCounts = graphql.query<
 export const stockCounts = graphql.query(
   'stockCounts',
   (_, response, context) => {
-    const stockCounts = Api.ResolverService.statistics.stock();
+    const stockCounts = ResolverService.statistics.stock();
 
     return response(context.data({ stockCounts }));
   }
@@ -165,17 +167,26 @@ export const upsertOutboundShipment = graphql.mutation(
     const { variables } = request;
     const { insertOutboundShipmentLines, updateOutboundShipments } = variables;
 
+    const queryResponse = {
+      __typename: 'BatchOutboundShipmentResponse',
+      insertOutboundShipmentLines: [] as { id: string }[],
+      updateOutboundShipments: [] as { id: string }[],
+    };
+
     if (updateOutboundShipments.length > 0) {
-      Api.MutationService.update.invoice(updateOutboundShipments[0]);
+      queryResponse.updateOutboundShipments = [
+        MutationService.update.invoice(updateOutboundShipments[0]),
+      ];
     }
 
     if (insertOutboundShipmentLines.length > 0) {
-      insertOutboundShipmentLines.forEach((line: InvoiceLine) => {
-        Api.MutationService.insert.invoiceLine(line);
-      });
+      queryResponse.insertOutboundShipmentLines =
+        insertOutboundShipmentLines.forEach((line: InvoiceLine) => {
+          MutationService.insert.invoiceLine(line);
+        });
     }
 
-    return response(context.data({ updateOutboundShipment: [] }));
+    return response(context.data({ upsertOutboundShipment: queryResponse }));
   }
 );
 
@@ -192,7 +203,6 @@ export const handlers = [
   itemsListView,
   itemsWithStockLines,
   upsertOutboundShipment,
-  // batchMutationHandler,
   invoiceCounts,
   stockCounts,
 ];


### PR DESCRIPTION
Bit big!

- Extremely tedious and frustrating without the real api but this adds inserting of invoice lines using the extracted schema......
- It's 'working' for both the mock server and mock worker (persisting, at least)
- There are a bunch of updates still needed, but thought to PR this for now as it's getting too big
- There are values which when added show in the table as `null`/`undefined` - i.e. for `batch` which 1) likely need values added and 2) need to handle this better in cells, probably
- You can only add a single line at a time, at the moment as the `id` given in `ItemDetailsModal` is always `""`, and so when updating/inserting lines we insert with id `""` and then update id `""`. Will add a `uuid` package to generate these in the next one
- Not handling the response right now - it's too difficult to try and handle this meaningfully without the proper api setup
