### PR TITLE
#587 stocktake edit item 1

### DIFF
--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -49,6 +49,7 @@
   "heading.404": "Feeling lost?",
   "heading.actions": "Actions",
   "heading.add-item": "Add Item",
+  "heading.edit-item": "Edit Item",
   "heading.additional-info": "Additional Info",
   "heading.comment": "Comment",
   "heading.description": "Description",

--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -2,5 +2,6 @@
     "label.stocktake-date": "Stocktake Date",
     "label.suggested": "Suggested",
     "label.finalised": "Finalised",
-    "label.counted-num-of-packs": "Counted # of Packs"
+    "label.counted-num-of-packs": "Counted # of Packs",
+    "label.add-line": "Add Line"
 }

--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -3,5 +3,6 @@
     "label.suggested": "Suggested",
     "label.finalised": "Finalised",
     "label.counted-num-of-packs": "Counted # of Packs",
-    "label.add-line": "Add Line"
+    "label.add-batch": "Add batch",
+    "label.add-new-line": "Add a new line"
 }

--- a/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
@@ -88,7 +88,7 @@ export const DetailView: FC = () => {
   };
 
   const onOK = () => {
-    // modalState.item && draft.upsertItem?.(modalState.item);
+    modalState.item && draft.upsertItem(modalState.item);
     hideDialog();
   };
 

--- a/packages/inventory/src/Stocktake/DetailView/api.ts
+++ b/packages/inventory/src/Stocktake/DetailView/api.ts
@@ -41,7 +41,7 @@ const createUpdateStocktakeInput = (
   return {
     description: patch.description,
     status: patch.status,
-    stocktakeDatetime: patch.stocktakeDatetime.toISOString(),
+    stocktakeDatetime: patch.stocktakeDatetime?.toISOString(),
     comment: patch.comment,
     id: patch.id,
     onHold: !!patch.onHold,

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { StocktakeController, StocktakeItem } from '../../../../types';
+import { ModalMode } from '../../DetailView';
+
+interface StocktakeLineEditProps {
+  item: StocktakeItem | null;
+  onChangeItem: (item: StocktakeItem | null) => void;
+  mode: ModalMode;
+  draft: StocktakeController;
+}
+
+export const StocktakeLineEdit: FC<StocktakeLineEditProps> = () => null;

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -2,6 +2,23 @@ import React, { FC } from 'react';
 import { StocktakeController, StocktakeItem } from '../../../../types';
 import { ModalMode } from '../../DetailView';
 import { StocktakeLineEditForm } from './StocktakeLineEditForm';
+import {
+  Divider,
+  TableContainer,
+  TabContext,
+  TabList,
+  Tab,
+  alpha,
+  TabPanel,
+  styled,
+  useTranslation,
+  useIsMediumScreen,
+  ButtonWithIcon,
+  PlusCircleIcon,
+  Box,
+} from '@openmsupply-client/common';
+import { BatchTable, PricingTable } from './StocktakeLineEditTables';
+import { createStocktakeRow, wrapStocktakeItem } from './utils';
 
 interface StocktakeLineEditProps {
   item: StocktakeItem | null;
@@ -10,16 +27,105 @@ interface StocktakeLineEditProps {
   draft: StocktakeController;
 }
 
+const StyledTabPanel = styled(TabPanel)({
+  height: '100%',
+});
+
+enum Tabs {
+  Batch = 'Batch',
+  Pricing = 'Pricing',
+}
+
 export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   item,
   draft,
   onChangeItem,
   mode,
-}) => (
-  <StocktakeLineEditForm
-    item={item}
-    onChangeItem={onChangeItem}
-    mode={mode}
-    draft={draft}
-  />
-);
+}) => {
+  const [currentTab, setCurrentTab] = React.useState<Tabs>(Tabs.Batch);
+  const isMediumScreen = useIsMediumScreen();
+  const t = useTranslation(['common', 'inventory']);
+
+  const wrappedStocktakeItem = item
+    ? wrapStocktakeItem(item, onChangeItem)
+    : null;
+
+  const batches = wrappedStocktakeItem ? wrappedStocktakeItem.lines : [];
+
+  const onAddBatch = () => {
+    if (wrappedStocktakeItem) {
+      wrappedStocktakeItem.upsertLine?.(
+        createStocktakeRow(wrappedStocktakeItem)
+      );
+    }
+  };
+
+  return (
+    <>
+      <StocktakeLineEditForm
+        item={item}
+        onChangeItem={onChangeItem}
+        mode={mode}
+        draft={draft}
+      />
+      <Divider margin={5} />
+      {item ? (
+        <TabContext value={currentTab}>
+          <Box flex={1} display="flex" justifyContent="space-between">
+            <Box flex={1} />
+            <Box flex={1}>
+              <TabList
+                value={currentTab}
+                centered
+                onChange={(_, v) => setCurrentTab(v)}
+              >
+                <Tab value={Tabs.Batch} label={Tabs.Batch} />
+                <Tab value={Tabs.Pricing} label={Tabs.Pricing} />
+              </TabList>
+            </Box>
+            <Box flex={1} justifyContent="flex-end" display="flex">
+              <ButtonWithIcon
+                color="primary"
+                variant="outlined"
+                onClick={onAddBatch}
+                label={t('label.add-line')}
+                Icon={<PlusCircleIcon />}
+              />
+            </Box>
+          </Box>
+
+          <TableContainer
+            sx={{
+              height: isMediumScreen ? 300 : 400,
+              marginTop: 2,
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: 'divider',
+              borderRadius: '20px',
+            }}
+          >
+            <Box
+              sx={{
+                width: 400,
+                height: isMediumScreen ? 300 : 400,
+                backgroundColor: theme =>
+                  alpha(theme.palette['background']['menu'], 0.4),
+                position: 'absolute',
+                borderRadius: '20px',
+              }}
+            />
+            <StyledTabPanel value={Tabs.Batch}>
+              <BatchTable batches={batches} />
+            </StyledTabPanel>
+
+            <StyledTabPanel value={Tabs.Pricing}>
+              <PricingTable batches={batches} />
+            </StyledTabPanel>
+          </TableContainer>
+        </TabContext>
+      ) : (
+        <Box sx={{ height: isMediumScreen ? 400 : 500 }} />
+      )}
+    </>
+  );
+};

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -88,7 +88,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                 color="primary"
                 variant="outlined"
                 onClick={onAddBatch}
