### PR TITLE
Add status translations and handling of save & next status button

### DIFF
--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -1,3 +1,5 @@
 {
-    "label.stocktake-date": "Stocktake Date"
+    "label.stocktake-date": "Stocktake Date",
+    "label.suggested": "Suggested",
+    "label.finalised": "Finalised"
 }

--- a/packages/common/src/schema.graphql
+++ b/packages/common/src/schema.graphql
@@ -1358,8 +1358,7 @@ type DeleteStocktakeLineResponseWithId {
 }
 
 enum StocktakeNodeStatus {
-  DRAFT
-  CONFIRMED
+  SUGGESTED
   FINALISED
 }
 

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1567,9 +1567,8 @@ export type StocktakeNode = {
 };
 
 export enum StocktakeNodeStatus {
-  Confirmed = 'CONFIRMED',
-  Draft = 'DRAFT',
-  Finalised = 'FINALISED'
+  Finalised = 'FINALISED',
+  Suggested = 'SUGGESTED'
 }
 
 export type StocktakeResponse = NodeError | StocktakeNode;

--- a/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
+++ b/packages/common/src/ui/components/inputs/DatePickers/DatePickerInput/DatePickerInput.tsx
@@ -4,11 +4,19 @@ import { BaseDatePickerInput } from '../BaseDatePickerInput';
 interface DatePickerInputProps {
   value: Date | null;
   onChange: (value: Date | null) => void;
+  disabled?: boolean;
 }
 
 export const DatePickerInput: FC<DatePickerInputProps> = ({
   value,
   onChange,
+  disabled = false,
 }) => {
-  return <BaseDatePickerInput onChange={onChange} value={value} />;
+  return (
+    <BaseDatePickerInput
+      disabled={disabled}
+      onChange={onChange}
+      value={value}
+    />
+  );
 };

