### PR TITLE
#448 inbound line adding 2

### DIFF
--- a/packages/common/src/ui/components/index.ts
+++ b/packages/common/src/ui/components/index.ts
@@ -17,6 +17,7 @@ import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
+import Fab from '@mui/material/Fab';
 
 export * from './portals';
 export * from './inputs';
@@ -37,6 +38,7 @@ export {
   AccordionSummary,
   CircularProgress,
   Collapse,
+  Fab,
   Input,
   InputAdornment,
   InputLabel,

--- a/packages/common/src/ui/icons/PlusCircle.tsx
+++ b/packages/common/src/ui/icons/PlusCircle.tsx
@@ -2,7 +2,7 @@ import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import * as React from 'react';
 
 export const PlusCircleIcon: React.FC<SvgIconProps> = props => (
-  <SvgIcon viewBox="0 0 20 22" {...props}>
+  <SvgIcon viewBox="0 0 21 20.5" {...props}>
     <path d="M14.7 10c0 .552-.47 1-1.05 1h-2.1v2c0 .552-.47 1-1.05 1-.58 0-1.05-.448-1.05-1v-2h-2.1c-.58 0-1.05-.448-1.05-1s.47-1 1.05-1h2.1V7c0-.552.47-1 1.05-1 .58 0 1.05.448 1.05 1v2h2.1c.58 0 1.05.448 1.05 1m-4.2 8c-4.632 0-8.4-3.589-8.4-8s3.768-8 8.4-8c4.632 0 8.4 3.589 8.4 8s-3.768 8-8.4 8m0-18C4.7 0 0 4.477 0 10s4.7 10 10.5 10S21 15.523 21 10 16.3 0 10.5 0" />
   </SvgIcon>
 );

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -45,7 +45,7 @@ const useDraftInbound = () => {
 };
 
 export const DetailView: FC = () => {
-  const t = useTranslation('common');
+  const t = useTranslation('outbound-shipment');
   const { hideDialog, showDialog, Modal } = useDialog();
   const { draft, save, onChangeSortBy, sortBy } = useDraftInbound();
 
@@ -66,6 +66,8 @@ export const DetailView: FC = () => {
     setSelectedItem({ item: null, editing: false });
     showDialog();
   };
+
+  const isEditMode = selectedItem.editing;
 
   const columns = useColumns(
     [
@@ -106,7 +108,7 @@ export const DetailView: FC = () => {
       <SidePanel draft={draft} />
 
       <Modal
-        title={t('heading.add-item')}
+        title={!isEditMode ? t('heading.add-item') : t('heading.edit-item')}
         cancelButton={<DialogButton variant="cancel" onClick={hideDialog} />}
         nextButton={<DialogButton variant="next" onClick={() => {}} />}
         okButton={<DialogButton variant="ok" onClick={hideDialog} />}

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -16,7 +16,7 @@ import {
   Item,
 } from '@openmsupply-client/common';
 
-import { reducer } from './reducer';
+import { InboundAction, reducer } from './reducer';
 import { getInboundShipmentDetailViewApi } from './api';
 import { Toolbar } from './Toolbar';
 import { Footer } from './Footer';
@@ -27,7 +27,6 @@ import { InboundLineEdit } from './modals/InboundLineEdit';
 
 import { isInboundEditable } from '../../utils';
 import { InboundShipmentItem } from '../../types';
-import { OutboundAction } from '../../OutboundShipment/DetailView/reducer';
 
 const useDraftInbound = () => {
   const { id } = useParams();
@@ -40,7 +39,7 @@ const useDraftInbound = () => {
   );
 
   const onChangeSortBy = (column: Column<InboundShipmentItem>) => {
-    dispatch(OutboundAction.onSortBy(column));
+    dispatch(InboundAction.onSortBy(column));
   };
 
   return { draft, save, dispatch, onChangeSortBy, sortBy: state.sortBy };
@@ -149,7 +148,7 @@ export const DetailView: FC = () => {
         nextButton={<DialogButton variant="next" onClick={() => {}} />}
         okButton={<DialogButton variant="ok" onClick={hideDialog} />}
         height={600}
-        width={900}
+        width={1024}
       >
         <InboundLineEdit
           item={selectedItem.item}

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -15,18 +15,19 @@ import {
   useTranslation,
   Item,
 } from '@openmsupply-client/common';
+
 import { reducer } from './reducer';
 import { getInboundShipmentDetailViewApi } from './api';
-
 import { Toolbar } from './Toolbar';
-import { isInboundEditable } from '../../utils';
 import { Footer } from './Footer';
 import { AppBarButtons } from './AppBarButtons';
 import { SidePanel } from './SidePanel';
+import { GeneralTab } from './GeneralTab';
+import { InboundLineEdit } from './modals/InboundLineEdit';
+
+import { isInboundEditable } from '../../utils';
 import { InboundShipmentItem } from '../../types';
 import { OutboundAction } from '../../OutboundShipment/DetailView/reducer';
-import { GeneralTab } from '../../OutboundShipment/DetailView/tabs/GeneralTab';
-import { InboundLineEdit } from './modals/InboundLineEdit';
 
 const useDraftInbound = () => {
   const { id } = useParams();
@@ -67,6 +68,10 @@ export const DetailView: FC = () => {
     item: InboundShipmentItem | null;
     editing: boolean;
   }>({ item: null, editing: false });
+
+  console.log('-------------------------------------------');
+  console.log('selectedItem', selectedItem);
+  console.log('-------------------------------------------');
 
   const onChangeSelectedItem = (newItem: Item | null) => {
     if (!newItem) return setSelectedItem({ item: newItem, editing: false });

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -13,6 +13,7 @@ import {
   useDialog,
   DialogButton,
   useTranslation,
+  Item,
 } from '@openmsupply-client/common';
 import { reducer } from './reducer';
 import { getInboundShipmentDetailViewApi } from './api';
@@ -44,6 +45,19 @@ const useDraftInbound = () => {
   return { draft, save, dispatch, onChangeSortBy, sortBy: state.sortBy };
 };
 
+export const itemToSummaryItem = (item: Item): InboundShipmentItem => {
+  return {
+    id: item.id,
+    itemId: item.id,
+    itemName: item.name,
+    itemCode: item.code,
+    itemUnit: item.unitName,
+    batches: {},
+    unitQuantity: 0,
+    numberOfPacks: 0,
+  };
+};
+
 export const DetailView: FC = () => {
   const t = useTranslation('outbound-shipment');
   const { hideDialog, showDialog, Modal } = useDialog();
@@ -53,9 +67,23 @@ export const DetailView: FC = () => {
     item: InboundShipmentItem | null;
     editing: boolean;
   }>({ item: null, editing: false });
-  console.log('-------------------------------------------');
-  console.log('selectedItem', selectedItem);
-  console.log('-------------------------------------------');
+
+  const onChangeSelectedItem = (newItem: Item | null) => {
+    if (!newItem) return setSelectedItem({ item: newItem, editing: false });
+
+    // Try and find the outbound summary row that matches the new item
+    const item = draft.items.find(
+      summaryItem => summaryItem.itemId === newItem.id
+    );
+
+    // If we found it, set the selected item.
+    if (item) {
+      setSelectedItem({ item, editing: true });
+    } else {
+      // otherwise, set the selected item to a newly created summary row.
+      setSelectedItem({ item: itemToSummaryItem(newItem), editing: false });
+    }
+  };
 
   const onRowClick = (item: InboundShipmentItem) => {
     setSelectedItem({ item, editing: true });
@@ -115,7 +143,11 @@ export const DetailView: FC = () => {
         height={600}
         width={900}
       >
-        <InboundLineEdit />
+        <InboundLineEdit
+          item={selectedItem.item}
+          onUpsert={() => {}}
+          onChangeItem={onChangeSelectedItem}
+        />
       </Modal>
     </TableProvider>
   );

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -62,6 +62,11 @@ export const DetailView: FC = () => {
     showDialog();
   };
 
+  const onAddItem = () => {
+    setSelectedItem({ item: null, editing: false });
+    showDialog();
+  };
+
   const columns = useColumns(
     [
       getNotePopoverColumn<InboundShipmentItem>(),
@@ -86,7 +91,7 @@ export const DetailView: FC = () => {
     <TableProvider createStore={createTableStore}>
       <AppBarButtons
         isDisabled={!isInboundEditable(draft)}
-        onAddItem={showDialog}
+        onAddItem={onAddItem}
       />
 
       <Toolbar draft={draft} />

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -71,14 +71,10 @@ export const DetailView: FC = () => {
     onClose: () => setSelectedItem({ item: null, editing: false }),
   });
 
-  console.log('-------------------------------------------');
-  console.log('selectedItem', selectedItem);
-  console.log('-------------------------------------------');
-
   const onChangeSelectedItem = (newItem: Item | null) => {
     if (!newItem) return setSelectedItem({ item: newItem, editing: false });
 
-    // Try and find the outbound summary row that matches the new item
+    // Try and find the summary row that matches the new item
     const item = draft.items.find(
       summaryItem => summaryItem.itemId === newItem.id
     );

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -61,13 +61,16 @@ export const itemToSummaryItem = (item: Item): InboundShipmentItem => {
 
 export const DetailView: FC = () => {
   const t = useTranslation('outbound-shipment');
-  const { hideDialog, showDialog, Modal } = useDialog();
+
   const { draft, save, onChangeSortBy, sortBy } = useDraftInbound();
 
   const [selectedItem, setSelectedItem] = React.useState<{
     item: InboundShipmentItem | null;
     editing: boolean;
   }>({ item: null, editing: false });
+  const { hideDialog, showDialog, Modal } = useDialog({
+    onClose: () => setSelectedItem({ item: null, editing: false }),
+  });
 
   console.log('-------------------------------------------');
   console.log('selectedItem', selectedItem);

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -49,7 +49,18 @@ export const DetailView: FC = () => {
   const { hideDialog, showDialog, Modal } = useDialog();
   const { draft, save, onChangeSortBy, sortBy } = useDraftInbound();
 
-  const onRowClick = () => {};
+  const [selectedItem, setSelectedItem] = React.useState<{
+    item: InboundShipmentItem | null;
+    editing: boolean;
+  }>({ item: null, editing: false });
+  console.log('-------------------------------------------');
+  console.log('selectedItem', selectedItem);
+  console.log('-------------------------------------------');
+
+  const onRowClick = (item: InboundShipmentItem) => {
+    setSelectedItem({ item, editing: true });
+    showDialog();
+  };
 
   const columns = useColumns(
     [

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -1,12 +1,34 @@
-import { FC } from 'react';
-import { Item } from '@openmsupply-client/common';
+import React, { FC } from 'react';
+import {
+  Item,
+  ModalRow,
+  ModalLabel,
+  Grid,
+  useTranslation,
+} from '@openmsupply-client/common';
 import { InboundShipmentItem } from '../../../types';
+import { ItemSearchInput } from '@openmsupply-client/system';
 interface InboundLineEditProps {
   item: InboundShipmentItem | null;
   onUpsert: (item: InboundShipmentItem) => void;
   onChangeItem: (item: Item | null) => void;
 }
 
-export const InboundLineEdit: FC<InboundLineEditProps> = () => {
-  return null;
+export const InboundLineEdit: FC<InboundLineEditProps> = ({
+  item,
+  onChangeItem,
+}) => {
+  const t = useTranslation('common');
+
+  return (
+    <ModalRow>
+      <ModalLabel label={t('label.item')} />
+      <Grid item flex={1}>
+        <ItemSearchInput
+          currentItemName={item?.itemName}
+          onChange={onChangeItem}
+        />
+      </Grid>
+    </ModalRow>
+  );
 };

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -1,5 +1,12 @@
 import { FC } from 'react';
+import { Item } from '@openmsupply-client/common';
+import { InboundShipmentItem } from '../../../types';
+interface InboundLineEditProps {
+  item: InboundShipmentItem | null;
+  onUpsert: (item: InboundShipmentItem) => void;
+  onChangeItem: (item: Item | null) => void;
+}
 
-export const InboundLineEdit: FC = () => {
+export const InboundLineEdit: FC<InboundLineEditProps> = () => {
   return null;
 };

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   Item,
   ModalRow,
@@ -6,20 +6,200 @@ import {
   Grid,
   useTranslation,
   BasicTextInput,
+  Divider,
+  Table,
+  Fab,
+  TableCell,
+  TableCellProps,
+  TableContainer,
+  TableHead,
+  TableRow,
+  PlusCircleIcon,
+  generateUUID,
+  NumericTextInput,
+  formatDate,
 } from '@openmsupply-client/common';
-import { InboundShipmentItem } from '../../../types';
+import { InboundShipmentItem, InboundShipmentRow } from '../../../types';
 import { ItemSearchInput } from '@openmsupply-client/system';
+import { flattenInboundItems } from '../../../utils';
 interface InboundLineEditProps {
   item: InboundShipmentItem | null;
   onUpsert: (item: InboundShipmentItem) => void;
   onChangeItem: (item: Item | null) => void;
 }
 
+const BasicCell: React.FC<TableCellProps> = ({ sx, ...props }) => (
+  <TableCell
+    {...props}
+    sx={{
+      borderBottomWidth: 0,
+      color: 'inherit',
+      fontSize: '12px',
+      padding: '0 8px',
+      whiteSpace: 'nowrap',
+      ...sx,
+    }}
+  />
+);
+
+const HeaderCell: React.FC<TableCellProps> = ({ children }) => (
+  <BasicCell
+    sx={{
+      color: theme => theme.typography.body1.color,
+      fontWeight: 'bold',
+      padding: '8px',
+      position: 'sticky',
+      top: 0,
+      zIndex: 10,
+      backgroundColor: 'white',
+    }}
+  >
+    {children}
+  </BasicCell>
+);
+
+const EditableCell: FC<{
+  onChange: (newValue: string) => void;
+  value: unknown;
+}> = ({ onChange, value }) => {
+  return (
+    <BasicCell>
+      <BasicTextInput
+        sx={{ width: 50 }}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+      />
+    </BasicCell>
+  );
+};
+
+const BatchRow: FC<{ batch: InboundShipmentRow }> = ({ batch }) => {
+  return (
+    <TableRow sx={{ height: 40 }}>
+      <EditableCell
+        onChange={newValue => batch.update?.('batch', newValue)}
+        value={batch.batch}
+      />
+
+      <BasicCell>
+        <NumericTextInput
+          onChange={e =>
+            batch.update?.('numberOfPacks', Number(e.target.value))
+          }
+          width={30}
+          value={batch.numberOfPacks}
+        />
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput
+          width={30}
+          value={batch.packSize}
+          onChange={e =>
+            batch.update?.('numberOfPacks', Number(e.target.value))
+          }
+        />
+      </BasicCell>
+
+      <BasicCell>
+        <NumericTextInput
+          width={30}
+          value={batch.sellPricePerPack}
+          onChange={e =>
+            batch.update?.('numberOfPacks', Number(e.target.value))
+          }
+        />
+      </BasicCell>
+      <BasicCell>
+        {batch.numberOfPacks * batch.packSize * batch.costPricePerPack}
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput
+          width={30}
+          value={batch.costPricePerPack}
+          onChange={e =>
+            batch.update?.('numberOfPacks', Number(e.target.value))
+          }
+        />
+      </BasicCell>
+      <BasicCell align="right">
+        {batch.numberOfPacks * batch.packSize}
+      </BasicCell>
+      <EditableCell
+        value={batch.expiryDate}
+        onChange={newValue => batch.update?.('expiryDate', newValue)}
+      />
+      <BasicCell>
+        <NumericTextInput width={30} value={null} onChange={() => {}} />
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput width={30} value={null} onChange={() => {}} />
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput width={30} value={null} onChange={() => {}} />
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput width={30} value={null} onChange={() => {}} />
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput width={30} value={null} onChange={() => {}} />
+      </BasicCell>
+      <BasicCell>
+        <NumericTextInput width={30} value={null} onChange={() => {}} />
+      </BasicCell>
+
+      <td style={{ marginBottom: 10 }} />
+    </TableRow>
+  );
+};
+
 export const InboundLineEdit: FC<InboundLineEditProps> = ({
   item,
   onChangeItem,
 }) => {
-  const t = useTranslation('common');
+  const t = useTranslation(['outbound-shipment', 'common']);
+
+  const [inboundItem, setInboundItem] =
+    React.useState<InboundShipmentItem | null>(item);
+
+  const onAddBatch = () => {
+    if (inboundItem) {
+      const id = generateUUID();
+      inboundItem.batches[id] = {
+        id,
+        numberOfPacks: 0,
+        stockLineId: '',
+        invoiceId: '',
+        itemId: '',
+        note: '',
+        costPricePerPack: 0,
+        expiryDate: formatDate(new Date()),
+        itemCode: '',
+        itemName: '',
+        packSize: 1,
+        sellPricePerPack: 0,
+        update: <K extends keyof InboundShipmentRow>(
+          key: K,
+          value: InboundShipmentRow[K]
+        ) => {
+          const batch = inboundItem.batches[id];
+          if (inboundItem && batch) {
+            batch[key] = value;
+            setInboundItem({
+              ...inboundItem,
+              batches: { ...inboundItem.batches, [id]: batch },
+            });
+          }
+        },
+      };
+
+      setInboundItem({ ...inboundItem });
+    }
+  };
+
+  useEffect(() => {
+    if (item) setInboundItem({ ...item });
+    else setInboundItem(item);
+  }, [item]);
 
   return (
     <>
@@ -55,6 +235,67 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
             />
           </Grid>
         </ModalRow>
+      )}
+      <Divider margin={5} />
+      {inboundItem && (
+        <TableContainer sx={{ height: 400 }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <HeaderCell>{t('label.batch')}</HeaderCell>
+                <HeaderCell>{t('label.num-packs')}</HeaderCell>
+                <HeaderCell>{t('label.pack-size')}</HeaderCell>
+
+                <HeaderCell>{t('label.sell')}</HeaderCell>
+                <HeaderCell>{t('label.cost')}</HeaderCell>
+                <HeaderCell>Line Total</HeaderCell>
+                <HeaderCell>Units</HeaderCell>
+                <HeaderCell>{t('label.expiry')}</HeaderCell>
+                <HeaderCell>% Margin</HeaderCell>
+
+                <HeaderCell>
+                  Volume/
+                  <br />
+                  Pack
+                </HeaderCell>
+                <HeaderCell>
+                  Weight/
+                  <br />
+                  Pack
+                </HeaderCell>
+                <HeaderCell>Location</HeaderCell>
+                <HeaderCell>
+                  Sent # <br /> Packs
+                </HeaderCell>
+                <HeaderCell>
+                  Sent Pack <br /> Size
+                </HeaderCell>
+              </TableRow>
+            </TableHead>
+
+            {flattenInboundItems([inboundItem]).map(batch => (
+              <BatchRow key={batch.id} batch={batch} />
+            ))}
+
+            <Fab
+              sx={{
+                alignSelf: 'flex-end',
+                maxHeight: 24,
+                maxWidth: 24,
+                minHeight: 24,
+                minWidth: 24,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+              color="secondary"
+              aria-label="add"
+              size="small"
+              onClick={onAddBatch}
+            >
+              <PlusCircleIcon />
+            </Fab>
+          </Table>
+        </TableContainer>
       )}
     </>
   );

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -280,16 +280,12 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
             <Fab
               sx={{
                 alignSelf: 'flex-end',
-                maxHeight: 24,
-                maxWidth: 24,
-                minHeight: 24,
-                minWidth: 24,
+                margin: '10px',
                 alignItems: 'center',
                 justifyContent: 'center',
               }}
               color="secondary"
               aria-label="add"
-              size="small"
               onClick={onAddBatch}
             >
               <PlusCircleIcon />

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -5,6 +5,7 @@ import {
   ModalLabel,
   Grid,
   useTranslation,
+  BasicTextInput,
 } from '@openmsupply-client/common';
 import { InboundShipmentItem } from '../../../types';
 import { ItemSearchInput } from '@openmsupply-client/system';
@@ -21,14 +22,40 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
   const t = useTranslation('common');
 
   return (
-    <ModalRow>
-      <ModalLabel label={t('label.item')} />
-      <Grid item flex={1}>
-        <ItemSearchInput
-          currentItemName={item?.itemName}
-          onChange={onChangeItem}
-        />
-      </Grid>
-    </ModalRow>
+    <>
+      <ModalRow>
+        <ModalLabel label={t('label.item')} />
+        <Grid item flex={1}>
+          <ItemSearchInput
+            currentItemName={item?.itemName}
+            onChange={onChangeItem}
+          />
+        </Grid>
+      </ModalRow>
+      {item && (
+        <ModalRow>
+          <Grid style={{ display: 'flex', marginTop: 10 }} flex={1}>
+            <ModalLabel label={t('label.code')} />
+            <BasicTextInput
+              disabled
+              sx={{ width: 150 }}
+              value={item.itemCode}
+            />
+          </Grid>
+          <Grid
+            style={{ display: 'flex', marginTop: 10 }}
+            justifyContent="flex-end"
+            flex={1}
+          >
+            <ModalLabel label={t('label.unit')} justifyContent="flex-end" />
+            <BasicTextInput
+              disabled
+              sx={{ width: 150 }}
+              value={item.itemUnit}
+            />
+          </Grid>
+        </ModalRow>
+      )}
+    </>
   );
 };

--- a/packages/invoices/src/types.ts
+++ b/packages/invoices/src/types.ts
@@ -115,6 +115,7 @@ export type OutboundShipmentAction =
 
 export interface OutboundShipmentRow extends InvoiceLine {
   updateNumberOfPacks?: (quantity: number) => void;
+
   stockLineId: string;
   invoiceId: string;
   itemId: string;
@@ -149,6 +150,10 @@ export interface OutboundShipment extends Invoice {
 }
 export interface InboundShipmentRow extends InvoiceLine {
   updateNumberOfPacks?: (quantity: number) => void;
+  update?: <K extends keyof InboundShipmentRow>(
+    key: K,
+    value: InboundShipmentRow[K]
+  ) => void;
   stockLineId: string;
   invoiceId: string;
   itemId: string;


### PR DESCRIPTION
This is adding a search input, some item fields and a table to the inbound edit item modal.

It's very loosey goosey right now. I wanted to get it in to have something concrete to show so we can determine whats best to do with the large amount of editable fields on an inbound row v the outbound rows.

Some options I can see:
- Just Scroll
- Tabs - i.e. `general`, `pricing`, `weights`, `discrepancies` `totals`
- 'Tabs' but actually they just scroll to the columns related to the above
- expando
- keep only general details in the table, click on a row and some 'detail' area shows up elsewhere to edit other things
- 1 row per modal and don't use the table [I find this to be least preferable so we can be more consistent 🤷 ]
- use some sort of 'card' in the area for each row, and have the modal vertically scroll - edit: apparently this is a 'responsive table'
![image](https://user-images.githubusercontent.com/35858975/142773679-7109db6e-3faf-480d-a5a4-1b8bd02885bf.png)