-                label={t('label.add-line', { ns: 'inventory' })}
+                label={t('label.add-batch', { ns: 'inventory' })}
                 Icon={<PlusCircleIcon />}
               />
             </Box>

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -88,7 +88,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                 color="primary"
                 variant="outlined"
                 onClick={onAddBatch}
-                label={t('label.add-line')}
+                label={t('label.add-line', { ns: 'inventory' })}
                 Icon={<PlusCircleIcon />}
               />
             </Box>

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import { StocktakeController, StocktakeItem } from '../../../../types';
 import { ModalMode } from '../../DetailView';
+import { StocktakeLineEditForm } from './StocktakeLineEditForm';
 
 interface StocktakeLineEditProps {
   item: StocktakeItem | null;
@@ -9,4 +10,16 @@ interface StocktakeLineEditProps {
   draft: StocktakeController;
 }
 
-export const StocktakeLineEdit: FC<StocktakeLineEditProps> = () => null;
+export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
+  item,
+  draft,
+  onChangeItem,
+  mode,
+}) => (
+  <StocktakeLineEditForm
+    item={item}
+    onChangeItem={onChangeItem}
+    mode={mode}
+    draft={draft}
+  />
+);

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -21,6 +21,7 @@ const itemToStocktakeItem = (item: Item): StocktakeItem => {
     snapshotNumPacks: () => '',
     lines: [],
     batch: () => '',
+    upsertLine: () => {},
   };
 };
 

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -1,0 +1,84 @@
+import React, { FC } from 'react';
+import {
+  Item,
+  ModalRow,
+  ModalLabel,
+  Grid,
+  useTranslation,
+  BasicTextInput,
+} from '@openmsupply-client/common';
+import { ItemSearchInput } from '@openmsupply-client/system';
+import { StocktakeController, StocktakeItem } from '../../../../types';
+import { ModalMode } from '../../DetailView';
+
+const itemToStocktakeItem = (item: Item): StocktakeItem => {
+  return {
+    id: item.id,
+    itemCode: () => item.code,
+    itemName: () => item.name,
+    expiryDate: () => '',
+    countedNumPacks: () => '',
+    snapshotNumPacks: () => '',
+    lines: [],
+    batch: () => '',
+  };
+};
+
+interface InboundLineEditProps {
+  item: StocktakeItem | null;
+  mode: ModalMode;
+  onChangeItem: (item: StocktakeItem) => void;
+  draft: StocktakeController;
+}
+
+export const StocktakeLineEditForm: FC<InboundLineEditProps> = ({
+  item,
+  mode,
+  onChangeItem,
+  draft,
+}) => {
+  const t = useTranslation(['common', 'inventory']);
+
+  return (
+    <>
+      <ModalRow>
+        <ModalLabel label={t('label.item')} />
+        <Grid item flex={1}>
+          <ItemSearchInput
+            disabled={mode === ModalMode.Update}
+            currentItem={{
+              id: item?.id ?? '',
+              name: item?.itemName() ?? '',
+              code: item?.itemCode() ?? '',
+              isVisible: true,
+              availableBatches: [],
+              unitName: '',
+              availableQuantity: 0,
+            }}
+            onChange={(newItem: Item | null) =>
+              newItem && onChangeItem(itemToStocktakeItem(newItem))
+            }
+            extraFilter={item => {
+              const itemAlreadyInShipment = draft.lines.some(
+                ({ id, isDeleted }) => id === item.id && !isDeleted
+              );
+              return !itemAlreadyInShipment;
+            }}
+          />
+        </Grid>
+      </ModalRow>
+      {item && (
+        <ModalRow>
+          <Grid style={{ display: 'flex', marginTop: 10 }} flex={1}>
+            <ModalLabel label={t('label.code')} />
+            <BasicTextInput
+              disabled
+              sx={{ width: 150 }}
+              value={item.itemCode()}
+            />
+          </Grid>
+        </ModalRow>
+      )}
+    </>
+  );
+};

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -1,0 +1,66 @@
+import React, { FC } from 'react';
+import {
+  DataTable,
+  useColumns,
+  TextInputCell,
+  getLineLabelColumn,
+  NumberInputCell,
+  CurrencyInputCell,
+} from '@openmsupply-client/common';
+import { StocktakeLine } from '../../../../types';
+
+export const BatchTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
+  const columns = useColumns<StocktakeLine>([
+    getLineLabelColumn(),
+    ['batch', { Cell: TextInputCell, width: 200 }],
+    [
+      'numberOfPacks',
+      {
+        Cell: NumberInputCell,
+        width: 100,
+        label: 'label.num-packs',
+      },
+    ],
+    ['packSize', { Cell: NumberInputCell }],
+
+    'expiryDate',
+  ]);
+
+  return (
+    <DataTable
+      columns={columns}
+      data={batches}
+      noDataMessage="Add a new line"
+      dense
+    />
+  );
+};
+
+export const PricingTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
+  const columns = useColumns<StocktakeLine>([
+    getLineLabelColumn(),
+    ['batch', { Cell: TextInputCell, width: 200 }],
+    ['sellPricePerPack', { Cell: CurrencyInputCell, width: 100 }],
+    ['costPricePerPack', { Cell: CurrencyInputCell, width: 100 }],
+    // [
+    //   'unitQuantity',
+    //   { accessor: rowData => rowData.numberOfPacks * rowData.packSize },
+    // ],
+    // [
+    //   'lineTotal',
+    //   {
+    //     accessor: rowData =>
+    //       rowData.numberOfPacks * rowData.packSize * rowData.costPricePerPack,
+    //   },
+    // ],
+  ]);
+
+  return (
+    <DataTable
+      columns={columns}
+      data={batches}
+      noDataMessage="Add a new line"
+      dense
+    />
+  );
+};

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -6,10 +6,12 @@ import {
   getLineLabelColumn,
   NumberInputCell,
   CurrencyInputCell,
+  useTranslation,
 } from '@openmsupply-client/common';
 import { StocktakeLine } from '../../../../types';
 
 export const BatchTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
