### PR TITLE
#406 filter out items

### DIFF
--- a/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -4,6 +4,8 @@ import {
   AutocompleteRenderInputParams,
   createFilterOptions,
   CreateFilterOptionsConfig,
+  AutocompleteInputChangeReason,
+  AutocompleteProps as MuiAutocompleteProps,
 } from '@mui/material';
 import {
   AutocompleteOption,
@@ -11,7 +13,11 @@ import {
   AutocompleteOptionRenderer,
 } from './types';
 import { BasicTextInput } from '../TextInput';
-export interface AutocompleteProps<T> {
+export interface AutocompleteProps<T>
+  extends Omit<
+    MuiAutocompleteProps<T, undefined, undefined, undefined>,
+    'renderInput'
+  > {
   defaultValue?: AutocompleteOption<T> | null;
   getOptionDisabled?: (option: T) => boolean;
   filterOptionConfig?: CreateFilterOptionsConfig<T>;
@@ -27,7 +33,11 @@ export interface AutocompleteProps<T> {
   clearable?: boolean;
   isOptionEqualToValue?: (option: T, value: T) => boolean;
   disabled?: boolean;
-  onInputChange?: (event: React.SyntheticEvent, value: string) => void;
+  onInputChange?: (
+    event: React.SyntheticEvent,
+    value: string,
+    reason: AutocompleteInputChangeReason
+  ) => void;
   inputValue?: string;
 }
 
@@ -49,6 +59,7 @@ export function Autocomplete<T>({
   disabled,
   onInputChange,
   inputValue,
+  ...restOfAutocompleteProps
 }: PropsWithChildren<AutocompleteProps<T>>): JSX.Element {
   const filterOptions = createFilterOptions(filterOptionConfig);
 
@@ -62,6 +73,7 @@ export function Autocomplete<T>({
 
   return (
     <MuiAutocomplete
+      {...restOfAutocompleteProps}
       inputValue={inputValue}
       onInputChange={onInputChange}
       disabled={disabled}

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -158,6 +158,7 @@ export const DetailView: FC = () => {
         width={1024}
       >
         <InboundLineEdit
+          draft={draft}
           mode={modalState.mode}
           item={modalState.item}
           onUpsert={() => {}}

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -26,7 +26,11 @@ import {
   useColumns,
   TextInputCell,
 } from '@openmsupply-client/common';
-import { InboundShipmentItem, InboundShipmentRow } from '../../../types';
+import {
+  InboundShipment,
+  InboundShipmentItem,
+  InboundShipmentRow,
+} from '../../../types';
 import { ItemSearchInput } from '@openmsupply-client/system';
 import { flattenInboundItems } from '../../../utils';
 import { ModalMode } from '../DetailView';
@@ -35,6 +39,7 @@ interface InboundLineEditProps {
   onUpsert: (item: InboundShipmentItem) => void;
   onChangeItem: (item: Item | null) => void;
   mode: ModalMode;
+  draft: InboundShipment;
 }
 
 const BasicCell: React.FC<TableCellProps> = ({ sx, ...props }) => (
@@ -327,6 +332,7 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
   item,
   onChangeItem,
   mode,
+  draft,
 }) => {
   const t = useTranslation(['outbound-shipment', 'common']);
 
@@ -391,6 +397,12 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
               unitName: '',
             }}
             onChange={onChangeItem}
+            extraFilter={item => {
+              const itemAlreadyInShipment = draft.items.some(
+                ({ id }) => id === item.id
+              );
+              return !itemAlreadyInShipment;
+            }}
           />
         </Grid>
       </ModalRow>

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit.tsx
@@ -29,10 +29,12 @@ import {
 import { InboundShipmentItem, InboundShipmentRow } from '../../../types';
 import { ItemSearchInput } from '@openmsupply-client/system';
 import { flattenInboundItems } from '../../../utils';
+import { ModalMode } from '../DetailView';
 interface InboundLineEditProps {
   item: InboundShipmentItem | null;
   onUpsert: (item: InboundShipmentItem) => void;
   onChangeItem: (item: Item | null) => void;
+  mode: ModalMode;
 }
 
 const BasicCell: React.FC<TableCellProps> = ({ sx, ...props }) => (
@@ -324,6 +326,7 @@ enum Tabs {
 export const InboundLineEdit: FC<InboundLineEditProps> = ({
   item,
   onChangeItem,
+  mode,
 }) => {
   const t = useTranslation(['outbound-shipment', 'common']);
 
@@ -378,7 +381,15 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
         <ModalLabel label={t('label.item')} />
         <Grid item flex={1}>
           <ItemSearchInput
-            currentItemName={item?.itemName}
+            disabled={mode === ModalMode.Update}
+            currentItem={{
+              name: item?.itemName ?? '',
+              id: item?.itemId ?? '',
+              code: item?.itemCode ?? '',
+              isVisible: true,
+              availableBatches: [],
+              unitName: '',
+            }}
             onChange={onChangeItem}
           />
         </Grid>

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -131,6 +131,7 @@ export const DetailView: FC = () => {
       />
 
       <ItemDetailsModal
+        draft={draft}
         isEditMode={selectedItem.editing}
         onNext={onNext}
         summaryItem={selectedItem?.item}

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -53,7 +53,14 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
         <ModalLabel label={t('label.item')} />
         <Grid item flex={1}>
           <ItemSearchInput
-            currentItemName={summaryItem?.itemName}
+            currentItem={{
+              name: summaryItem?.itemName ?? '',
+              id: summaryItem?.itemId ?? '',
+              code: summaryItem?.itemCode ?? '',
+              isVisible: true,
+              availableBatches: [],
+              unitName: '',
+            }}
             onChange={onChangeItem}
           />
         </Grid>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -20,7 +20,7 @@ import {
   Box,
 } from '@openmsupply-client/common';
 import { ItemSearchInput } from '@openmsupply-client/system/src/Item';
-import { OutboundShipmentSummaryItem } from '../../../types';
+import { OutboundShipment, OutboundShipmentSummaryItem } from '../../../types';
 import { PackSizeController } from './ItemDetailsModal';
 
 interface ItemDetailsFormProps {
@@ -31,6 +31,7 @@ interface ItemDetailsFormProps {
   onChangeQuantity: (quantity: number, packSize: number | null) => void;
   packSizeController: PackSizeController;
   availableQuantity: number;
+  draft: OutboundShipment;
 }
 
 export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
@@ -41,6 +42,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
   summaryItem,
   packSizeController,
   availableQuantity,
+  draft,
 }) => {
   const t = useTranslation(['outbound-shipment', 'common']);
 
@@ -62,6 +64,12 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
               unitName: '',
             }}
             onChange={onChangeItem}
+            extraFilter={item => {
+              const itemAlreadyInShipment = draft.items.some(
+                ({ id }) => id === item.id
+              );
+              return !itemAlreadyInShipment;
+            }}
           />
         </Grid>
       </ModalRow>

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -17,6 +17,7 @@ import { BatchesTable, sortByExpiry } from './BatchesTable';
 import { ItemDetailsForm } from './ItemDetailsForm';
 import {
   BatchRow,
+  OutboundShipment,
   OutboundShipmentRow,
   OutboundShipmentSummaryItem,
 } from '../../../types';
@@ -30,6 +31,7 @@ interface ItemDetailsModalProps {
   onChangeItem: (item: Item | null) => void;
   onNext: () => void;
   isEditMode: boolean;
+  draft: OutboundShipment;
 }
 
 export const getInvoiceLine = (
@@ -197,6 +199,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   summaryItem,
   onNext,
   isEditMode,
+  draft,
 }) => {
   const t = useTranslation(['outbound-shipment']);
   const methods = useForm({ mode: 'onBlur' });
@@ -343,6 +346,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
         <form>
           <Grid container gap={0.5}>
             <ItemDetailsForm
+              draft={draft}
               availableQuantity={sumAvailableQuantity(batchRows)}
               packSizeController={packSizeController}
               onChangeItem={onChangeItem}

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
@@ -32,12 +32,14 @@ interface ItemSearchInputProps {
   currentItem?: Item;
   currentItemName?: string;
   disabled?: boolean;
+  extraFilter?: (item: Item) => boolean;
 }
 
 export const ItemSearchInput: FC<ItemSearchInputProps> = ({
   onChange,
   currentItem,
   disabled = false,
+  extraFilter,
 }) => {
   const [filter, setFilter] = useState<{
     searchTerm: string;
@@ -70,6 +72,10 @@ export const ItemSearchInput: FC<ItemSearchInputProps> = ({
     }
   }, [open, value, buffer]);
 
+  const options = extraFilter
+    ? data?.nodes?.filter(extraFilter) ?? []
+    : data?.nodes ?? [];
+
   return (
     <Autocomplete
       disabled={disabled}
@@ -91,7 +97,7 @@ export const ItemSearchInput: FC<ItemSearchInputProps> = ({
       onChange={(_, item) => {
         onChange(item);
       }}
-      options={defaultOptionMapper(data?.nodes ?? [], 'name')}
+      options={defaultOptionMapper(options, 'name')}
       renderOption={renderOption}
       width="100%"
       isOptionEqualToValue={(option, value) => option?.id === value?.id}


### PR DESCRIPTION
Fixes #406 

- Can't do `not` on a filter, so doing it in JS
- I quite like the added `extraFilter` prop anyway. Think it'll come in handy.
- Don't like the prop drilling of the draft