### PR TITLE
#456 ok next weird

### DIFF
--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -152,7 +152,15 @@ export const DetailView: FC = () => {
             : t('heading.edit-item')
         }
         cancelButton={<DialogButton variant="cancel" onClick={hideDialog} />}
-        nextButton={<DialogButton variant="next" onClick={() => {}} />}
+        nextButton={
+          <DialogButton
+            variant="next"
+            onClick={() => {}}
+            disabled={
+              modalState.mode === ModalMode.Update && draft.items.length === 3
+            }
+          />
+        }
         okButton={<DialogButton variant="ok" onClick={hideDialog} />}
         height={600}
         width={1024}

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -138,6 +138,7 @@ export const DetailView: FC = () => {
         onClose={itemModalControl.toggleOff}
         onChangeItem={onChangeSelectedItem}
         upsertInvoiceLine={line => draft.upsertLine?.(line)}
+        isOnlyItem={draft.items.length === 1}
       />
 
       <Toolbar draft={draft} />

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -30,6 +30,7 @@ interface ItemDetailsModalProps {
   onChangeItem: (item: Item | null) => void;
   onNext: () => void;
   isEditMode: boolean;
+  isOnlyItem: boolean;
 }
 
 export const getInvoiceLine = (
@@ -197,6 +198,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   summaryItem,
   onNext,
   isEditMode,
+  isOnlyItem,
 }) => {
   const t = useTranslation(['outbound-shipment']);
   const methods = useForm({ mode: 'onBlur' });
@@ -324,7 +326,9 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
       cancelButton={<DialogButton variant="cancel" onClick={onCancel} />}
       nextButton={
         <DialogButton
-          disabled={isEditMode ? false : getAllocatedQuantity(batchRows) <= 0}
+          disabled={
+            isEditMode ? isOnlyItem : getAllocatedQuantity(batchRows) <= 0
+          }
           variant="next"
           onClick={onNext}
         />


### PR DESCRIPTION
Fixes #456 

Quick one to disable OK & Next if the user is editing the only item. I know you said to make the button act as OK, but thought that was misleading, since there is no 'next' to go to 🤷 