+  const t = useTranslation('inventory');
   const columns = useColumns<StocktakeLine>([
     getLineLabelColumn(),
     ['batch', { Cell: TextInputCell, width: 200 }],
@@ -36,13 +38,14 @@ export const BatchTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
     <DataTable
       columns={columns}
       data={batches}
-      noDataMessage="Add a new line"
+      noDataMessage={t('label.add-new-line')}
       dense
     />
   );
 };
 
 export const PricingTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
+  const t = useTranslation('inventory');
   const columns = useColumns<StocktakeLine>([
     getLineLabelColumn(),
     ['batch', { Cell: TextInputCell, width: 200 }],
@@ -54,7 +57,7 @@ export const PricingTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
     <DataTable
       columns={columns}
       data={batches}
-      noDataMessage="Add a new line"
+      noDataMessage={t('label.add-new-line')}
       dense
     />
   );

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -46,8 +46,8 @@ export const PricingTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
   const columns = useColumns<StocktakeLine>([
     getLineLabelColumn(),
     ['batch', { Cell: TextInputCell, width: 200 }],
-    ['sellPricePerPack', { Cell: CurrencyInputCell, width: 100 }],
-    ['costPricePerPack', { Cell: CurrencyInputCell, width: 100 }],
+    ['sellPricePerPack', { Cell: CurrencyInputCell, width: 200 }],
+    ['costPricePerPack', { Cell: CurrencyInputCell, width: 200 }],
   ]);
 
   return (

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -13,16 +13,22 @@ export const BatchTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
   const columns = useColumns<StocktakeLine>([
     getLineLabelColumn(),
     ['batch', { Cell: TextInputCell, width: 200 }],
-    [
-      'numberOfPacks',
-      {
-        Cell: NumberInputCell,
-        width: 100,
-        label: 'label.num-packs',
-      },
-    ],
-    ['packSize', { Cell: NumberInputCell }],
-
+    {
+      key: 'snapshotNumPacks',
+      label: 'label.num-packs',
+      width: 100,
+    },
+    {
+      key: 'snapshotPackSize',
+      label: 'label.pack-size',
+      width: 100,
+    },
+    {
+      key: 'countedNumPacks',
+      label: 'label.counted-num-of-packs',
+      width: 100,
+      Cell: NumberInputCell,
+    },
     'expiryDate',
   ]);
 
@@ -42,17 +48,6 @@ export const PricingTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
     ['batch', { Cell: TextInputCell, width: 200 }],
     ['sellPricePerPack', { Cell: CurrencyInputCell, width: 100 }],
     ['costPricePerPack', { Cell: CurrencyInputCell, width: 100 }],
-    // [
-    //   'unitQuantity',
-    //   { accessor: rowData => rowData.numberOfPacks * rowData.packSize },
-    // ],
-    // [
-    //   'lineTotal',
-    //   {
-    //     accessor: rowData =>
-    //       rowData.numberOfPacks * rowData.packSize * rowData.costPricePerPack,
-    //   },
-    // ],
   ]);
 
   return (

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/index.ts
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/index.ts
@@ -1,0 +1,1 @@
+export * from './StocktakeLineEdit';

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/utils.ts
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/utils.ts
@@ -1,4 +1,5 @@
 import { generateUUID } from '@openmsupply-client/common';
+import { createStocktakeItem } from '../../reducer';
 
 import { StocktakeItem, StocktakeLine } from './../../../../types';
 
@@ -61,7 +62,9 @@ export const wrapStocktakeItem = (
       } else {
         updatedLines.push(line);
       }
-      const updatedItem = { ...seed, lines: updatedLines };
+
+      const updatedItem = createStocktakeItem(seed.id, updatedLines);
+      updatedItem.upsertLine = seed.upsertLine;
 
       updater(updatedItem);
     },

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/utils.ts
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/utils.ts
@@ -1,0 +1,73 @@
+import { generateUUID } from '@openmsupply-client/common';
+
+import { StocktakeItem, StocktakeLine } from './../../../../types';
+
+export const createStocktakeRow = (
+  stocktakeItem: StocktakeItem,
+  seed?: StocktakeLine
+): StocktakeLine => {
+  const id = generateUUID();
+  const row = {
+    id,
+    batch: '',
+    costPricePerPack: 0,
+    sellPricePerPack: 0,
+    expiryDate: undefined,
+    itemId: stocktakeItem.id,
+    itemCode: stocktakeItem.itemCode(),
+    itemName: stocktakeItem.itemName(),
+    snapshotNumPacks: undefined,
+    snapshotPackSize: undefined,
+    countedNumPacks: undefined,
+    isCreated: !seed,
+    isUpdated: false,
+    isDeleted: false,
+    ...seed,
+    update: (key: string, value: string) => {
+      if (key === 'batch') {
+        row.batch = value;
+      }
+      if (key === 'countedNumPacks') {
+        row.countedNumPacks = Number(value);
+      }
+
+      if (key === 'costPricePerPack') {
+        row.costPricePerPack = Number(value);
+      }
+      if (key === 'sellPricePerPack') {
+        row.sellPricePerPack = Number(value);
+      }
+
+      row.isUpdated = true;
+
+      stocktakeItem.upsertLine?.(row);
+    },
+  };
+
+  return row;
+};
+
+export const wrapStocktakeItem = (
+  seed: StocktakeItem,
+  updater: (item: StocktakeItem | null) => void
+): StocktakeItem => {
+  const wrapped = {
+    ...seed,
+    upsertLine: (line: StocktakeLine) => {
+      const updatedLines = [...seed.lines];
+      const idx = updatedLines.findIndex(l => l.id === line.id);
+      if (idx !== -1) {
+        updatedLines[idx] = line;
+      } else {
+        updatedLines.push(line);
+      }
+      const updatedItem = { ...seed, lines: updatedLines };
+
+      updater(updatedItem);
+    },
+  };
+
+  const lines = seed.lines.map(batch => createStocktakeRow(wrapped, batch));
+
+  return { ...wrapped, lines };
+};

