### PR TITLE
#273 upsert items

### DIFF
--- a/packages/common/src/intl/locales/ar.json
+++ b/packages/common/src/intl/locales/ar.json
@@ -123,5 +123,6 @@
   "link.backorders": "Backorders",
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
-  "placeholder.enter-a-customers-name": "Enter a customers name"
+  "placeholder.enter-a-customers-name": "Enter a customers name",
+  "dev.log-draft": "Log draft"
 }

--- a/packages/common/src/intl/locales/en.json
+++ b/packages/common/src/intl/locales/en.json
@@ -123,5 +123,6 @@
   "link.backorders": "Backorders",
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
+  "dev.log-draft": "Log draft",
   "placeholder.enter-a-customers-name": "Enter a customers name"
 }

--- a/packages/common/src/intl/locales/fr.json
+++ b/packages/common/src/intl/locales/fr.json
@@ -123,5 +123,6 @@
   "link.backorders": "Backorders",
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
+  "dev.log-draft": "Log draft",
   "placeholder.enter-a-customers-name": "Enter a customers name"
 }

--- a/packages/common/src/intl/locales/pt.json
+++ b/packages/common/src/intl/locales/pt.json
@@ -123,5 +123,6 @@
   "link.backorders": "Backorders",
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
+  "dev.log-draft": "Log draft",
   "placeholder.enter-a-customers-name": "Enter a customers name"
 }

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -92,6 +92,39 @@ query invoice($id: String!) {
             note
             locationDescription
             sellPricePerPack
+            stockLine {
+              __typename
+              ... on NodeError {
+                __typename
+                error {
+                  description
+                  ... on DatabaseError {
+                    __typename
+                    description
+                    fullError
+                  }
+                  ... on RecordNotFound {
+                    __typename
+                    description
+                  }
+                }
+              }
+              ... on StockLineNode {
+                __typename
+                availableNumberOfPacks
+                batch
+                costPricePerPack
+                expiryDate
+                id
+                itemId
+                packSize
+                sellPricePerPack
+                storeId
+                totalNumberOfPacks
+                onHold
+                note
+              }
+            }
           }
           totalCount
         }

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -567,11 +567,13 @@ query stockCounts {
 mutation upsertOutboundShipment(
   $deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!]
   $insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!]
