### PR TITLE
#314 improved fefo UI

### DIFF
--- a/packages/common/src/intl/locales/ar.json
+++ b/packages/common/src/intl/locales/ar.json
@@ -124,5 +124,8 @@
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
   "placeholder.enter-a-customers-name": "Enter a customers name",
+  "label.packs-to-batches-with": "packs to batches with a pack size of",
+  "label.allocate": "Allocate",
+  "label.units": "Units",
   "dev.log-draft": "Log draft"
 }

--- a/packages/common/src/intl/locales/en.json
+++ b/packages/common/src/intl/locales/en.json
@@ -109,6 +109,7 @@
   "label.select-rows-to-delete-them": "Select rows to delete them",
   "label.select": "Select",
   "label.selected": "Selected",
+  "label.packs-to-batches-with": "packs to batches with a pack size of",
   "label.sell": "Sell",
   "label.shipped": "Shipped",
   "label.status": "Status",
@@ -120,9 +121,11 @@
   "label.type": "Type",
   "label.unit-quantity": "Unit Quantity",
   "label.unit": "Unit",
+  "label.units": "Units",
   "link.backorders": "Backorders",
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
   "dev.log-draft": "Log draft",
+  "label.allocate": "Allocate",
   "placeholder.enter-a-customers-name": "Enter a customers name"
 }

--- a/packages/common/src/intl/locales/fr.json
+++ b/packages/common/src/intl/locales/fr.json
@@ -58,6 +58,7 @@
   "heading.expiring-stock": "Expiring Stock",
   "heading.related-documents": "Related documents",
   "heading.shipments-to-be-picked": "Shipments to be picked",
+  "label.allocate": "Allocate",
   "label.allocated": "Allocated",
   "label.allocation": "Allocation",
   "label.available": "Available",
@@ -124,5 +125,7 @@
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
   "dev.log-draft": "Log draft",
+  "label.packs-to-batches-with": "packs to batches with a pack size of",
+  "label.units": "Units",
   "placeholder.enter-a-customers-name": "Enter a customers name"
 }

--- a/packages/common/src/intl/locales/pt.json
+++ b/packages/common/src/intl/locales/pt.json
@@ -124,5 +124,8 @@
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
   "dev.log-draft": "Log draft",
+  "label.packs-to-batches-with": "packs to batches with a pack size of",
+  "label.allocate": "Allocate",
+  "label.units": "Units",
   "placeholder.enter-a-customers-name": "Enter a customers name"
 }

