### PR TITLE
#448 inbound line edit 7

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,6 +28,7 @@
     "immer": "^9.0.6",
     "kbar": "0.1.0-beta.12",
     "notistack": "^2.0.3",
+    "react-currency-input-field": "^3.6.0",
     "react-hook-form": "^7.17.0",
     "react-i18next": "^11.14.2",
     "react-query": "^3.24.3",

--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -110,6 +110,8 @@
   "label.unit-quantity": "Unit Quantity",
   "label.unit": "Unit",
   "label.units": "Units",
+  "label.line-total": "Line total",
+  "label.num-packs": "# Packs",
   "link.backorders": "Backorders",
   "link.copy-to-clipboard": "Copy to Clipboard",
   "link.history": "History",

--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.stories.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { CurrencyInput } from './CurrencyInput';
+import { Box, Typography } from '@mui/material';
+
+export default {
+  title: 'Inputs/CurrencyInput',
+  component: CurrencyInput,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} as ComponentMeta<typeof CurrencyInput>;
+
+const Template: ComponentStory<typeof CurrencyInput> = () => {
+  const [value1, setValue1] = React.useState(0);
+
+  return (
+    <Box>
+      <CurrencyInput defaultValue={value1} onChangeNumber={setValue1} />
+      <Typography>Stored value: {value1}</Typography>
+    </Box>
+  );
+};
+
+export const Primary = Template.bind({});

--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -54,7 +54,7 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   }, [value]);
 
   // Call the onChangeNumber prop when the buffer changes to a valid number, which
-  // is essentially in ever case except when the number ends in a decimal. If the user
+  // is essentially in every case except when the number ends in a decimal. If the user
   // loses focus when the buffer is in this invalid state, the currency input will
   // append two zeros so will always result in a valid number.
   useEffect(() => {

--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -1,0 +1,79 @@
+import React, { FC, useEffect } from 'react';
+import { styled } from '../../../../styles';
+import RCInput, {
+  CurrencyInputProps as RCInputProps,
+} from 'react-currency-input-field';
+
+interface CurrencyInputProps extends RCInputProps {
+  onChangeNumber: (value: number) => void;
+  maxWidth?: number;
+}
+
+const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
+  fontFamily: theme.typography.fontFamily,
+  height: 34.125,
+  borderRadius: '8px',
+  padding: '4px 8px',
+  backgroundColor: '#f2f2f5',
+  textAlign: 'right',
+  border: 'none',
+  '&:focus': {
+    outline: 'none',
+  },
+}));
+
+export const CurrencyInput: FC<CurrencyInputProps> = ({
+  allowNegativeValue = false,
+  prefix = '$',
+  decimalSeparator = '.',
+  decimalsLimit = 2,
+  allowDecimals = true,
+  decimalScale = 2,
+  value = 0,
+  onChangeNumber,
+  maxWidth,
+  ...restOfProps
+}) => {
+  // Buffer the internal input value so we can account for the decimal separator
+  // which, when input will result in the input being NaN (e.g. '42.') when cast
+  // to a number. In this case, we want to keep the value as '42.' in the input
+  // but not persisted. Though, whenever I have an uncontrolled component I
+  // generally will always regret it, so sync the passed value up with the buffer.
+  const [buffer, setBuffer] = React.useState<string | undefined>(String(value));
+  useEffect(() => {
+    if (value !== Number(buffer)) {
+      setBuffer(String(value));
+    }
+  }, [value]);
+
+  // Call the onChangeNumber prop when the buffer changes to a valid number, which
+  // is essentially in ever case except when the number ends in a decimal. If the user
+  // loses focus when the buffer is in this invalid state, the currency input will
+  // append two zeros so will always result in a valid number.
+  useEffect(() => {
+    if (buffer == null) {
+      return onChangeNumber(0);
+    }
+    if (!Number.isNaN(buffer)) {
+      return onChangeNumber(Number(buffer));
+    }
+  }, [buffer]);
+
+  return (
+    <StyledCurrencyInput
+      sx={{ maxWidth }}
+      value={buffer}
+      onValueChange={newValue => {
+        setBuffer(newValue);
+      }}
+      allowNegativeValue={allowNegativeValue}
+      prefix={prefix}
+      decimalSeparator={decimalSeparator}
+      decimalsLimit={decimalsLimit}
+      allowDecimals={allowDecimals}
+      decimalScale={decimalScale}
+      transformRawValue={value => value.replace(/[^0-9.]/g, '')}
+      {...restOfProps}
+    />
+  );
+};

