### PR TITLE
#585 Add item columns and summary items to stocktake detail view

### DIFF
--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -127,5 +127,7 @@
   "link.history": "History",
   "placeholder.enter-a-customers-name": "Enter a customers name",
   "placeholder.enter-a-suppliers-name": "Enter a suppliers name",
-  "placeholder.enter-an-item-code-or-name": "Enter item code or name"
+  "placeholder.enter-an-item-code-or-name": "Enter item code or name",
+  "label.counted-num-of-packs": "Counted # of Packs",
+  "label.snapshot-num-of-packs": "Snapshot # of Packs"
 }

--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -1,5 +1,6 @@
 {
     "label.stocktake-date": "Stocktake Date",
     "label.suggested": "Suggested",
-    "label.finalised": "Finalised"
+    "label.finalised": "Finalised",
+    "label.counted-num-of-packs": "Counted # of Packs"
 }

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -57,7 +57,8 @@ const getDefaultAccessor =
   ): ColumnDataAccessor<T> =>
   (row: T) => {
     const key = column.key as keyof T;
-    return row[key];
+    const value = row[key];
+    return typeof value === 'function' ? value() : value;
   };
 
 const getDefaultFormatter = <T extends DomainObject>(

--- a/packages/common/src/utils/arrays/utils.ts
+++ b/packages/common/src/utils/arrays/utils.ts
@@ -1,15 +1,13 @@
-export const ifTheSameElseDefault = <
-  T,
-  K extends keyof T,
-  J extends T[K] | undefined
->(
+export const ifTheSameElseDefault = <T, K extends keyof T, J>(
   someEntities: T[],
   key: K,
   defaultValue: J
-): J => {
-  const value = someEntities[0]?.[key] as J;
-  const allTheSame = someEntities.every(entity => entity[key] === value);
-  return allTheSame && value ? value : defaultValue;
+): J | T[K] => {
+  const value = someEntities[0]?.[key];
+  const allTheSame = someEntities.every(entity => {
+    return entity[key] === value;
+  });
+  return allTheSame && value != undefined ? value : defaultValue;
 };
 
 export const arrayToRecord = <T extends { id: string }>(

--- a/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -22,7 +22,7 @@ export const StocktakeListView: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const { api } = useOmSupplyApi();
-  const t = useTranslation('inventory');
+  const t = useTranslation(['common', 'inventory']);
 
   const {
     totalCount,

--- a/packages/inventory/src/types.ts
+++ b/packages/inventory/src/types.ts
@@ -1,3 +1,4 @@
+import { Column } from './../../common/src/ui/layout/tables/columns/types';
 import { StocktakeLineNode } from './../../common/src/types/schema';
 import { StocktakeNode, StocktakeNodeStatus } from '@openmsupply-client/common';
 
@@ -19,10 +20,15 @@ export interface StocktakeLine extends StocktakeLineNode {
 
 export interface StocktakeItem {
   id: string;
-  itemCode: string;
-  itemName: string;
+  itemCode: () => string;
+  itemName: () => string;
   isDeleted?: boolean;
   lines: StocktakeLine[];
+
+  batch: () => string;
+  expiryDate: () => string;
+  countedNumPacks: () => string;
+  snapshotNumPacks: () => string;
 }
 
 export interface Stocktake
@@ -41,6 +47,7 @@ export interface StocktakeController extends Omit<Stocktake, 'lines'> {
   updateStocktakeDatetime: (newDate: Date | null) => void;
   updateOnHold: () => void;
   updateStatus: (newStatus: StocktakeNodeStatus) => void;
+  sortBy: (column: Column<StocktakeItem>) => void;
 }
 
 export enum StocktakeActionType {
@@ -48,6 +55,7 @@ export enum StocktakeActionType {
   UpdateStocktakeDatetime = 'Stocktake/UpdateStocktakeDatetime',
   UpdateOnHold = 'Stocktake/UpdateOnHold',
   UpdateStatus = 'Stocktake/UpdateStatus',
+  SortBy = 'Stocktake/SortBy',
 }
 
 export type StocktakeAction =
@@ -65,4 +73,8 @@ export type StocktakeAction =
   | {
       type: StocktakeActionType.UpdateStatus;
       payload: { newStatus: StocktakeNodeStatus };
+    }
+  | {
+      type: StocktakeActionType.SortBy;
+      payload: { column: Column<StocktakeItem> };
     };

--- a/packages/mock-server/src/data/data.ts
+++ b/packages/mock-server/src/data/data.ts
@@ -735,7 +735,7 @@ const createStocktakeLines = (): StocktakeLine[] => {
 
   return stocktake
     .map(stocktake => {
-      const stockLineSubset = takeRandomSubsetFrom(stockLines, 10);
+      const stockLineSubset = takeRandomSubsetFrom(stockLines, 100);
       return stockLineSubset.map(seed => {
         const item = getItem(seed.itemId);
         return createStocktakeLine(stocktake.id, item, seed);


### PR DESCRIPTION
Fixes #585 

- At least partly :)
- I am not sure that these columns are right. You could add a bunch of things pack sizes, prices etc. but I though I would just do this for now and get feedback - the pieces are in place to lock in/add columns
- The sorting isn't working well. I started adding it and realised that I would need a new sorting function that needs to account for the `[multiple]` values but wanted to check in to see what would be best for that. Determining the aggregated value of the column (for say, counted number of packs) and sorting by that value (which doesn't work for say, batch) or just sorting all the `[multiple]` as either the 'first' or 'last' values in a sort 🤔 