+  $updateOutboundShipmentLines: [UpdateOutboundShipmentLineInput!]
   $updateOutboundShipments: [UpdateOutboundShipmentInput!]
 ) {
   batchOutboundShipment(
     deleteOutboundShipmentLines: $deleteOutboundShipmentLines
     insertOutboundShipmentLines: $insertOutboundShipmentLines
+    updateOutboundShipmentLines: $updateOutboundShipmentLines
     updateOutboundShipments: $updateOutboundShipments
   ) {
     __typename

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,5 +1,6 @@
 import { ObjectWithStringKeys } from './utility';
 import { StockLineNode } from './schema';
+import { InvoiceLineNode } from '..';
 
 export * from './utility';
 export * from './schema';
@@ -52,25 +53,10 @@ export type Store = {
   name: string;
 };
 
-export interface InvoiceLine extends DomainObject {
-  id: string;
-
-  itemId: string;
-  itemName: string;
-  itemCode: string;
-  itemUnit: string;
-  packSize: number;
-  numberOfPacks: number;
-  costPricePerPack: number;
-  sellPricePerPack: number;
+export interface InvoiceLine extends InvoiceLineNode, DomainObject {
+  stockLine?: StockLine;
   stockLineId: string;
-
-  expiryDate?: string | null;
-
-  batch?: string | null;
-
-  locationDescription?: string | null;
-  note?: string | null;
+  invoiceId: string;
 }
 
 export interface InvoiceRow extends DomainObject {

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1199,6 +1199,7 @@ export type StockCountsQuery = { __typename?: 'Queries', stockCounts: { __typena
 export type UpsertOutboundShipmentMutationVariables = Exact<{
   deleteOutboundShipmentLines?: Maybe<Array<DeleteOutboundShipmentLineInput> | DeleteOutboundShipmentLineInput>;
   insertOutboundShipmentLines?: Maybe<Array<InsertOutboundShipmentLineInput> | InsertOutboundShipmentLineInput>;
+  updateOutboundShipmentLines?: Maybe<Array<UpdateOutboundShipmentLineInput> | UpdateOutboundShipmentLineInput>;
   updateOutboundShipments?: Maybe<Array<UpdateOutboundShipmentInput> | UpdateOutboundShipmentInput>;
 }>;
 
@@ -1751,10 +1752,11 @@ export const StockCountsDocument = gql`
 }
     `;
 export const UpsertOutboundShipmentDocument = gql`
-    mutation upsertOutboundShipment($deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!], $insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!], $updateOutboundShipments: [UpdateOutboundShipmentInput!]) {
+    mutation upsertOutboundShipment($deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!], $insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!], $updateOutboundShipmentLines: [UpdateOutboundShipmentLineInput!], $updateOutboundShipments: [UpdateOutboundShipmentInput!]) {
   batchOutboundShipment(
     deleteOutboundShipmentLines: $deleteOutboundShipmentLines
     insertOutboundShipmentLines: $insertOutboundShipmentLines
+    updateOutboundShipmentLines: $updateOutboundShipmentLines
     updateOutboundShipments: $updateOutboundShipments
   ) {
     __typename

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1117,7 +1117,7 @@ export type InvoiceQueryVariables = Exact<{
 }>;
 
 
-export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null | undefined, entryDatetime: any, invoiceNumber: number, allocatedDatetime?: any | null | undefined, pickedDatetime?: any | null | undefined, shippedDatetime?: any | null | undefined, deliveredDatetime?: any | null | undefined, enteredByName: string, requisitionNumber?: number | null | undefined, purchaseOrderNumber?: number | null | undefined, inboundShipmentNumber?: number | null | undefined, goodsReceiptNumber?: number | null | undefined, onHold: boolean, color: string, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } }, lines: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename?: 'PaginationError', description: string } } | { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemCode: string, itemUnit: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null | undefined, locationDescription?: string | null | undefined, sellPricePerPack: number }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, subtotal: number, taxPercentage: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null | undefined, entryDatetime: any, invoiceNumber: number, allocatedDatetime?: any | null | undefined, pickedDatetime?: any | null | undefined, shippedDatetime?: any | null | undefined, deliveredDatetime?: any | null | undefined, enteredByName: string, requisitionNumber?: number | null | undefined, purchaseOrderNumber?: number | null | undefined, inboundShipmentNumber?: number | null | undefined, goodsReceiptNumber?: number | null | undefined, onHold: boolean, color: string, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } }, lines: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename?: 'PaginationError', description: string } } | { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemCode: string, itemUnit: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null | undefined, locationDescription?: string | null | undefined, sellPricePerPack: number, stockLine?: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: any | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null | undefined } | null | undefined }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, subtotal: number, taxPercentage: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type InvoicesQueryVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
@@ -1297,6 +1297,39 @@ export const InvoiceDocument = gql`
             note
             locationDescription
             sellPricePerPack
+            stockLine {
+              __typename
+              ... on NodeError {
+                __typename
+                error {
+                  description
+                  ... on DatabaseError {
+                    __typename
+                    description
+                    fullError
+                  }
+                  ... on RecordNotFound {
+                    __typename
+                    description
+                  }
+                }
+              }
+              ... on StockLineNode {
+                __typename
+                availableNumberOfPacks
+                batch
+                costPricePerPack
+                expiryDate
+                id
+                itemId
+                packSize
+                sellPricePerPack
+                storeId
+                totalNumberOfPacks
+                onHold
+                note
+              }
+            }
           }
           totalCount
         }

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -11,7 +11,7 @@ interface DataRowProps<T extends DomainObject> {
   onClick?: (rowData: T) => void;
   rowData: T;
   rowKey: string;
-  ExpandContent?: FC;
+  ExpandContent?: FC<{ rowData: T }>;
 }
 
 export const DataRow = <T extends DomainObject>({
@@ -74,7 +74,7 @@ export const DataRow = <T extends DomainObject>({
       <tr>
         <td style={{ display: 'flex' }}>
           <Collapse sx={{ flex: 1 }} in={isExpanded}>
-            {ExpandContent ? <ExpandContent /> : null}
+            {ExpandContent ? <ExpandContent rowData={rowData} /> : null}
           </Collapse>
         </td>
       </tr>

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -71,7 +71,7 @@ const getDefaultFormatter = <T extends DomainObject>(
     }
     case ColumnFormat.Currency: {
       return (value: unknown) => {
-        if (Number.isNaN(value)) return '';
+        if (Number.isNaN(Number(value))) return '';
 
         const formatNumber = useFormatNumber();
 
@@ -80,7 +80,7 @@ const getDefaultFormatter = <T extends DomainObject>(
       };
     }
     default: {
-      return (value: unknown) => String(value);
+      return (value: unknown) => String(value ?? '');
     }
   }
 };

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -25,5 +25,5 @@ export interface TableProps<T extends DomainObject> {
   onRowClick?: (row: T) => void;
   children?: ReactNode;
   noDataMessageKey?: LocaleKey;
-  ExpandContent?: FC;
+  ExpandContent?: FC<{ rowData: T }>;
 }

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -158,8 +158,6 @@ const getColumnLookup = <T extends DomainObject>(): Record<
     label: 'label.unit-quantity',
     key: 'unitQuantity',
     width: 100,
-    accessor: row =>
-      String(Number(row['quantity'] ?? 0) * Number(row['packSize'] ?? 0)),
     align: ColumnAlign.Right,
   },
   itemUnit: {

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -13,7 +13,12 @@ import {
   useOmSupplyApi,
   Item,
 } from '@openmsupply-client/common';
-import { reducer, OutboundAction, itemToSummaryItem } from './reducer';
+import {
+  reducer,
+  OutboundAction,
+  itemToSummaryItem,
+  recalculateSummary,
+} from './reducer';
 import { getOutboundShipmentDetailViewApi } from '../../api';
 import { GeneralTab } from './tabs/GeneralTab';
 import { ItemDetailsModal } from './modals/ItemDetailsModal';
@@ -65,7 +70,15 @@ export const DetailView: FC = () => {
       'sellPricePerPack',
       'packSize',
       'itemUnit',
-      'unitQuantity',
+      [
+        'unitQuantity',
+        {
+          accessor: rowData => {
+            const { unitQuantity } = recalculateSummary(rowData);
+            return unitQuantity;
+          },
+        },
+      ],
       'numberOfPacks',
       getRowExpandColumn<OutboundShipmentSummaryItem>(),
       GenericColumnKey.Selection,

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -13,12 +13,7 @@ import {
   useOmSupplyApi,
   Item,
 } from '@openmsupply-client/common';
-import {
-  reducer,
-  OutboundAction,
-  itemToSummaryItem,
-  recalculateSummary,
-} from './reducer';
+import { reducer, OutboundAction, itemToSummaryItem } from './reducer';
 import { getOutboundShipmentDetailViewApi } from '../../api';
 import { GeneralTab } from './tabs/GeneralTab';
 import { ItemDetailsModal } from './modals/ItemDetailsModal';
@@ -70,15 +65,7 @@ export const DetailView: FC = () => {
       'sellPricePerPack',
       'packSize',
       'itemUnit',
-      [
-        'unitQuantity',
-        {
-          accessor: rowData => {
-            const { unitQuantity } = recalculateSummary(rowData);
-            return unitQuantity;
-          },
-        },
-      ],
+      'unitQuantity',
       'numberOfPacks',
       getRowExpandColumn<OutboundShipmentSummaryItem>(),
       GenericColumnKey.Selection,

--- a/packages/invoices/src/OutboundShipment/DetailView/SidePanel.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/SidePanel.tsx
@@ -114,11 +114,28 @@ export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
   return (
     <DetailPanelPortal
       Actions={
-        <DetailPanelAction
-          icon={<CopyIcon />}
-          titleKey="link.copy-to-clipboard"
-          onClick={copyToClipboard}
-        />
+        <>
+          {!process.env['NODE_ENV'] ||
+            (process.env['NODE_ENV'] === 'development' && (
+              <DetailPanelAction
+                icon={<CopyIcon />}
+                titleKey="dev.log-draft"
+                onClick={() =>
+                  draft.items.forEach(item => {
+                    console.table(item);
+                    Object.values(item.batches).forEach(batch => {
+                      console.table(batch);
+                    });
+                  })
+                }
+              />
+            ))}
+          <DetailPanelAction
+            icon={<CopyIcon />}
+            titleKey="link.copy-to-clipboard"
+            onClick={copyToClipboard}
+          />
+        </>
       }
     >
       <AdditionalInfoSection draft={draft} />

--- a/packages/invoices/src/OutboundShipment/DetailView/SidePanel.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/SidePanel.tsx
@@ -120,14 +120,15 @@ export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
               <DetailPanelAction
                 icon={<CopyIcon />}
                 titleKey="dev.log-draft"
-                onClick={() =>
+                onClick={() => {
+                  console.table(draft);
                   draft.items.forEach(item => {
                     console.table(item);
                     Object.values(item.batches).forEach(batch => {
                       console.table(batch);
                     });
-                  })
-                }
+                  });
+                }}
               />
             ))}
           <DetailPanelAction

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -187,7 +187,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   summaryItem,
 }) => {
   const methods = useForm({ mode: 'onBlur' });
-  const { reset, register, setValue, getValues } = methods;
+  const { reset, register, setValue } = methods;
 
   const { batchRows, setBatchRows, isLoading } = useBatchRows(summaryItem);
   const packSizeController = usePackSizeController(batchRows);
@@ -206,32 +206,20 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
     onReset();
   };
   const upsert = () => {
-    if (!summaryItem) return;
+    if (!summaryItem) return null;
 
-    const values = getValues();
-    const invoiceLines = batchRows.map(batch =>
-      getInvoiceLine(
-        generateUUID(),
-        summaryItem,
-        batch,
-        Number(values[batch.id] || 0)
-      )
-    );
-
-    invoiceLines
-      .filter(line => line.numberOfPacks > 0)
-      .forEach(upsertInvoiceLine);
-    const placeholderValue = Number(values['placeholder'] || 0);
-    if (placeholderValue > 0) {
-      invoiceLines.push(
-        getInvoiceLine(
-          'placeholder',
-          summaryItem,
-          { id: 'placeholder', expiryDate: '' },
-          placeholderValue
-        )
+    // TODO: Handle placeholder upserting.
+    const invoiceLines = batchRows
+      .filter(({ id }) => id !== 'placeholder')
+      .map(batch =>
+        getInvoiceLine(generateUUID(), summaryItem, batch, batch.quantity)
       );
-    }
+
+    // Upsert each line. Any lines which do no already exist and have no had any
+    // packs allocated, will not be created, but those which already exist and have
+    // their quantity reduced to 0 will be marked for deletion.
+    invoiceLines.forEach(upsertInvoiceLine);
+
     onReset();
   };
   const upsertAndClose = () => {

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -105,7 +105,13 @@ const useBatchRows = (summaryItem: OutboundShipmentSummaryItem | null) => {
           const matchingInvoiceRow = Object.values(summaryItem.batches).find(
             ({ stockLineId }) => stockLineId === batch.id
           );
-          return { ...batch, quantity: matchingInvoiceRow?.numberOfPacks ?? 0 };
+          return {
+            ...batch,
+            quantity: matchingInvoiceRow?.numberOfPacks ?? 0,
+            availableNumberOfPacks:
+              batch.availableNumberOfPacks +
+              (matchingInvoiceRow?.numberOfPacks ?? 0),
+          };
         })
         .sort(sortByDisabledThenExpiryDate);
       rows.push(createPlaceholderRow());

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -351,7 +351,7 @@ describe('DetailView reducer: deleting lines', () => {
   });
 
   it('a line which is created, then deleted, is removed from state completely', () => {
-    const lineToDelete = createLine('99', { itemId: '99', stockLine: '99' });
+    const lineToDelete = createLine('99', { itemId: '99', stockLineId: '99' });
     const state1 = callReducer(OutboundAction.upsertLine(lineToDelete));
     const state2 = callReducer(OutboundAction.deleteLine(lineToDelete), state1);
 

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -481,4 +481,33 @@ describe('DetailView reducer: inserting', () => {
 
     expect(findRow(state, lineToInsert.id)).toBeUndefined();
   });
+
+  it('inserts new lines under already existing summary items', () => {
+    const lineToInsert = createLine('999', {
+      stockLineId: '999',
+      itemId: '1',
+      numberOfPacks: 99,
+    });
+    const state = callReducer(OutboundAction.upsertLine(lineToInsert));
+
+    const summaryItem = state.draft.items.find(({ id }) => id === '1');
+
+    expect(summaryItem?.batches[lineToInsert.id]).toEqual({
+      ...lineToInsert,
+      isCreated: true,
+    });
+  });
+
+  it('ignores lines which are being inserted under an already existing summary item with zero number of packs', () => {
+    const lineToInsert = createLine('999', {
+      stockLineId: '999',
+      itemId: '1',
+      numberOfPacks: 0,
+    });
+    const state = callReducer(OutboundAction.upsertLine(lineToInsert));
+
+    const summaryItem = state.draft.items.find(({ id }) => id === '1');
+
+    expect(summaryItem?.batches[lineToInsert.id]).toBeUndefined();
+  });
 });

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -204,6 +204,60 @@ describe('DetailView reducer: updating lines', () => {
       })
     );
   });
+
+  it('marks any line that exists as being updated with a number of packs of zero as a delete', () => {
+    const lineToUpdate = createLine('11', { numberOfPacks: 0 });
+    const state1 = callReducer(OutboundAction.upsertLine(lineToUpdate));
+
+    expect(findRow(state1, lineToUpdate.id)).toEqual(
+      expect.objectContaining({
+        isDeleted: true,
+        isUpdated: false,
+        isCreated: false,
+      })
+    );
+  });
+
+  it('deletes from state lines which are created and deleted through setting the packs to zero, as well as removing the summary item.', () => {
+    // The two lines for a summary item.
+    const lineToDelete = createLine('99', { itemId: '999', stockLineId: '99' });
+    const lineToUpdate = createLine('991', {
+      itemId: '999',
+      stockLineId: '999',
+      numberOfPacks: 0,
+    });
+
+    // Insert each of the lines
+    const state1 = callReducer(OutboundAction.upsertLine(lineToDelete));
+    expect(findRow(state1, lineToDelete.id)?.isCreated).toBe(true);
+
+    const state2 = callReducer(OutboundAction.upsertLine(lineToUpdate), state1);
+    expect(findRow(state2, lineToUpdate.id)?.isCreated).toBe(true);
+
+    // One is deleted normally and is removed from state completely as it is not persisted to the
+    // server.
+    const state3 = callReducer(OutboundAction.deleteLine(lineToDelete), state2);
+    expect(findRow(state3, lineToDelete.id)).toEqual(undefined);
+
+    // Delete one by setting the number of packs to zero.
+    const state4 = callReducer(
+      OutboundAction.upsertLine({
+        ...lineToUpdate,
+        numberOfPacks: 0,
+        isCreated: true,
+      }),
+      state3
+    );
+    expect(findRow(state4, lineToUpdate.id)).toEqual(undefined);
+
+    const anySummaryItemsWithNoBatches = state4.draft.items.filter(
+      summaryItem => {
+        return Object.values(summaryItem.batches).length === 0;
+      }
+    );
+
+    expect(anySummaryItemsWithNoBatches.length).toBe(0);
+  });
 });
 
 describe('DetailView reducer: merging', () => {

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.test.ts
@@ -224,7 +224,7 @@ describe('DetailView reducer: updating lines', () => {
     const lineToUpdate = createLine('991', {
       itemId: '999',
       stockLineId: '999',
-      numberOfPacks: 0,
+      numberOfPacks: 99,
     });
 
     // Insert each of the lines
@@ -469,5 +469,16 @@ describe('DetailView reducer: inserting', () => {
     const state = callReducer(OutboundAction.upsertLine(lineToInsert));
 
     expect(findRow(state, lineToInsert.id)).toBeTruthy();
+  });
+
+  it('ignores lines which are being inserted with zero number of packs', () => {
+    const lineToInsert = createLine('999', {
+      stockLineId: '999',
+      itemId: '999',
+      numberOfPacks: 0,
+    });
+    const state = callReducer(OutboundAction.upsertLine(lineToInsert));
+
+    expect(findRow(state, lineToInsert.id)).toBeUndefined();
   });
 });

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -49,7 +49,9 @@ const getExistingLine = (
   return { existingRow, existingSummaryItem };
 };
 
-const recalculateSummary = (summaryItem: OutboundShipmentSummaryItem) => {
+export const recalculateSummary = (
+  summaryItem: OutboundShipmentSummaryItem
+): { unitQuantity: number; numberOfPacks: number } => {
   const unitQuantity = Object.values<OutboundShipmentRow>(
     summaryItem.batches
   ).reduce(getUnitQuantity, 0);
@@ -204,6 +206,9 @@ export const reducer = (
                 unitQuantity,
                 numberOfPacks,
               });
+            } else {
+              existingSummaryItem.unitQuantity = unitQuantity;
+              existingSummaryItem.numberOfPacks = numberOfPacks;
             }
 
             return itemsArray;

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -390,6 +390,7 @@ const createLine = (
 ): OutboundShipmentRow => {
   return {
     ...line,
+    stockLineId: line.stockLine?.id ?? '',
     invoiceId: draft.id,
   };
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/reducer.ts
@@ -292,8 +292,14 @@ export const reducer = (
             existingSummaryItem.numberOfPacks = numberOfPacks;
             existingSummaryItem.batches[existingRow.id] = existingRow;
           } else {
+            // Ignore lines which have a number of packs of zero.
+            if (line.numberOfPacks === 0) {
+              break;
+            }
+
             const newLine = {
               ...line,
+              invoiceId: draft.id,
               isCreated: true,
               isUpdated: false,
               isDeleted: false,

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -15,16 +15,20 @@ interface GeneralTabProps<T extends ObjectWithStringKeys & DomainObject> {
   onRowClick?: (rowData: T) => void;
 }
 
-const Expand: FC = () => {
+const Expand: FC<{ rowData: OutboundShipmentSummaryItem }> = ({ rowData }) => {
   return (
-    <Box p={1} height={300}>
+    <Box p={1} height={300} style={{ overflow: 'scroll' }}>
       <Box
         flex={1}
         display="flex"
         height="100%"
         borderRadius={4}
         bgcolor="#c7c9d933"
-      />
+      >
+        <span style={{ whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify(rowData, null, 2)}
+        </span>
+      </Box>
     </Box>
   );
 };

--- a/packages/mock-server/src/api/mutations.ts
+++ b/packages/mock-server/src/api/mutations.ts
@@ -15,6 +15,7 @@ const adjustStockLineQuantity = (
   quantity: number
 ): StockLine => {
   const stockLine = db.get.byId.stockLine(stockLineId);
+
   const newQuantity = stockLine.availableNumberOfPacks + quantity;
 
   if (newQuantity < 0) {
@@ -102,7 +103,6 @@ export const update = {
     const currentInvoiceLine = db.get.byId.invoiceLine(invoiceLine.id);
     const { quantity } = currentInvoiceLine;
 
-    // const shouldSubtract = quantity > invoiceLine?.numberOfPacks ?
     const difference = quantity - (invoiceLine?.numberOfPacks ?? 0);
 
     adjustStockLineQuantity(invoiceLine?.stockLineId ?? '', difference);

--- a/packages/mock-server/src/api/mutations.ts
+++ b/packages/mock-server/src/api/mutations.ts
@@ -1,4 +1,7 @@
-import { InsertOutboundShipmentLineInput } from './../../../common/src/types/schema';
+import {
+  InsertOutboundShipmentLineInput,
+  UpdateOutboundShipmentLineInput,
+} from './../../../common/src/types/schema';
 import { ResolverService } from './resolvers';
 import { createInvoice } from './../data/data';
 import { Api } from './index';
@@ -95,12 +98,14 @@ export const update = {
 
     return resolvedInvoice;
   },
-  invoiceLine: (invoiceLine: InvoiceLine): InvoiceLine => {
+  invoiceLine: (invoiceLine: UpdateOutboundShipmentLineInput): InvoiceLine => {
     const currentInvoiceLine = db.get.byId.invoiceLine(invoiceLine.id);
     const { quantity } = currentInvoiceLine;
-    const difference = quantity - invoiceLine.quantity;
 
-    adjustStockLineQuantity(invoiceLine.stockLineId, difference);
+    // const shouldSubtract = quantity > invoiceLine?.numberOfPacks ?
+    const difference = quantity - (invoiceLine?.numberOfPacks ?? 0);
+
+    adjustStockLineQuantity(invoiceLine?.stockLineId ?? '', difference);
 
     return db.update.invoiceLine(invoiceLine);
   },

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -10,6 +10,7 @@ import {
 import {
   UpdateOutboundShipmentInput,
   InsertOutboundShipmentLineInput,
+  UpdateOutboundShipmentLineInput,
 } from '@openmsupply-client/common';
 import {
   isAlmostExpired,
@@ -141,10 +142,10 @@ export const update = {
     InvoiceData[idx] = newInvoice;
     return newInvoice;
   },
-  invoiceLine: (invoiceLine: InvoiceLine): InvoiceLine => {
+  invoiceLine: (invoiceLine: UpdateOutboundShipmentLineInput): InvoiceLine => {
     const idx = InvoiceLineData.findIndex(getFilter(invoiceLine.id, 'id'));
     if (idx < 0) throw new Error('Invalid invoice line id');
-    const newLine: InvoiceLine = { ...InvoiceLineData[idx], ...invoiceLine };
+    const newLine = { ...InvoiceLineData[idx], ...invoiceLine } as InvoiceLine;
     InvoiceLineData[idx] = newLine;
     return newLine;
   },

--- a/packages/mock-server/src/schema/Invoice.ts
+++ b/packages/mock-server/src/schema/Invoice.ts
@@ -55,6 +55,7 @@ const MutationResolvers = {
       insertOutboundShipmentLines: [] as { id: string }[],
       updateOutboundShipments: [] as { id: string }[],
       deleteOutboundShipmentLines: [] as { id: string }[],
+      updateOutboundShipmentLines: [] as { id: string }[],
     };
 
     if (vars.deleteOutboundShipments) {
@@ -84,6 +85,13 @@ const MutationResolvers = {
       response.deleteOutboundShipmentLines =
         vars.deleteOutboundShipmentLines.map(line => ({
           id: MutationService.remove.invoiceLine(line.id),
+        }));
+    }
+
+    if (vars.updateOutboundShipmentLines) {
+      response.updateOutboundShipmentLines =
+        vars.updateOutboundShipmentLines.map(line => ({
+          id: MutationService.update.invoiceLine(line).id,
         }));
     }
 

--- a/packages/mock-server/src/worker/handlers.ts
+++ b/packages/mock-server/src/worker/handlers.ts
@@ -9,6 +9,7 @@ import {
   InvoicesQueryVariables,
   ItemsListViewQueryVariables,
   NamesQueryVariables,
+  UpdateOutboundShipmentLineInput,
 } from '@openmsupply-client/common';
 
 const updateInvoice = graphql.mutation<
@@ -169,6 +170,7 @@ export const upsertOutboundShipment = graphql.mutation(
       insertOutboundShipmentLines,
       updateOutboundShipments,
       deleteOutboundShipmentLines,
+      updateOutboundShipmentLines,
     } = variables;
 
     const queryResponse = {
@@ -176,6 +178,7 @@ export const upsertOutboundShipment = graphql.mutation(
       insertOutboundShipmentLines: [] as { id: string }[],
       updateOutboundShipments: [] as { id: string; __typename: string }[],
       deleteOutboundShipmentLines: [] as { id: string; __typename: string }[],
+      updateOutboundShipmentLines: [] as { id: string; __typename: string }[],
     };
 
     if (updateOutboundShipments.length > 0) {
@@ -201,6 +204,14 @@ export const upsertOutboundShipment = graphql.mutation(
         });
     }
 
+    if (updateOutboundShipmentLines.length > 0) {
+      queryResponse.deleteOutboundShipmentLines =
+        updateOutboundShipmentLines.map(
+          (line: UpdateOutboundShipmentLineInput) => {
+            MutationService.update.invoiceLine(line);
+          }
+        );
+    }
     return response(context.data({ batchOutboundShipment: queryResponse }));
   }
 );


### PR DESCRIPTION
#273 

- finally?!
- This one makes editing lines work! It's working well against the mock server and workers
- There are still a few issues with available quantity I will point out in comments.
- I've noticed a bug with deleting (where deleting isn't deleting everything) which i'll fix elsewhere
- I've also had a bug a few times with an invalid stock line against the mock server and also once where there was an invalid quantity deduction. I checked my payload and all of the values sent seem to be correct, so I believe this is more about server errors so I am ignoring, for now (I also couldn't find a reliable replication, if you happen to find one I would like to fix the server regardless).
- At the moment, we are sending all lines per save as an update regardless of if they've been touched or not. This is for the use case of save -> edit row -> response comes back -> set all to clean or..?. Basically need a 'saving' and 'editted during save' state? Maybe silly and I should just mark them all as clean after a response 🤷 