--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -9,6 +9,9 @@ interface CurrencyInputProps extends RCInputProps {
   maxWidth?: number;
 }
 
+// TODO: It would be nice if we were to just use the BasicTextInput or
+// another MUI text input rather than trying to recreate the style so that
+// it could stay in sync with style updated.
 const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
   fontFamily: theme.typography.fontFamily,
   height: 34.125,
@@ -22,6 +25,10 @@ const StyledCurrencyInput = styled(RCInput)(({ theme }) => ({
   },
 }));
 
+// TODO: I think the implementation of this could be swapped out by making a
+// headless component that uses something like currency.js in a custom hook
+// to manage the currency value. Then you could use whatever input component
+// you liked. That would just take a little more time than I have right now!
 export const CurrencyInput: FC<CurrencyInputProps> = ({
   allowNegativeValue = false,
   prefix = '$',

--- a/packages/common/src/ui/components/inputs/CurrencyInput/index.ts
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/index.ts
@@ -1,0 +1,1 @@
+export * from './CurrencyInput';

--- a/packages/common/src/ui/components/inputs/SearchBar/SearchBar.stories.tsx
+++ b/packages/common/src/ui/components/inputs/SearchBar/SearchBar.stories.tsx
@@ -17,10 +17,12 @@ const Template: ComponentStory<typeof SearchBar> = () => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   useEffect(() => {
-    setTimeout(() => {
-      setIsLoading(false);
-      alert('Response received!');
-    }, 2000);
+    if (value) {
+      setTimeout(() => {
+        setIsLoading(false);
+        alert('Response received!');
+      }, 2000);
+    }
   }, [value]);
 
   return (

--- a/packages/common/src/ui/components/inputs/index.ts
+++ b/packages/common/src/ui/components/inputs/index.ts
@@ -4,3 +4,4 @@ export * from './Autocomplete';
 export * from './TextArea';
 export * from './Select';
 export * from './SearchBar';
+export * from './CurrencyInput';

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -61,7 +61,9 @@ export const DataTable = <T extends DomainObject>({
   }
 
   return (
-    <TableContainer sx={{ display: 'flex', flexDirection: 'column' }}>
+    <TableContainer
+      sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+    >
       <MuiTable sx={{ overflow: 'auto', display: 'block', flex: 1 }}>
         <TableHead sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <HeaderRow dense={dense}>
@@ -79,6 +81,7 @@ export const DataTable = <T extends DomainObject>({
             return (
               <DataRow
                 ExpandContent={ExpandContent}
+                rowIndex={idx}
                 columns={columns}
                 key={row.id}
                 onClick={onRowClick}

--- a/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
+++ b/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { DomainObject } from '../../../../../types';
+import { ColumnAlign, ColumnDefinition } from '../types';
+import { useTranslation } from '../../../../../intl';
+
+export const getLineLabelColumn = <
+  T extends DomainObject
+>(): ColumnDefinition<T> => ({
+  key: 'lineLabel',
+  sortable: false,
+  align: ColumnAlign.Right,
+  width: 100,
+  Header: () => {
+    return null;
+  },
+
+  Cell: ({ rowIndex }) => {
+    const t = useTranslation('common');
+    const label = t('label.line', { line: rowIndex + 1 });
+
+    return <>{label}</>;
+  },
+});

--- a/packages/common/src/ui/layout/tables/columns/LineLabel/index.ts
+++ b/packages/common/src/ui/layout/tables/columns/LineLabel/index.ts
@@ -1,0 +1,1 @@
+export * from './LineLabel';

--- a/packages/common/src/ui/layout/tables/columns/index.ts
+++ b/packages/common/src/ui/layout/tables/columns/index.ts
@@ -4,3 +4,4 @@ export * from './NameAndColorColumn';
 export * from './NotePopoverColumn';
 export * from './types';
 export * from './RowExpand';
+export * from './LineLabel';

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -9,6 +9,8 @@ export interface CellProps<T extends DomainObject> {
   columns: Column<T>[];
   column: Column<T>;
   rowKey: string;
+  columnIndex: number;
+  rowIndex: number;
 }
 
 export interface HeaderProps<T extends DomainObject> {

--- a/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -4,15 +4,17 @@ import { CurrencyInput } from '../../../../../components/inputs';
 import { DomainObject } from '../../../../../../types';
 import { useDebounceCallback } from '../../../../../../hooks';
 
-type R<T> = T &
+type DomainObjectWithUpdater<T> = T &
   DomainObject & { update?: (key: string, value: string) => void };
 
-type CP<T> = CellProps<R<T>>;
+type CellPropsWithUpdaterObject<T> = CellProps<DomainObjectWithUpdater<T>>;
 
 export const CurrencyInputCell = <T extends DomainObject>({
   rowData,
   column,
-}: CP<T>): React.ReactElement<CP<T>> => {
+}: CellPropsWithUpdaterObject<T>): React.ReactElement<
+  CellPropsWithUpdaterObject<T>
+> => {
   const [buffer, setBuffer] = React.useState(Number(column.accessor(rowData)));
 
   const noop = () => {};

--- a/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { CellProps } from '../../../columns';
+import { CurrencyInput } from '../../../../../components/inputs';
+import { DomainObject } from '../../../../../../types';
+import { useDebounceCallback } from '../../../../../../hooks';
+
+type R<T> = T &
+  DomainObject & { update?: (key: string, value: string) => void };
+
+type CP<T> = CellProps<R<T>>;
+
+export const CurrencyInputCell = <T extends DomainObject>({
+  rowData,
+  column,
+}: CP<T>): React.ReactElement<CP<T>> => {
+  const [buffer, setBuffer] = React.useState(Number(column.accessor(rowData)));
+
+  const noop = () => {};
+  const updater = useDebounceCallback(rowData.update ?? noop, [rowData], 250);
+
+  return (
+    <CurrencyInput
+      maxWidth={column.width}
+      value={buffer}
+      onChangeNumber={newNumber => {
+        setBuffer(newNumber);
+        updater(String(column.key), String(newNumber));
+      }}
+    />
+  );
+};

--- a/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/index.ts
+++ b/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/index.ts
@@ -1,0 +1,1 @@
+export * from './CurrencyInputCell';

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { CellProps } from '../../../columns';
+import { BasicTextInput } from '../../../../../components/inputs/TextInput';
+import { DomainObject } from '../../../../../../types';
+import { useDebounceCallback } from '../../../../../../hooks';
+
+type R<T> = T &
+  DomainObject & { update?: (key: string, value: string) => void };
+
+type CP<T> = CellProps<R<T>>;
+
+export const NumberInputCell = <T extends DomainObject>({
+  rowData,
+  column,
+}: CP<T>): React.ReactElement<CP<T>> => {
+  const [buffer, setBuffer] = React.useState(column.accessor(rowData));
+
+  const noop = () => {};
+  const updater = useDebounceCallback(rowData.update ?? noop, [rowData], 250);
+
+  return (
+    <BasicTextInput
+      InputProps={{ sx: { '& .MuiInput-input': { textAlign: 'right' } } }}
+      type="number"
+      value={buffer}
+      onChange={e => {
+        const newValue = e.target.value;
+        setBuffer(newValue);
+        updater(String(column.key), newValue);
+      }}
+    />
+  );
+};

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -4,15 +4,17 @@ import { BasicTextInput } from '../../../../../components/inputs/TextInput';
 import { DomainObject } from '../../../../../../types';
 import { useDebounceCallback } from '../../../../../../hooks';
 
-type R<T> = T &
+type DomainObjectWithUpdater<T> = T &
   DomainObject & { update?: (key: string, value: string) => void };
 
-type CP<T> = CellProps<R<T>>;
+type CellPropsWithUpdaterObject<T> = CellProps<DomainObjectWithUpdater<T>>;
 
 export const NumberInputCell = <T extends DomainObject>({
   rowData,
   column,
-}: CP<T>): React.ReactElement<CP<T>> => {
+}: CellPropsWithUpdaterObject<T>): React.ReactElement<
+  CellPropsWithUpdaterObject<T>
+> => {
   const [buffer, setBuffer] = React.useState(column.accessor(rowData));
 
   const noop = () => {};

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/index.ts
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/index.ts
@@ -1,0 +1,1 @@
+export * from './NumberInputCell';

--- a/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -4,15 +4,17 @@ import { BasicTextInput } from '../../../../../components/inputs/TextInput';
 import { DomainObject } from '../../../../../../types';
 import { useDebounceCallback } from '../../../../../../hooks';
 
-type R<T> = T &
+type DomainObjectWithUpdater<T> = T &
   DomainObject & { update?: (key: string, value: string) => void };
 
-type CP<T> = CellProps<R<T>>;
+type CellPropsWithUpdaterObject<T> = CellProps<DomainObjectWithUpdater<T>>;
 
 export const TextInputCell = <T extends DomainObject>({
   rowData,
   column,
-}: CP<T>): React.ReactElement<CP<T>> => {
+}: CellPropsWithUpdaterObject<T>): React.ReactElement<
+  CellPropsWithUpdaterObject<T>
+> => {
   const [buffer, setBuffer] = React.useState(column.accessor(rowData));
 
   const noop = () => {};

--- a/packages/common/src/ui/layout/tables/components/Cells/index.ts
+++ b/packages/common/src/ui/layout/tables/components/Cells/index.ts
@@ -1,1 +1,3 @@
 export * from './TextInputCell';
+export * from './NumberInputCell';
+export * from './CurrencyInputCell';

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.stories.tsx
@@ -25,6 +25,7 @@ const Template: Story = ({ onClick }) => {
         <DataRow
           columns={columns}
           rowKey="rowKey"
+          rowIndex={0}
           rowData={{
             id: '',
             status: 'Finalised',

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.test.tsx
@@ -20,7 +20,12 @@ describe('DataRow', () => {
     return (
       <Table>
         <TableBody>
-          <DataRow columns={columns} rowKey="rowKey" rowData={{ id: 'josh' }} />
+          <DataRow
+            columns={columns}
+            rowKey="rowKey"
+            rowIndex={0}
+            rowData={{ id: 'josh' }}
+          />
         </TableBody>
       </Table>
     );

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -13,6 +13,7 @@ interface DataRowProps<T extends DomainObject> {
   rowKey: string;
   ExpandContent?: FC<{ rowData: T }>;
   dense?: boolean;
+  rowIndex: number;
 }
 
 export const DataRow = <T extends DomainObject>({
@@ -20,6 +21,7 @@ export const DataRow = <T extends DomainObject>({
   onClick,
   rowData,
   rowKey,
+  rowIndex,
   ExpandContent,
   dense = false,
 }: DataRowProps<T>): JSX.Element => {
@@ -49,7 +51,7 @@ export const DataRow = <T extends DomainObject>({
         onClick={onRowClick}
         hover={hasOnClick}
       >
-        {columns.map(column => {
+        {columns.map((column, columnIndex) => {
           return (
             <TableCell
               key={`${rowKey}${column.key}`}
@@ -74,6 +76,8 @@ export const DataRow = <T extends DomainObject>({
                 columns={columns}
                 column={column}
                 rowKey={rowKey}
+                columnIndex={columnIndex}
+                rowIndex={rowIndex}
               />
             </TableCell>
           );

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -32,7 +32,8 @@ export type ColumnKey =
   | 'locationDescription'
   | 'unitQuantity'
   | 'numberOfPacks'
-  | 'otherPartyName';
+  | 'otherPartyName'
+  | 'lineTotal';
 
 const getColumnLookup = <T extends DomainObject>(): Record<
   ColumnKey,
@@ -166,6 +167,13 @@ const getColumnLookup = <T extends DomainObject>(): Record<
     label: 'label.unit',
     key: 'unit',
     width: 50,
+  },
+  lineTotal: {
+    label: 'label.line-total',
+    key: 'lineTotal',
+    width: 100,
+    align: ColumnAlign.Right,
+    format: ColumnFormat.Currency,
   },
 });
 

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -29,11 +29,9 @@
   },
   "dependencies": {
     "@fontsource/inter": "^4.5.0",
-    "@openmsupply-client/catalogue": "^0.0.0",
     "@openmsupply-client/common": "^0.0.1",
     "@openmsupply-client/config": "^0.0.0",
     "@openmsupply-client/dashboard": "^0.0.0",
-    "@openmsupply-client/distribution": "^0.0.0",
     "@openmsupply-client/system": "^0.0.0",
     "history": "^5.1.0",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,19 +757,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-display-name@^7.0.0", "@babel/plugin-transform-react-display-name@^7.14.5", "@babel/plugin-transform-react-display-name@^7.16.0":
+"@babel/plugin-transform-react-display-name@^7.0.0", "@babel/plugin-transform-react-display-name@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.0.tgz#9a0ad8aa8e8790883a7bd2736f66229a58125676"
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-jsx-development@^7.14.5", "@babel/plugin-transform-react-jsx-development@^7.16.0":
+"@babel/plugin-transform-react-jsx-development@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.0.tgz#1cb52874678d23ab11d0d16488d54730807303ef"
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.16.0"
 
-"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.12.12", "@babel/plugin-transform-react-jsx@^7.14.5", "@babel/plugin-transform-react-jsx@^7.16.0":
+"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.12.12", "@babel/plugin-transform-react-jsx@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.0.tgz#55b797d4960c3de04e07ad1c0476e2bc6a4889f1"
   dependencies:
@@ -779,7 +779,7 @@
     "@babel/plugin-syntax-jsx" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/plugin-transform-react-pure-annotations@^7.14.5", "@babel/plugin-transform-react-pure-annotations@^7.16.0":
+"@babel/plugin-transform-react-pure-annotations@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.0.tgz#23db6ddf558d8abde41b8ad9d59f48ad5532ccab"
   dependencies:
@@ -946,17 +946,6 @@
     "@babel/plugin-transform-dotall-regex" "^7.4.4"
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
-
-"@babel/preset-react@7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.14.5.tgz#0fbb769513f899c2c56f3a882fa79673c2d4ab3c"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/helper-validator-option" "^7.14.5"
-    "@babel/plugin-transform-react-display-name" "^7.14.5"
-    "@babel/plugin-transform-react-jsx" "^7.14.5"
-    "@babel/plugin-transform-react-jsx-development" "^7.14.5"
-    "@babel/plugin-transform-react-pure-annotations" "^7.14.5"
 
 "@babel/preset-react@^7.12.10":
   version "7.16.0"
@@ -13087,6 +13076,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
 react-colorful@^5.1.2:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.0.tgz#8359f218984a927095477a190ab9927eaf865c0c"
+
+react-currency-input-field@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-currency-input-field/-/react-currency-input-field-3.6.0.tgz#1b19eb34c14cdf9c95ff8c5acd5abcc4441aed09"
+  integrity sha512-UBj/+TxS13kEv2+UuysVPboK0HgXlxVoVx5FESCDHyu7bT4ybNpJxUqHCIcWdsWU+TsfvNndgzNdiKFSiFIJcQ==
 
 react-dev-utils@^11.0.3:
   version "11.0.4"


### PR DESCRIPTION
Was getting a bit big. Thought I'd stop here!

- I removed all the unsupported fields and therefore tabs - only leaving the batch and pricing tabs since they needed rewriting anyway, no point having commented & also wrong code
- Added a numeric input and currency input. For the currency I used a currency input package. This is wrapped and exported from common so if we want to remove it we can pretty easily (though maybe I should have no extended the props of the packaged component) - I know how annoying currency can be and so it saved a little bit of time and the result I think is pretty nice. 
- Made the inputs inputable - though they're only editable for newly added rows, for now (the new rows are given the updater function, passed in rows aren't, yet).
- I played a bit with some animations for switching between tabs. Thought they were OK, but a bit distracting and annoying.