--- a/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -69,6 +69,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
             label={t('label.stocktake-date', { ns: 'inventory' })}
             Input={
               <DatePickerInput
+                disabled={!isStocktakeEditable(draft)}
                 value={new Date(draft.stocktakeDatetime)}
                 onChange={newDate => {
                   draft.updateStocktakeDatetime(newDate);

--- a/packages/inventory/src/Stocktake/DetailView/reducer.ts
+++ b/packages/inventory/src/Stocktake/DetailView/reducer.ts
@@ -1,17 +1,20 @@
-import {
-  StocktakeItem,
-  StocktakeActionType,
-  StocktakeController,
-} from '../../types';
 import { Dispatch } from 'react';
 import {
   produce,
   DocumentActionSet,
   DocumentActionType,
   SortBy,
+  StocktakeNodeStatus,
 } from '@openmsupply-client/common';
+import {
+  StocktakeItem,
+  StocktakeActionType,
+  StocktakeAction,
+  Stocktake,
+  StocktakeController,
+} from '../../types';
+
 import { placeholderStocktake } from '../../utils';
-import { StocktakeAction, Stocktake } from '../../types';
 
 export interface StocktakeStateShape {
   draft: StocktakeController;
@@ -34,6 +37,12 @@ const StocktakeActionCreator = {
   updateOnHold: (): StocktakeAction => {
     return {
       type: StocktakeActionType.UpdateOnHold,
+    };
+  },
+  updateStatus: (newStatus: StocktakeNodeStatus): StocktakeAction => {
+    return {
+      type: StocktakeActionType.UpdateStatus,
+      payload: { newStatus },
     };
   },
 };
@@ -73,6 +82,8 @@ export const reducer = (
             updateOnHold: () => {
               dispatch(StocktakeActionCreator.updateOnHold());
             },
+            updateStatus: (newStatus: StocktakeNodeStatus) =>
+              dispatch(StocktakeActionCreator.updateStatus(newStatus)),
           };
 
           break;
@@ -101,6 +112,13 @@ export const reducer = (
 
         case StocktakeActionType.UpdateOnHold: {
           state.draft.onHold = !state.draft.onHold;
+          break;
+        }
+
+        case StocktakeActionType.UpdateStatus: {
+          // TODO: Probably there should be some more checks here for
+          // finalising
+          state.draft.status = action.payload.newStatus;
           break;
         }
       }

--- a/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router';
 import {
+  StocktakeNodeStatus,
   DataTable,
   useColumns,
   useListData,
@@ -9,16 +10,19 @@ import {
   useNotification,
   generateUUID,
   useOmSupplyApi,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { getStocktakeListViewApi } from './api';
 import { StocktakeRow } from '../../types';
+import { getStocktakeTranslator } from '../../utils';
 
 export const StocktakeListView: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const { api } = useOmSupplyApi();
+  const t = useTranslation('inventory');
 
   const {
     totalCount,
@@ -40,10 +44,17 @@ export const StocktakeListView: FC = () => {
     getStocktakeListViewApi(api)
   );
 
+  const statusTranslator = getStocktakeTranslator(t);
+
   const columns = useColumns<StocktakeRow>(
     [
       'stocktakeNumber',
-      'status',
+      [
+        'status',
+        {
+          formatter: status => statusTranslator(status as StocktakeNodeStatus),
+        },
+      ],
       'description',
       'comment',
       'stocktakeDatetime',

--- a/packages/inventory/src/types.ts
+++ b/packages/inventory/src/types.ts
@@ -1,5 +1,5 @@
 import { StocktakeLineNode } from './../../common/src/types/schema';
-import { StocktakeNode } from '@openmsupply-client/common';
+import { StocktakeNode, StocktakeNodeStatus } from '@openmsupply-client/common';
 
 export type StocktakeRow = Pick<
   StocktakeNode,
@@ -40,12 +40,14 @@ export interface StocktakeController extends Omit<Stocktake, 'lines'> {
   update: (key: string, value: string) => void;
   updateStocktakeDatetime: (newDate: Date | null) => void;
   updateOnHold: () => void;
+  updateStatus: (newStatus: StocktakeNodeStatus) => void;
 }
 
 export enum StocktakeActionType {
   Update = 'Stocktake/Update',
   UpdateStocktakeDatetime = 'Stocktake/UpdateStocktakeDatetime',
   UpdateOnHold = 'Stocktake/UpdateOnHold',
+  UpdateStatus = 'Stocktake/UpdateStatus',
 }
 
 export type StocktakeAction =
@@ -59,4 +61,8 @@ export type StocktakeAction =
     }
   | {
       type: StocktakeActionType.UpdateOnHold;
+    }
+  | {
+      type: StocktakeActionType.UpdateStatus;
+      payload: { newStatus: StocktakeNodeStatus };
     };

--- a/packages/inventory/src/utils.ts
+++ b/packages/inventory/src/utils.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from './../../common/src/intl/intlHelpers';
 import { StocktakeNodeStatus } from '@openmsupply-client/common';
 import { StocktakeItem, StocktakeLine, StocktakeController } from './types';
 
@@ -6,7 +7,7 @@ export const placeholderStocktake: StocktakeController = {
   comment: '',
   description: '',
   lines: [],
-  status: StocktakeNodeStatus.Draft,
+  status: StocktakeNodeStatus.Suggested,
   stocktakeDatetime: null,
   stocktakeNumber: 0,
   enteredByName: '',
@@ -36,8 +37,7 @@ export const flattenStocktakeItems = (
 };
 
 export const getStocktakeStatuses = (): StocktakeNodeStatus[] => [
-  StocktakeNodeStatus.Draft,
-  StocktakeNodeStatus.Confirmed,
+  StocktakeNodeStatus.Suggested,
   StocktakeNodeStatus.Finalised,
 ];
 
@@ -59,6 +59,11 @@ export const getNextStocktakeStatus = (
 // TODO: When stocktake statuses are finalised, this function should be passed
 // `t` and should properly translate the status.
 export const getStocktakeTranslator =
-  () =>
-  (currentStatus: StocktakeNodeStatus): string =>
-    currentStatus;
+  (t: ReturnType<typeof useTranslation>) =>
+  (currentStatus: StocktakeNodeStatus): string => {
+    if (currentStatus === StocktakeNodeStatus.Suggested) {
+      return t('label.suggested', { ns: 'inventory' });
+    }
+
+    return t('label.finalised', { ns: 'inventory' });
+  };

--- a/packages/mock-server/src/data/data.ts
+++ b/packages/mock-server/src/data/data.ts
@@ -690,7 +690,10 @@ const createStocktake = (): Stocktake => {
     stocktakeDatetime: faker.date.past(1.5).toISOString(),
     comment: takeRandomElementFrom(comments),
     description: takeRandomElementFrom(comments),
-    status: StocktakeNodeStatus.Draft,
+    status: takeRandomElementFrom([
+      StocktakeNodeStatus.Suggested,
+      StocktakeNodeStatus.Finalised,
+    ]),
     entryDatetime: faker.date.past(1.5).toISOString(),
     enteredByName: randomName(),
     onHold: faker.datatype.boolean(),

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -141,7 +141,7 @@ export const stocktake = {
   },
   insert: (input: InsertStocktakeInput): Stocktake => {
     const stocktakeNumber = faker.datatype.number({ max: 1000 });
-    const status = StocktakeNodeStatus.Draft;
+    const status = StocktakeNodeStatus.Suggested;
 
     const stocktake = {
       ...input,


### PR DESCRIPTION
Fixes #584 

- Just using suggested/finalised which is what I think msupply is using. I prefer new/finalised, so I thought if I used suggested/finalised then there would be more chance to lock in draft
- Added translations for the detail view and list view
- Made the next status button work