--- a/packages/inventory/src/Stocktake/DetailView/reducer.ts
+++ b/packages/inventory/src/Stocktake/DetailView/reducer.ts
@@ -53,6 +53,10 @@ export const StocktakeActionCreator = {
     type: StocktakeActionType.SortBy,
     payload: { column },
   }),
+  upsertItem: (item: StocktakeItem): StocktakeAction => ({
+    type: StocktakeActionType.Upsert,
+    payload: { item },
+  }),
 };
 
 export const getInitialState = (): StocktakeStateShape => ({
@@ -75,7 +79,7 @@ const toLookup = <T, K extends keyof T & string>(
   return lookup;
 };
 
-const createStocktakeItem = (
+export const createStocktakeItem = (
   id: string,
   lines: StocktakeLine[]
 ): StocktakeItem => {
@@ -134,6 +138,8 @@ export const reducer = (
               dispatch(StocktakeActionCreator.updateStatus(newStatus)),
             sortBy: (column: Column<StocktakeItem>) =>
               dispatch(StocktakeActionCreator.sortBy(column)),
+            upsertItem: (item: StocktakeItem) =>
+              dispatch(StocktakeActionCreator.upsertItem(item)),
           };
 
           break;
@@ -199,6 +205,17 @@ export const reducer = (
 
           draft.lines = sortedLines;
           state.sortBy = newSortBy;
+
+          break;
+        }
+
+        case StocktakeActionType.Upsert: {
+          const { payload } = action;
+          const { item } = payload;
+
+          const itemIdx = state.draft.lines.findIndex(i => i.id === item.id);
+          if (itemIdx >= 0) state.draft.lines[itemIdx] = item;
+          else state.draft.lines.push(item);
 
           break;
         }

--- a/packages/inventory/src/Stocktake/DetailView/reducer.ts
+++ b/packages/inventory/src/Stocktake/DetailView/reducer.ts
@@ -90,6 +90,7 @@ const createStocktakeItem = (
       String(ifTheSameElseDefault(lines, 'countedNumPacks', '[multiple]')),
     snapshotNumPacks: () =>
       String(ifTheSameElseDefault(lines, 'snapshotNumPacks', '[multiple]')),
+    upsertLine: () => {},
   };
 };
 

--- a/packages/inventory/src/types.ts
+++ b/packages/inventory/src/types.ts
@@ -16,6 +16,7 @@ export interface StocktakeLine extends StocktakeLineNode {
   isCreated?: boolean;
   isDeleted?: boolean;
   isUpdated?: boolean;
+  update: (key: string, value: string) => void;
 }
 
 export interface StocktakeItem {
@@ -29,6 +30,7 @@ export interface StocktakeItem {
   expiryDate: () => string;
   countedNumPacks: () => string;
   snapshotNumPacks: () => string;
+  upsertLine: (line: StocktakeLine) => void;
 }
 
 export interface Stocktake

--- a/packages/inventory/src/types.ts
+++ b/packages/inventory/src/types.ts
@@ -50,6 +50,7 @@ export interface StocktakeController extends Omit<Stocktake, 'lines'> {
   updateOnHold: () => void;
   updateStatus: (newStatus: StocktakeNodeStatus) => void;
   sortBy: (column: Column<StocktakeItem>) => void;
+  upsertItem: (item: StocktakeItem) => void;
 }
 
 export enum StocktakeActionType {
@@ -58,6 +59,7 @@ export enum StocktakeActionType {
   UpdateOnHold = 'Stocktake/UpdateOnHold',
   UpdateStatus = 'Stocktake/UpdateStatus',
   SortBy = 'Stocktake/SortBy',
+  Upsert = 'Stocktake/Upsert',
 }
 
 export type StocktakeAction =
@@ -79,4 +81,8 @@ export type StocktakeAction =
   | {
       type: StocktakeActionType.SortBy;
       payload: { column: Column<StocktakeItem> };
+    }
+  | {
+      type: StocktakeActionType.Upsert;
+      payload: { item: StocktakeItem };
     };

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/utils.ts
@@ -1,7 +1,6 @@
-import { generateUUID, arrayToRecord } from '@openmsupply-client/common';
+import { generateUUID, arrayToRecord, Item } from '@openmsupply-client/common';
 import { InboundShipmentItem, InboundShipmentRow } from '../../../../types';
 import { recalculateSummary } from '../../../../OutboundShipment/DetailView/reducer';
-import { Item } from '@openmsupply-client/mock-server/src/data';
 
 export const createInboundShipmentBatch = (
   inboundItem: InboundShipmentItem,


### PR DESCRIPTION
Fixes #587 

- Bit more substance to this one!
![image](https://user-images.githubusercontent.com/35858975/144725858-3c5ec463-edd1-4af1-baf3-3a709d3bc424.png)
- This is adding a pretty basic stocktake edit modal similar to inbounds

TODO: Creating stocktake lines from existing stock lines. 
- I am thinking either having some sort of list which shows existing stock lines (maybe on the left or right of the modal..?) where you can check the stock lines and this adds a stocktake line to the item OR just creating the stock lines and if they're not counted then they get pruned (mobile style) OR having a column "Count this line" (more explicit but doesn't make sense for newly added lines) OR a combo box with tags

🤷  Not sure. Probably need to play around with some options