### PR TITLE
#293 editable rows

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -32,3 +32,4 @@ export * from './useDebounce';
 export * from './useDocument';
 export * from './useToggle';
 export * from './useContentAreaHeight';
+export * from './useFilterBy';

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -261,10 +261,12 @@ query itemsWithStockLines(
   $offset: Int
   $key: ItemSortFieldInput!
   $desc: Boolean
+  $filter: ItemFilterInput
 ) {
   items(
     page: { first: $first, offset: $offset }
     sort: { key: $key, desc: $desc }
+    filter: $filter
   ) {
     ... on ConnectorError {
       __typename
@@ -351,10 +353,12 @@ query itemsListView(
   $offset: Int
   $key: ItemSortFieldInput!
   $desc: Boolean
+  $filter: ItemFilterInput
 ) {
   items(
     page: { first: $first, offset: $offset }
     sort: { key: $key, desc: $desc }
+    filter: $filter
   ) {
     ... on ConnectorError {
       __typename

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -16,6 +16,15 @@ export interface Name extends DomainObject {
   isSupplier: boolean;
 }
 
+export interface ItemRow extends DomainObject {
+  id: string;
+  isVisible: boolean;
+  code: string;
+  name: string;
+  availableQuantity: number;
+  unitName?: string;
+}
+
 export interface Item extends DomainObject {
   id: string;
   isVisible: boolean;

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1145,6 +1145,7 @@ export type ItemsWithStockLinesQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
   key: ItemSortFieldInput;
   desc?: Maybe<Scalars['Boolean']>;
+  filter?: Maybe<ItemFilterInput>;
 }>;
 
 
@@ -1155,6 +1156,7 @@ export type ItemsListViewQueryVariables = Exact<{
   offset?: Maybe<Scalars['Int']>;
   key: ItemSortFieldInput;
   desc?: Maybe<Scalars['Boolean']>;
+  filter?: Maybe<ItemFilterInput>;
 }>;
 
 
@@ -1446,8 +1448,12 @@ export const NamesDocument = gql`
 }
     `;
 export const ItemsWithStockLinesDocument = gql`
-    query itemsWithStockLines($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean) {
-  items(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
+    query itemsWithStockLines($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean, $filter: ItemFilterInput) {
+  items(
+    page: {first: $first, offset: $offset}
+    sort: {key: $key, desc: $desc}
+    filter: $filter
+  ) {
     ... on ConnectorError {
       __typename
       error {
@@ -1529,8 +1535,12 @@ export const ItemsWithStockLinesDocument = gql`
 }
     `;
 export const ItemsListViewDocument = gql`
-    query itemsListView($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean) {
-  items(page: {first: $first, offset: $offset}, sort: {key: $key, desc: $desc}) {
+    query itemsListView($first: Int, $offset: Int, $key: ItemSortFieldInput!, $desc: Boolean, $filter: ItemFilterInput) {
+  items(
+    page: {first: $first, offset: $offset}
+    sort: {key: $key, desc: $desc}
+    filter: $filter
+  ) {
     ... on ConnectorError {
       __typename
       error {

--- a/packages/common/src/ui/forms/Modal/ModalInput.tsx
+++ b/packages/common/src/ui/forms/Modal/ModalInput.tsx
@@ -6,17 +6,19 @@ import { BasicTextInput } from '../../components/inputs/TextInput/BasicTextInput
 
 export interface ModalInputProps {
   defaultValue?: unknown;
-  inputProps: UseFormRegisterReturn;
+  inputProps?: UseFormRegisterReturn;
   width?: number;
+  disabled?: boolean;
 }
 
 export const ModalInput: React.FC<ModalInputProps> = ({
   defaultValue,
   inputProps,
+  disabled = false,
   width = 240,
 }) => {
   const { errors } = useFormState();
-  const error = get(errors, inputProps.name);
+  const error = get(errors, inputProps?.name ?? '');
   const errorProps = error ? { error: true, helperText: error.message } : {};
 
   return (
@@ -32,6 +34,7 @@ export const ModalInput: React.FC<ModalInputProps> = ({
       }}
     >
       <BasicTextInput
+        disabled={disabled}
         defaultValue={defaultValue}
         sx={{ width: `${width}px` }}
         {...errorProps}

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -8,7 +8,7 @@ import { Collapse } from '@mui/material';
 
 interface DataRowProps<T extends DomainObject> {
   columns: Column<T>[];
-  onClick?: (rowValues: T) => void;
+  onClick?: (rowData: T) => void;
   rowData: T;
   rowKey: string;
   ExpandContent?: FC;

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -7,7 +7,6 @@ import {
   InfoIcon,
   isAlmostExpired,
   ModalNumericInput,
-  Item,
   Table,
   TableBody,
   TableCell,
@@ -26,7 +25,6 @@ import {
 import { BatchRow } from '../types';
 
 export interface BatchesTableProps {
-  item: Item | null;
   onChange: (key: string, value: number, packSize: number) => void;
   register: UseFormRegister<FieldValues>;
   rows: BatchRow[];
@@ -155,13 +153,10 @@ const BasicCell: React.FC<TableCellProps> = ({ sx, ...props }) => (
 );
 
 export const BatchesTable: React.FC<BatchesTableProps> = ({
-  item,
   onChange,
   register,
   rows,
 }) => {
-  if (!item) return null;
-
   const t = useTranslation();
   const onChangeValue: React.ChangeEventHandler<HTMLInputElement> = event =>
     onChange('placeholder', Number(event.target.value), 1);

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -127,7 +127,11 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
         {quantityDescription}
         <Grid style={{ display: 'flex' }} justifyContent="flex-end" flex={1}>
           <ModalLabel labelKey="label.unit" justifyContent="flex-end" />
-          <ModalInput disabled width={150} />
+          <ModalInput
+            disabled
+            width={150}
+            defaultValue={summaryItem?.itemUnit ?? ''}
+          />
         </Grid>
       </ModalRow>
     </Grid>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -17,13 +17,14 @@ import {
   ModalNumericInput,
 } from '@openmsupply-client/common';
 import { ItemSearchInput } from '@openmsupply-client/system/src/Item';
+import { OutboundShipmentSummaryItem } from '../types';
 
 interface ItemDetailsFormProps {
   allocatedQuantity: number;
   invoiceLine?: InvoiceLine;
   quantity?: number;
   register: UseFormRegister<FieldValues>;
-  selectedItem?: Item;
+  summaryItem?: OutboundShipmentSummaryItem;
   packSize: number;
   onChangeItem: (newItem: Item) => void;
   onChangeQuantity: (quantity: number) => void;
@@ -39,12 +40,11 @@ const SimpleText = styled(Typography)({
 
 export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
   allocatedQuantity,
-  invoiceLine,
   onChangeItem,
   onChangeQuantity,
   quantity,
   register,
-  selectedItem,
+  summaryItem,
   setPackSize,
   packSize,
 }) => {
@@ -65,12 +65,6 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
     setPackSize(newPackSize);
   };
 
-  selectedItem?.availableBatches.forEach(batch => {
-    if (packSizes.every(pack => pack !== batch.packSize)) {
-      packSizes.push(batch.packSize);
-    }
-  });
-
   const packSizeOptions = packSizes.sort().map(pack => ({
     label: String(pack),
     value: pack,
@@ -85,22 +79,20 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
       <ModalRow>
         <ModalLabel labelKey="label.item" />
         <Grid item flex={1}>
-          <ItemSearchInput value={selectedItem} onChange={onChangeItem} />
+          <ItemSearchInput
+            currentItemId={summaryItem?.itemId}
+            onChange={onChangeItem}
+          />
         </Grid>
       </ModalRow>
       <ModalRow>
         <ModalLabel labelKey="label.available" />
-        <NumericTextInput
-          defaultValue={invoiceLine?.itemCode}
-          inputProps={register('availableQuantity')}
-          disabled
-          sx={{ width: 85 }}
-        />
+        <NumericTextInput value={0} disabled sx={{ width: 85 }} />
         <Grid style={{ display: 'flex' }} justifyContent="flex-end" flex={1}>
           <ModalLabel labelKey="label.code" justifyContent="flex-end" />
           <ModalInput
-            defaultValue={invoiceLine?.itemCode}
-            inputProps={register('code', { disabled: true })}
+            defaultValue={summaryItem?.itemCode ?? ''}
+            disabled
             width={150}
           />
         </Grid>
@@ -114,7 +106,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
             pattern: { value: /^[0-9]+$/, message: t('error.invalid-value') },
             onChange: event => onChangeQuantity(Number(event.target.value)),
           })}
-          defaultValue={invoiceLine?.numberOfPacks}
+          defaultValue={summaryItem?.numberOfPacks || 0}
         />
         <Grid
           item
@@ -135,12 +127,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
         {quantityDescription}
         <Grid style={{ display: 'flex' }} justifyContent="flex-end" flex={1}>
           <ModalLabel labelKey="label.unit" justifyContent="flex-end" />
-          <ModalInput
-            inputProps={register('unitName', {
-              disabled: true,
-            })}
-            width={150}
-          />
+          <ModalInput disabled width={150} />
         </Grid>
       </ModalRow>
     </Grid>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -102,16 +102,7 @@ const useStockLines = (itemCode: string | undefined) => {
     });
   }, [data]);
 
-  const onIssue = (stockLineId: string, quantity: number) => {
-    const batchRowIdx = batchRows.findIndex(batch => batch.id === stockLineId);
-    const batchRow = batchRows[batchRowIdx];
-    if (!batchRow) return;
-
-    batchRows[batchRowIdx] = { ...batchRow, quantity };
-    setBatchRows([...batchRows]);
-  };
-
-  return { batchRows, onIssue, isLoading };
+  return { batchRows, isLoading };
 };
 
 export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -77,13 +77,13 @@ const sortByDisabledThenExpiryDate = (a: BatchRow, b: BatchRow) => {
 
 const useStockLines = (itemCode: string | undefined) => {
   const [batchRows, setBatchRows] = useState<BatchRow[]>([]);
-  const { data, isLoading } = useItems({
+  const { data, isLoading, onFilterByCode } = useItems({
     code: { equalTo: itemCode },
   });
 
   useEffect(() => {
     if (!itemCode) return;
-    data?.onFilterByCode(itemCode);
+    onFilterByCode(itemCode);
   }, [itemCode]);
 
   useEffect(() => {

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -113,8 +113,6 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   onChangeItem,
   summaryItem,
 }) => {
-  const [batchRows, setBatchRows] = useState<BatchRow[]>([]);
-
   const [quantity, setQuantity] = useState(0);
   const [allocated, setAllocated] = useState(0);
   const [packSize, setPackSize] = useState(1);
@@ -122,7 +120,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   const methods = useForm({ mode: 'onBlur' });
   const { reset, register, setValue, getValues } = methods;
 
-  const { batchRows: bRows, isLoading } = useStockLines(summaryItem?.itemCode);
+  const { batchRows, isLoading } = useStockLines(summaryItem?.itemCode);
 
   const { hideDialog, showDialog, Modal } = useDialog({
     title: 'heading.add-item',
@@ -131,7 +129,6 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
 
   const onReset = () => {
     reset();
-    setBatchRows([]);
     setQuantity(0);
 
     setValue('quantity', '');
@@ -282,7 +279,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
               <BatchesTable
                 onChange={onChangeRowQuantity}
                 register={register}
-                rows={bRows}
+                rows={batchRows}
               />
             )}
           </Grid>

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -12,6 +12,7 @@ import {
   Invoice,
   InvoiceLine,
   ifTheSameElseDefault,
+  Item,
 } from '@openmsupply-client/common';
 import { placeholderInvoice } from './index';
 import {
@@ -85,9 +86,22 @@ export interface OutboundShipmentStateShape {
 
 type InvoiceLinesByItemId = Record<string, OutboundShipmentRow[]>;
 
-const createItem = (
+export const itemToSummaryItem = (item: Item): OutboundShipmentSummaryItem => {
+  return {
+    id: item.id,
+    itemId: item.id,
+    itemName: item.name,
+    itemCode: item.code,
+    itemUnit: item.unitName,
+    batches: [],
+    unitQuantity: 0,
+    numberOfPacks: 0,
+  };
+};
+
+export const createSummaryItem = (
   itemId: string,
-  batches: OutboundShipmentRow[]
+  batches: OutboundShipmentRow[] = []
 ): OutboundShipmentSummaryItem => {
   const item: OutboundShipmentSummaryItem = {
     id: itemId,
@@ -114,7 +128,7 @@ const createItem = (
   return item;
 };
 
-const createItems = (lines: OutboundShipmentRow[]) => {
+const createSummaryItems = (lines: OutboundShipmentRow[]) => {
   const byItem: InvoiceLinesByItemId = lines.reduce((acc, line) => {
     const itemId = line.itemId;
     const lines = acc[itemId]
@@ -125,7 +139,7 @@ const createItems = (lines: OutboundShipmentRow[]) => {
   }, {} as InvoiceLinesByItemId);
 
   return Object.keys(byItem).map(itemId =>
-    createItem(itemId, byItem[itemId] as OutboundShipmentRow[])
+    createSummaryItem(itemId, byItem[itemId] as OutboundShipmentRow[])
   );
 };
 
@@ -182,7 +196,7 @@ export const reducer = (
           draft.deleteLine = line =>
             dispatch?.(OutboundAction.deleteLine(line));
 
-          draft.items = createItems(draft.lines);
+          draft.items = createSummaryItems(draft.lines);
 
           break;
         }

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -12,6 +12,7 @@ import { OutboundShipmentSummaryItem } from '../types';
 interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   data: T[];
   columns: Column<T>[];
+  onRowClick?: (rowData: T) => void;
 }
 
 const Expand: FC = () => {
@@ -30,12 +31,13 @@ const Expand: FC = () => {
 
 export const GeneralTabComponent: FC<
   GeneralTabProps<OutboundShipmentSummaryItem>
-> = ({ data, columns }) => {
+> = ({ data, columns, onRowClick }) => {
   const { pagination } = usePagination();
   // const activeRows = data.filter(({ isDeleted }) => !isDeleted);
 
   return (
     <DataTable
+      onRowClick={onRowClick}
       ExpandContent={Expand}
       pagination={{ ...pagination, total: data.length }}
       columns={columns}

--- a/packages/mock-server/src/schema/Item.ts
+++ b/packages/mock-server/src/schema/Item.ts
@@ -1,4 +1,7 @@
-import { ItemSortFieldInput } from '@openmsupply-client/common/src/types/schema';
+import {
+  ItemSortFieldInput,
+  ItemFilterInput,
+} from '@openmsupply-client/common/src/types/schema';
 import { Api } from '../api';
 import { ListResponse, Item as ItemType } from '../data/types';
 
@@ -8,6 +11,7 @@ const QueryResolvers = {
     vars: {
       page?: { first?: number; offset?: number };
       sort: [{ key: ItemSortFieldInput; desc: boolean }];
+      filter: ItemFilterInput;
     }
   ): ListResponse<ItemType> => {
     return Api.ResolverService.list.item({
@@ -15,6 +19,7 @@ const QueryResolvers = {
       offset: vars?.page?.offset ?? 0,
       desc: vars.sort[0]?.desc ?? false,
       key: vars.sort[0]?.key ?? ItemSortFieldInput.Name,
+      filter: vars.filter,
     });
   },
 };

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.stories.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.stories.tsx
@@ -13,7 +13,7 @@ const Template: Story = () => {
 
   return (
     <ItemSearchInput
-      value={selectedItem}
+      currentItem={selectedItem}
       onChange={item => {
         setSelectedItem(item);
       }}

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
@@ -29,15 +29,23 @@ const renderOption = (
 
 interface ItemSearchInputProps {
   onChange: (item: Item) => void;
-  value?: Item;
+  currentItem?: Item;
+  currentItemId?: string;
 }
 
 export const ItemSearchInput: FC<ItemSearchInputProps> = ({
   onChange,
-  value,
+  currentItem,
+  currentItemId,
 }) => {
   const { data, isLoading } = useItems();
   const t = useTranslation();
+
+  const value =
+    currentItem ??
+    (currentItemId
+      ? data?.nodes?.find(i => i.id === currentItemId)
+      : undefined);
 
   return (
     <Autocomplete

--- a/packages/system/src/Item/hooks/useItems/useItems.ts
+++ b/packages/system/src/Item/hooks/useItems/useItems.ts
@@ -32,15 +32,14 @@ const availableBatchesGuard = (
 
 export const useItems = (
   initialFilter?: FilterBy<Item> | null
-): UseQueryResult<{
+): { onFilterByCode: (code: string) => void } & UseQueryResult<{
   nodes: Item[];
   totalCount: number;
-  onFilterByCode: (code: string) => void;
 }> => {
   const { api } = useOmSupplyApi();
   const filter = useFilterBy<Item>(initialFilter);
 
-  return useQuery(['items', 'list', filter.filterBy], async () => {
+  const queryState = useQuery(['items', 'list', filter.filterBy], async () => {
     const result = await api.itemsWithStockLines({
       key: ItemSortFieldInput.Name,
       filter: filter.filterBy,
@@ -54,10 +53,12 @@ export const useItems = (
       availableBatches: availableBatchesGuard(item.availableBatches),
     }));
 
-    const onFilterByCode = (code: string) => {
-      filter.onChangeStringFilterRule('code', 'equalTo', code);
-    };
-
-    return { totalCount: items.totalCount, nodes, onFilterByCode };
+    return { totalCount: items.totalCount, nodes };
   });
+
+  const onFilterByCode = (code: string) => {
+    filter.onChangeStringFilterRule('code', 'equalTo', code);
+  };
+
+  return { ...queryState, onFilterByCode };
 };


### PR DESCRIPTION
Working on #293 ..

- So, we need to edit a row which means we need to set that row as the 'selected row' at some higher level than the modal. This PR lifts the state of the 'selectedItem' in the modal to be at the `DetailView` level. Which means that the `DetailView` passes a callback to change the selected item, also.
- In addition, instead of passing an `InvoiceLine`, we need to have the modal work on all `InvoiceLine`s of an item within the invoice, so have adjusted the modal to work with a `SummaryItem`.

With these changes, a couple of challenges:
- When passing the `SummaryItem`, we have access to the invoice lines, but not the `StockLine`s (In addition, we have the item name, code and ID, but not the actual item - however, it's not needed). I thought of a few solutions: Put the stock lines into the summary item! Bit of an easy one for this, but I feared the stock lines will become stale, so wanted to avoid caching them. Instead, since the item details modal currently has a list of all items and stock lines, we could just use the itemID to search for the stock lines! I was going to go for this, however it has been a concern of mine that we are querying for all items and all stock lines, so I decided to take the long way round..
- Request for the stock lines! Using the `itemCode` of the summary item (As there is no filter right now for an itemID, nor a query for stock lines) which is passed, query for all the stock lines. This means we can remove querying for the stock lines in the `items` query (not done yet) and also add filtering/pagination to the list and not have to rely on all items and stock lines being queried for.
- What this means is that when we open the modal or select an item, the stock lines will need to be fetched, so the `BatchesTable` won't always auto-load. If this is problem in practise, there's some ways we can fix this problem. For example, we can fire the query for the stock lines when hovering a row to edit, or pre-fetch stock lines on invoice load. Similarly for selecting an item - we can prefetch as we filter if we really want to fix the latency. It will still end up as an overall decrease in data sent (and avoid the situation where there's 5000 items and a few stock lines per?).