--- a/packages/common/src/ui/components/buttons/FlatButton.tsx
+++ b/packages/common/src/ui/components/buttons/FlatButton.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
   icon: React.ReactNode;
   labelKey: LocaleKey;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
 }
 
 const StyledButton = styled(MuiButton)({
@@ -17,12 +18,18 @@ const StyledButton = styled(MuiButton)({
   textTransform: 'none' as Property.TextTransform,
 });
 
-export const FlatButton: React.FC<ButtonProps> = props => {
+export const FlatButton: React.FC<ButtonProps> = ({
+  color,
+  labelKey,
+  icon,
+  onClick,
+  disabled = false,
+}) => {
   const t = useTranslation();
 
-  const { color, labelKey, icon, onClick } = props;
   return (
     <StyledButton
+      disabled={disabled}
       onClick={onClick}
       startIcon={icon}
       variant="text"

--- a/packages/common/src/ui/components/index.ts
+++ b/packages/common/src/ui/components/index.ts
@@ -16,6 +16,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
 
 export * from './portals';
 export * from './inputs';
@@ -49,4 +50,5 @@ export {
   Radio,
   RadioGroup,
   FormControlLabel,
+  Switch,
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -30,7 +30,7 @@ export interface BatchesTableProps {
   rows: BatchRow[];
 }
 
-const sortByExpiry = (a: BatchRow, b: BatchRow) => {
+export const sortByExpiry = (a: BatchRow, b: BatchRow) => {
   const expiryA = new Date(a.expiryDate ?? '');
   const expiryB = new Date(b.expiryDate ?? '');
 
@@ -201,14 +201,16 @@ export const BatchesTable: React.FC<BatchesTableProps> = ({
     )
     .sort(sortByExpiry);
 
-  const onHoldRows = rowsWithoutPlaceholder
-    .filter(
-      ({ onHold, availableNumberOfPacks }) =>
-        onHold && availableNumberOfPacks > 0
-    )
+  const nonAllocatableRows = rowsWithoutPlaceholder.filter(
+    ({ onHold, availableNumberOfPacks }) =>
+      onHold || availableNumberOfPacks === 0
+  );
+
+  const onHoldRows = nonAllocatableRows
+    .filter(({ onHold }) => onHold)
     .sort(sortByExpiry);
 
-  const noStockRows = rowsWithoutPlaceholder
+  const noStockRows = nonAllocatableRows
     .filter(
       ({ availableNumberOfPacks, onHold }) =>
         availableNumberOfPacks === 0 && !onHold

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -177,7 +177,7 @@ export const BatchesTable: React.FC<BatchesTableProps> = ({
   return (
     <>
       <TableContainer>
-        <Divider margin={40} />
+        <Divider margin={10} />
         <Table>
           <TableHead>
             <TableRow>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -137,6 +137,10 @@ const HeaderCell: React.FC<TableCellProps> = ({ children }) => (
       color: theme => theme.typography.body1.color,
       fontWeight: 'bold',
       padding: '8px',
+      position: 'sticky',
+      top: 0,
+      zIndex: 10,
+      backgroundColor: 'white',
     }}
   >
     {children}
@@ -176,8 +180,8 @@ export const BatchesTable: React.FC<BatchesTableProps> = ({
 
   return (
     <>
-      <TableContainer>
-        <Divider margin={10} />
+      <Divider margin={10} />
+      <TableContainer sx={{ height: 400 }}>
         <Table>
           <TableHead>
             <TableRow>
@@ -195,7 +199,7 @@ export const BatchesTable: React.FC<BatchesTableProps> = ({
               <HeaderCell></HeaderCell>
             </TableRow>
           </TableHead>
-          <TableBody>
+          <TableBody sx={{ overflow: 'scroll' }}>
             {rows
               .filter(({ id }) => id !== 'placeholder')
               .map((batch, index) => (

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/BatchesTable.tsx
@@ -66,7 +66,7 @@ const BatchesRow: React.FC<BatchesRowProps> = ({ batch, label, onChange }) => {
       <BasicCell align="right">{label}</BasicCell>
       <BasicCell sx={{ width: '88px' }}>
         <ModalNumericInput
-          value={batch.quantity}
+          value={batch.numberOfPacks}
           inputProps={stockLineInputProps}
           disabled={isDisabled}
         />
@@ -75,7 +75,7 @@ const BatchesRow: React.FC<BatchesRowProps> = ({ batch, label, onChange }) => {
       <BasicCell sx={{ width: '88px' }}>
         <ReadOnlyInput
           number
-          value={String(batch.quantity * batch.packSize)}
+          value={String(batch.numberOfPacks * batch.packSize)}
           {...register(`${batch.id}_total`)}
         />
       </BasicCell>
@@ -216,7 +216,7 @@ export const BatchesTable: React.FC<BatchesTableProps> = ({
               </BasicCell>
               <BasicCell sx={{ paddingTop: '3px' }}>
                 <ModalNumericInput
-                  value={placeholderRow?.quantity}
+                  value={placeholderRow?.numberOfPacks ?? 0}
                   inputProps={placeholderInputProps}
                 />
               </BasicCell>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -48,7 +48,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
   const [issueType, setIssueType] = useState('packs');
 
   return (
-    <Grid container gap={0.5}>
+    <Grid container gap={0.5} height={200}>
       <ModalRow>
         <ModalLabel labelKey="label.item" />
         <Grid item flex={1}>
@@ -94,7 +94,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
         </Grid>
       </ModalRow>
 
-      {summaryItem && (
+      {summaryItem ? (
         <>
           <Divider margin={10} />
 
@@ -172,6 +172,8 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
             </Grid>
           </Box>
         </>
+      ) : (
+        <Box height={100} />
       )}
     </Grid>
   );

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -140,7 +140,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
 
               <Box marginLeft={1} />
 
-              {issueType === 'packs' && (
+              {issueType === 'packs' && packSizeController.selected.value && (
                 <Select
                   sx={{ width: 110 }}
                   inputProps={register('packSize')}
@@ -163,7 +163,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
                   onChangeQuantity(
                     Number(quantity),
                     issueType === 'packs'
-                      ? packSizeController.selected.value
+                      ? Number(packSizeController.selected.value)
                       : null
                   );
                   setQuantity('');

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -9,16 +9,15 @@ import {
   NumericTextInput,
   UseFormRegister,
   Select,
-  styled,
   useTranslation,
-  Typography,
   InputLabel,
   ModalNumericInput,
   FlatButton,
   CheckIcon,
-  Radio,
-  RadioGroup,
   FormControlLabel,
+  Switch,
+  Divider,
+  Box,
 } from '@openmsupply-client/common';
 import { ItemSearchInput } from '@openmsupply-client/system/src/Item';
 import { OutboundShipmentSummaryItem } from '../types';
@@ -34,13 +33,6 @@ interface ItemDetailsFormProps {
   availableQuantity: number;
 }
 
-const SimpleText = styled(Typography)({
-  fontSize: 12,
-  marginLeft: 16,
-  alignSelf: 'center',
-  display: 'inline-flex',
-});
-
 export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
   allocatedQuantity,
   onChangeItem,
@@ -51,14 +43,6 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
   availableQuantity,
 }) => {
   const t = useTranslation();
-
-  const quantityDescription = allocatedQuantity ? (
-    <SimpleText
-      sx={{
-        color: allocatedQuantity ? 'error.main' : undefined,
-      }}
-    >{`${allocatedQuantity} ${t('label.allocated')}`}</SimpleText>
-  ) : undefined;
 
   const [quantity, setQuantity] = useState('');
   const [issueType, setIssueType] = useState('packs');
@@ -84,14 +68,6 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
         />
 
         <Grid style={{ display: 'flex' }} justifyContent="flex-end" flex={1}>
-          <ModalLabel labelKey="label.code" justifyContent="flex-end" />
-          <ModalInput
-            defaultValue={summaryItem?.itemCode ?? ''}
-            disabled
-            width={150}
-          />
-        </Grid>
-        <Grid style={{ display: 'flex' }} justifyContent="flex-end" flex={1}>
           <ModalLabel labelKey="label.unit" justifyContent="flex-end" />
           <ModalInput
             disabled
@@ -102,81 +78,101 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
       </ModalRow>
 
       <ModalRow>
-        <Grid
-          sx={{
-            marginTop: '20px',
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-          }}
-          container
-        >
-          <ModalLabel labelKey="label.pack-quantity" />
-          <ModalNumericInput
-            value={Number(quantity)}
-            inputProps={register('quantity', {
-              required: true,
-              min: { value: 1, message: t('error.invalid-value') },
-              pattern: {
-                value: /^[0-9]+$/,
-                message: t('error.invalid-value'),
-              },
-              onChange: event => {
-                setQuantity(event.target.value);
-              },
-            })}
-            defaultValue={0}
-          />
-
-          <Grid item alignItems="center" display="flex">
-            <InputLabel sx={{ fontSize: '12px' }}>
-              {t('label.pack-size')}
-            </InputLabel>
-          </Grid>
-          <Select
-            disabled={issueType === 'units'}
-            sx={{ width: 110 }}
-            inputProps={register('packSize')}
-            options={packSizeController.options}
-            value={packSizeController.selected.value}
-            onChange={e =>
-              packSizeController.setPackSize(Number(e.target.value))
-            }
-          />
-          <RadioGroup
-            value={issueType}
-            onChange={() => {
-              setIssueType(state => (state === 'packs' ? 'units' : 'packs'));
-            }}
-          >
-            <FormControlLabel
-              control={<Radio size="small" />}
-              label="Packs"
-              value="packs"
-            />
-            <FormControlLabel
-              control={<Radio size="small" />}
-              label="Units"
-              value="units"
-            />
-          </RadioGroup>
-
-          {quantityDescription}
-          <FlatButton
-            color="secondary"
-            icon={<CheckIcon />}
-            labelKey="label.issue"
-            onClick={() => {
-              onChangeQuantity(
-                Number(quantity),
-                issueType === 'packs' ? packSizeController.selected.value : null
-              );
-              setQuantity('');
-            }}
+        <ModalLabel labelKey="label.allocated" />
+        <NumericTextInput
+          value={allocatedQuantity}
+          disabled
+          style={{ width: 85 }}
+        />
+        <Grid style={{ display: 'flex' }} justifyContent="flex-end" flex={1}>
+          <ModalLabel labelKey="label.code" justifyContent="flex-end" />
+          <ModalInput
+            defaultValue={summaryItem?.itemCode ?? ''}
+            disabled
+            width={150}
           />
         </Grid>
       </ModalRow>
+
+      {summaryItem && (
+        <>
+          <Divider margin={10} />
+
+          <Box display="flex" flex={1} flexDirection="column">
+            <ModalRow>
+              <FormControlLabel
+                onChange={(_, checked) =>
+                  setIssueType(checked ? 'packs' : 'units')
+                }
+                control={
+                  <Switch defaultChecked color="secondary" size="small" />
+                }
+                label={<Box fontSize={10}>Allocate to Packs?</Box>}
+                value="packs"
+              />
+            </ModalRow>
+
+            <Grid container>
+              <ModalLabel labelKey="label.allocate" />
+              <ModalNumericInput
+                value={Number(quantity)}
+                inputProps={register('quantity', {
+                  min: { value: 1, message: t('error.invalid-value') },
+                  pattern: {
+                    value: /^[0-9]+$/,
+                    message: t('error.invalid-value'),
+                  },
+                  onChange: event => {
+                    setQuantity(event.target.value);
+                  },
+                })}
+              />
+
+              <Box marginLeft={1} />
+
+              <Grid item alignItems="center" display="flex">
+                <InputLabel sx={{ fontSize: '12px' }}>
+                  {issueType === 'packs'
+                    ? t('label.packs-to-batches-with')
+                    : t('label.units')}
+                </InputLabel>
+              </Grid>
+
+              <Box marginLeft={1} />
+
+              {issueType === 'packs' && (
+                <Select
+                  sx={{ width: 110 }}
+                  inputProps={register('packSize')}
+                  options={packSizeController.options}
+                  value={packSizeController.selected.value}
+                  onChange={e =>
+                    packSizeController.setPackSize(Number(e.target.value))
+                  }
+                />
+              )}
+
+              <Box marginLeft="auto" />
+
+              <FlatButton
+                disabled={Number(quantity) <= 0}
+                color="secondary"
+                icon={<CheckIcon />}
+                labelKey="label.allocate"
+                onClick={() => {
+                  onChangeQuantity(
+                    Number(quantity),
+                    issueType === 'packs'
+                      ? packSizeController.selected.value
+                      : null
+                  );
+                  setQuantity('');
+                }}
+              />
+            </Grid>
+          </Box>
+        </>
+      )}
     </Grid>
   );
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -8,6 +8,8 @@ import {
   useDialog,
   FormProvider,
   generateUUID,
+  InlineSpinner,
+  Box,
 } from '@openmsupply-client/common';
 import { useStockLines } from '@openmsupply-client/system';
 import { BatchesTable } from './BatchesTable';
@@ -335,13 +337,25 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
               allocatedQuantity={getAllocatedQuantity(batchRows)}
               summaryItem={summaryItem || undefined}
             />
-            {!isLoading && (
-              <BatchesTable
-                onChange={onChangeRowQuantity}
-                register={register}
-                rows={batchRows}
-              />
-            )}
+            {!!summaryItem ? (
+              !isLoading ? (
+                <BatchesTable
+                  onChange={onChangeRowQuantity}
+                  register={register}
+                  rows={batchRows}
+                />
+              ) : (
+                <Box
+                  display="flex"
+                  flex={1}
+                  height={300}
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  <InlineSpinner />
+                </Box>
+              )
+            ) : null}
           </Grid>
         </form>
       </FormProvider>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -279,7 +279,9 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
       const batchRow = newBatchRows[batchRowIdx];
       if (!batchRow) return null;
 
-      const availableUnits = batch.availableNumberOfPacks * batch.packSize;
+      const currentAllocatedUnits = batch.numberOfPacks - batch.packSize;
+      const totalAvailableUnits = batch.availableNumberOfPacks * batch.packSize;
+      const availableUnits = totalAvailableUnits - currentAllocatedUnits;
       const allocatedUnits = Math.min(toAllocate, availableUnits);
       const allocatedNumberOfPacks = Math.floor(
         allocatedUnits / batch.packSize
@@ -289,7 +291,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
 
       newBatchRows[batchRowIdx] = {
         ...batchRow,
-        numberOfPacks: allocatedNumberOfPacks,
+        numberOfPacks: batch.numberOfPacks + allocatedNumberOfPacks,
       };
     });
 
@@ -302,7 +304,8 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
 
     newBatchRows[placeholderIdx] = {
       ...placeholder,
-      numberOfPacks: toAllocate * (issuePackSize || 1),
+      numberOfPacks:
+        placeholder.numberOfPacks + toAllocate * (issuePackSize || 1),
     };
 
     setBatchRows(newBatchRows);

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -127,11 +127,21 @@ const useBatchRows = (summaryItem: OutboundShipmentSummaryItem | null) => {
 
 export type PackSizeController = ReturnType<typeof usePackSizeController>;
 
-const usePackSizeController = (batches: { packSize: number }[]) => {
+const usePackSizeController = (
+  batches: {
+    packSize: number;
+    onHold: boolean;
+    availableNumberOfPacks: number;
+  }[]
+) => {
   // Creating a sorted array of distinct pack sizes
   const packSizes = Array.from(
     new Set(
       batches
+        .filter(
+          ({ onHold, availableNumberOfPacks }) =>
+            availableNumberOfPacks > 0 && !onHold
+        )
         .reduce((sizes, { packSize }) => [...sizes, packSize], [] as number[])
         .sort()
     )

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -129,7 +129,7 @@ const usePackSizeController = (
     value: packSize,
   }));
 
-  const defaultPackSize = options[0] ?? { label: '1', value: 1 };
+  const defaultPackSize = options[0] ?? { label: '', value: '' };
 
   const [selected, setSelected] = useState(defaultPackSize);
 
@@ -138,6 +138,15 @@ const usePackSizeController = (
     if (!packSizeOption) return;
     setSelected(packSizeOption);
   };
+
+  useEffect(() => {
+    if (defaultPackSize.value && typeof defaultPackSize.value == 'number') {
+      setPackSize(defaultPackSize.value);
+    }
+    if (packSizes.length === 0) {
+      setSelected({ label: '', value: '' });
+    }
+  }, [defaultPackSize.value]);
 
   return { selected, setPackSize, options };
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/types.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/types.ts
@@ -18,7 +18,7 @@ export interface OutboundShipmentRow extends InvoiceLine {
   isCreated?: boolean;
 }
 export interface BatchRow extends StockLine {
-  quantity: number;
+  numberOfPacks: number;
 }
 
 export interface InvoiceStatusLog {


### PR DESCRIPTION
There's a bit going on here!

- Updated the FEFO UI bit. Think it looks OK?
![image](https://user-images.githubusercontent.com/35858975/142071143-942a7f2f-ee7e-4dfe-82e2-e51d677d26cf.png)

![image](https://user-images.githubusercontent.com/35858975/142071191-758db3fe-feaf-4461-9cf0-ac9b1b48b5e6.png)
- Made the allocation add rather than replace
- filtered out the invalid pack sizes from the pack size selection
- made placeholder in unit quantity? Though, the column header says # packs so maybe not a good idea.. or can put pack size 1? I dunno...
- added an `allocated` field - dunno if it's useful.
- changed the sort order a bit - I was getting confused when FEFO allocating 🤣  so I put the on hold rows at the top of the invalid area (and a divider between) and then the zero stock ones underneath 🤷 
- Made the headers sticky and added some heights cause the height changing so much was annoying me? Though, it's still not exactly right?
- added a loading indicator for the batches table
- Also changed the field BatchRow.quantity to number of packs to be consistent