### PR TITLE
basic cell text overflow

### DIFF
--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -5,7 +5,7 @@ import { Column } from '../../columns/types';
 import { DomainObject } from '../../../../../types';
 import { useExpanded, useDisabled } from '../../context';
 import { Collapse } from '@mui/material';
-
+import { cellHorizontalPadding } from '../index';
 interface DataRowProps<T extends DomainObject> {
   columns: Column<T>[];
   onClick?: (rowData: T) => void;
@@ -60,10 +60,9 @@ export const DataRow = <T extends DomainObject>({
                 borderBottom: 'none',
                 justifyContent: 'flex-end',
                 overflow: 'hidden',
-                textOverflow: 'none',
                 whiteSpace: 'nowrap',
-                paddingLeft: '16px',
-                paddingRight: '16px',
+                paddingLeft: `${cellHorizontalPadding}px`,
+                paddingRight: `${cellHorizontalPadding}px`,
                 ...(hasOnClick && { cursor: 'pointer' }),
                 flex: `${column.width} 0 auto`,
                 minWidth: column.minWidth,

--- a/packages/common/src/ui/layout/tables/components/index.tsx
+++ b/packages/common/src/ui/layout/tables/components/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation, useFormatDate } from '../../../../intl';
 
 export * from './DataRow';
 export * from './Cells';
+export const cellHorizontalPadding = 16;
 
 export const BasicCell = <T extends DomainObject>({
   column,
@@ -14,7 +15,14 @@ export const BasicCell = <T extends DomainObject>({
   const d = useFormatDate();
 
   return (
-    <span style={{ textOverflow: 'ellipsis' }}>
+    <span
+      style={{
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        width: column.width - 2 * cellHorizontalPadding,
+        display: 'inline-block',
+      }}
+    >
       {column.formatter(column.accessor(rowData), { t, d })}
     </span>
   );


### PR DESCRIPTION
Fixes #515 
A small tidy - the span needs to be a block element in order to have a defined width, which is required for overflow. When it takes the width from the `td` that's the full width, and the available is less the padding, so have manually adjusted. Not great, but working ok.