### PR TITLE
#475 stock list 2

### DIFF
--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -114,5 +114,6 @@
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",
   "placeholder.enter-a-customers-name": "Enter a customers name",
-  "placeholder.enter-a-suppliers-name": "Enter a suppliers name"
+  "placeholder.enter-a-suppliers-name": "Enter a suppliers name",
+  "placeholder.enter-an-item-code-or-name": "Enter item code or name"
 }

--- a/packages/host/src/routers/InventoryRouter.tsx
+++ b/packages/host/src/routers/InventoryRouter.tsx
@@ -3,6 +3,10 @@ import { Navigate, useMatch } from 'react-router-dom';
 import { RouteBuilder } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 
+const StockService = React.lazy(
+  () => import('@openmsupply-client/system/src/Stock/Service/Service')
+);
+
 const fullItemPath = RouteBuilder.create(AppRoute.Inventory)
   .addPart(AppRoute.Stock)
   .addWildCard()
@@ -10,7 +14,7 @@ const fullItemPath = RouteBuilder.create(AppRoute.Inventory)
 
 export const InventoryRouter: FC = () => {
   if (useMatch(fullItemPath)) {
-    return <div>Stock list</div>;
+    return <StockService />;
   } else {
     const notFoundRoute = RouteBuilder.create(AppRoute.PageNotFound).build();
     return <Navigate to={notFoundRoute} />;

--- a/packages/system/src/Stock/Components/Toolbar.tsx
+++ b/packages/system/src/Stock/Components/Toolbar.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react';
+import {
+  AppBarContentPortal,
+  InputWithLabelRow,
+  BasicTextInput,
+  useTranslation,
+} from '@openmsupply-client/common';
+
+interface ToolbarProps {
+  filterString: string | null;
+  onChangeFilter: (filterString: string) => void;
+}
+
+export const Toolbar: FC<ToolbarProps> = ({ filterString, onChangeFilter }) => {
+  const t = useTranslation(['common']);
+
+  return (
+    <AppBarContentPortal
+      sx={{
+        paddingBottom: '16px',
+        flex: 1,
+        justifyContent: 'space-between',
+        display: 'flex',
+      }}
+    >
+      <InputWithLabelRow
+        label={t('label.search')}
+        labelWidth={null}
+        Input={
+          <BasicTextInput
+            value={filterString}
+            placeholder={t('placeholder.enter-an-item-code-or-name')}
+            onChange={e => onChangeFilter(e.target.value)}
+          />
+        }
+      />
+    </AppBarContentPortal>
+  );
+};

--- a/packages/system/src/Stock/Components/index.ts
+++ b/packages/system/src/Stock/Components/index.ts
@@ -1,0 +1,1 @@
+export * from './Toolbar';

--- a/packages/system/src/Stock/ListView/ListView.tsx
+++ b/packages/system/src/Stock/ListView/ListView.tsx
@@ -1,0 +1,80 @@
+import React, { FC } from 'react';
+import {
+  TableProvider,
+  DataTable,
+  useListData,
+  useColumns,
+  createTableStore,
+  useOmSupplyApi,
+  usePagination,
+  useTranslation,
+  Column,
+  getDataSorter,
+  SortBy,
+} from '@openmsupply-client/common';
+import { Toolbar } from '../Components';
+import { getStockListViewApi } from './api';
+import { StockRow } from '../types';
+
+export const StockListView: FC = () => {
+  const { pagination } = usePagination();
+  const t = useTranslation('common');
+  const { api } = useOmSupplyApi();
+  const [filterString, setFilterString] = React.useState<string>('');
+  const [sortBy, setSortBy] = React.useState<SortBy<StockRow>>({
+    key: 'itemName',
+    direction: 'asc',
+  });
+  const { data, isLoading } = useListData(
+    { initialSortBy: { key: 'itemName' } },
+    ['stock', 'list'],
+    getStockListViewApi(api)
+  );
+  const onChangeSortBy = (column: Column<StockRow>) => {
+    const isDesc = column.key === sortBy.key ? !sortBy.isDesc : false;
+    setSortBy({ key: column.key, isDesc, direction: isDesc ? 'desc' : 'asc' });
+  };
+
+  const columns = useColumns<StockRow>(
+    [
+      'itemCode',
+      'itemName',
+      'batch',
+      'expiryDate',
+      'itemUnit',
+      'packSize',
+      'numberOfPacks',
+    ],
+    {
+      sortBy,
+      onChangeSortBy,
+    },
+    [sortBy]
+  );
+
+  const filterData = (row: StockRow) => {
+    const re = RegExp(`^${filterString ?? '.'}`, 'i');
+    return re.test(row.itemName) || re.test(row.itemCode);
+  };
+
+  const filteredSortedData =
+    data?.filter(filterData).sort(getDataSorter(sortBy.key, !!sortBy.isDesc)) ??
+    [];
+
+  return (
+    <TableProvider createStore={createTableStore}>
+      <Toolbar onChangeFilter={setFilterString} filterString={filterString} />
+      <DataTable
+        pagination={{ ...pagination, total: filteredSortedData.length }}
+        columns={columns}
+        data={filteredSortedData.slice(
+          pagination.offset,
+          pagination.offset + pagination.first
+        )}
+        onChangePage={pagination.onChangePage}
+        noDataMessage={t('error.no-items')}
+        isLoading={isLoading}
+      />
+    </TableProvider>
+  );
+};

--- a/packages/system/src/Stock/ListView/api.ts
+++ b/packages/system/src/Stock/ListView/api.ts
@@ -1,0 +1,63 @@
+import {
+  ListApi,
+  SortBy,
+  ItemSortFieldInput,
+  OmSupplyApi,
+  FilterBy,
+} from '@openmsupply-client/common';
+import { availableBatchesGuard, itemsGuard } from '../../Item/utils';
+import { StockRow } from '../types';
+const onRead =
+  (api: OmSupplyApi) =>
+  async ({
+    sortBy,
+    filterBy,
+  }: {
+    first: number;
+    offset: number;
+    sortBy: SortBy<StockRow>;
+    filterBy: FilterBy<StockRow> | null;
+  }): Promise<{
+    nodes: StockRow[];
+    totalCount: number;
+  }> => {
+    const result = await api.itemsWithStockLines({
+      first: 1000,
+      offset: 0,
+      key: ItemSortFieldInput.Name,
+      desc: sortBy.isDesc,
+      filter: filterBy,
+    });
+
+    const items = itemsGuard(result);
+    const nodes: StockRow[] = [];
+    items.nodes.forEach(item => {
+      const availableBatches = availableBatchesGuard(item.availableBatches);
+      availableBatches
+        .filter(batch => batch.totalNumberOfPacks > 0)
+        .forEach(batch =>
+          nodes.push({
+            id: batch.id,
+            itemCode: item.code,
+            itemName: item.name,
+            itemUnit: item.unitName ?? '',
+            batch: batch.batch ?? '',
+            expiryDate: batch.expiryDate,
+            packSize: batch.packSize,
+            numberOfPacks: batch.totalNumberOfPacks,
+          })
+        );
+    });
+
+    return { totalCount: nodes.length, nodes };
+  };
+
+export const getStockListViewApi = (api: OmSupplyApi): ListApi<StockRow> => ({
+  onRead:
+    ({ first, offset, sortBy, filterBy }) =>
+    () =>
+      onRead(api)({ first, offset, sortBy, filterBy }),
+  onDelete: async () => [''],
+  onUpdate: async () => '',
+  onCreate: async () => '',
+});

--- a/packages/system/src/Stock/ListView/index.ts
+++ b/packages/system/src/Stock/ListView/index.ts
@@ -1,0 +1,1 @@
+export * from './ListView';

--- a/packages/system/src/Stock/Service/Service.tsx
+++ b/packages/system/src/Stock/Service/Service.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+import { Routes, Route } from 'react-router-dom';
+
+import { RouteBuilder } from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
+import { StockListView } from '../ListView';
+
+const Service: FC = () => {
+  const stockRoute = RouteBuilder.create(AppRoute.Stock).build();
+
+  return (
+    <Routes>
+      <Route path={stockRoute} element={<StockListView />} />
+    </Routes>
+  );
+};
+
+export default Service;

--- a/packages/system/src/Stock/Service/index.ts
+++ b/packages/system/src/Stock/Service/index.ts
@@ -1,0 +1,1 @@
+export * from './Service';

--- a/packages/system/src/Stock/index.ts
+++ b/packages/system/src/Stock/index.ts
@@ -1,0 +1,1 @@
+export * from './ListView';

--- a/packages/system/src/Stock/types.ts
+++ b/packages/system/src/Stock/types.ts
@@ -1,0 +1,12 @@
+import { ObjectWithStringKeys } from '@openmsupply-client/common';
+
+export interface StockRow extends ObjectWithStringKeys {
+  id: string;
+  itemCode: string;
+  itemName: string;
+  itemUnit: string;
+  batch: string;
+  expiryDate: Date;
+  packSize: number;
+  numberOfPacks: number;
+}

--- a/packages/system/src/index.ts
+++ b/packages/system/src/index.ts
@@ -1,1 +1,2 @@
 export * from './Item';
+export * from './Stock';


### PR DESCRIPTION
Fixes #416 

Decided not to export to excel at this stage. Also the query endpoint isn't ideal since I have to filter out for zero stock items. for now, I've reused the `getStockListViewApi` call and have just asked for 1000 rows, then filtered and sorted manually in the `ListView`. Means that it only has to query once and still supports pagination and sorting.