### PR TITLE
#589 requisition order and requisition dates

### DIFF
--- a/packages/common/src/intl/locales/en/distribution.json
+++ b/packages/common/src/intl/locales/en/distribution.json
@@ -15,5 +15,7 @@
   "label.num-packs": "# Packs",
   "label.packs-to-batches-with": "packs to batches with a pack size of",
   "label.placeholder": "Placeholder",
-  "label.add-batch": "Add batch"
+  "label.add-batch": "Add batch",
+  "label.order-date": "Order date",
+  "label.requisition-date": "Requisition date"
 }

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -403,6 +403,7 @@ query requisition($id: String!) {
       __typename
       id
       orderDate
+      requisitionDate
       comment
       theirReference
       type

--- a/packages/common/src/schema.graphql
+++ b/packages/common/src/schema.graphql
@@ -1687,6 +1687,7 @@ type DeleteCustomerRequisitionLineResponseWithId {
 input UpdateCustomerRequisitionInput {
   id: String!
   orderDate: String
+  requisitionDate: String
   otherPartyId: String
   comment: String
   theirReference: String

--- a/packages/common/src/schema.graphql
+++ b/packages/common/src/schema.graphql
@@ -1273,7 +1273,8 @@ type UpdateOutboundShipmentResponseWithId {
 
 type RequisitionNode {
   id: String!
-  orderDate: String
+  orderDate: DateTime
+  requisitionDate: DateTime
   comment: String
   theirReference: String
   type: RequisitionNodeType

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -1426,10 +1426,11 @@ export type RequisitionNode = {
   id: Scalars['String'];
   lines: RequisitionLinesResponse;
   maxMOS?: Maybe<Scalars['Int']>;
-  orderDate?: Maybe<Scalars['String']>;
+  orderDate?: Maybe<Scalars['DateTime']>;
   otherParty: NameResponse;
   otherPartyId: Scalars['String'];
   otherPartyName: Scalars['String'];
+  requisitionDate?: Maybe<Scalars['DateTime']>;
   requisitionNumber: Scalars['Int'];
   status: SupplierRequisitionNodeStatus;
   theirReference?: Maybe<Scalars['String']>;
@@ -1982,7 +1983,7 @@ export type RequisitionQueryVariables = Exact<{
 }>;
 
 
-export type RequisitionQuery = { __typename?: 'Queries', requisition: { __typename: 'NodeError' } | { __typename: 'RequisitionNode', id: string, orderDate?: string | null | undefined, comment?: string | null | undefined, theirReference?: string | null | undefined, type?: RequisitionNodeType | null | undefined, requisitionNumber: number, thresholdMOS?: number | null | undefined, maxMOS?: number | null | undefined, status: SupplierRequisitionNodeStatus, otherPartyId: string, lines: { __typename: 'ConnectorError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'PaginationError', description: string } } | { __typename: 'RequisitionLineConnector', totalCount: number, nodes: Array<{ __typename?: 'RequisitionLineNode', id: string, itemName?: string | null | undefined, itemCode?: string | null | undefined, itemUnit?: string | null | undefined, itemId: string, comment?: string | null | undefined, monthlyConsumption?: number | null | undefined, monthsOfSupply?: number | null | undefined, supplyQuantity?: number | null | undefined, openingQuantity?: number | null | undefined, issuedQuantity?: number | null | undefined, requestedQuantity?: number | null | undefined, receivedQuantity?: number | null | undefined, imprestQuantity?: number | null | undefined, previousQuantity?: number | null | undefined, calculatedQuantity?: number | null | undefined, previousStockOnHand?: number | null | undefined, closingQuantity?: number | null | undefined, stockAdditions?: number | null | undefined, stockLosses?: number | null | undefined, expiredQuantity?: number | null | undefined, otherPartyClosingQuantity?: number | null | undefined }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean } | { __typename: 'NodeError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'RecordNotFound', description: string } } } };
+export type RequisitionQuery = { __typename?: 'Queries', requisition: { __typename: 'NodeError' } | { __typename: 'RequisitionNode', id: string, orderDate?: string | null | undefined, requisitionDate?: string | null | undefined, comment?: string | null | undefined, theirReference?: string | null | undefined, type?: RequisitionNodeType | null | undefined, requisitionNumber: number, thresholdMOS?: number | null | undefined, maxMOS?: number | null | undefined, status: SupplierRequisitionNodeStatus, otherPartyId: string, lines: { __typename: 'ConnectorError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'PaginationError', description: string } } | { __typename: 'RequisitionLineConnector', totalCount: number, nodes: Array<{ __typename?: 'RequisitionLineNode', id: string, itemName?: string | null | undefined, itemCode?: string | null | undefined, itemUnit?: string | null | undefined, itemId: string, comment?: string | null | undefined, monthlyConsumption?: number | null | undefined, monthsOfSupply?: number | null | undefined, supplyQuantity?: number | null | undefined, openingQuantity?: number | null | undefined, issuedQuantity?: number | null | undefined, requestedQuantity?: number | null | undefined, receivedQuantity?: number | null | undefined, imprestQuantity?: number | null | undefined, previousQuantity?: number | null | undefined, calculatedQuantity?: number | null | undefined, previousStockOnHand?: number | null | undefined, closingQuantity?: number | null | undefined, stockAdditions?: number | null | undefined, stockLosses?: number | null | undefined, expiredQuantity?: number | null | undefined, otherPartyClosingQuantity?: number | null | undefined }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean } | { __typename: 'NodeError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'RecordNotFound', description: string } } } };
 
 export type UpsertSupplierRequisitionMutationVariables = Exact<{
   deleteSupplierRequisitionLines?: Maybe<Array<DeleteSupplierRequisitionLineInput> | DeleteSupplierRequisitionLineInput>;
@@ -2487,6 +2488,7 @@ export const RequisitionDocument = gql`
       __typename
       id
       orderDate
+      requisitionDate
       comment
       theirReference
       type

--- a/packages/mock-server/src/data/data.ts
+++ b/packages/mock-server/src/data/data.ts
@@ -576,6 +576,7 @@ const createRequisition = (
     requisitionNumber: faker.datatype.number({ max: 1000 }),
     otherPartyId: otherParty.id,
     orderDate: faker.date.past(1.5).toISOString(),
+    requisitionDate: faker.date.past(1.5).toISOString(),
     type,
     maxMOS: 3,
     thresholdMOS: 3,

--- a/packages/requisitions/src/CustomerRequisition/DetailView/SidePanel.tsx
+++ b/packages/requisitions/src/CustomerRequisition/DetailView/SidePanel.tsx
@@ -13,8 +13,6 @@ import {
   PanelRow,
   PanelField,
   ColorSelectButton,
-  useFormatDate,
-  DatePickerInput,
 } from '@openmsupply-client/common';
 import { isRequisitionEditable } from '../../utils';
 import { CustomerRequisition } from '../../types';
@@ -61,24 +59,6 @@ const RelatedDocumentsSection: FC<SidePanelProps> = () => {
   );
 };
 
-const DatesSection: FC<SidePanelProps> = ({ draft }) => {
-  const t = useTranslation(['common', 'distribution']);
-  const d = useFormatDate();
-  return (
-    <DetailPanelSection
-      title={t('heading.related-documents', { ns: 'distribution' })}
-    >
-      <Grid container gap={0.5}>
-        <PanelRow>
-          <PanelLabel>Order date:</PanelLabel>
-
-          <DatePickerInput value={draft.orderDate} onChange={() => {}} />
-        </PanelRow>
-      </Grid>
-    </DetailPanelSection>
-  );
-};
-
 export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
   const { success } = useNotification();
   const t = useTranslation(['outbound-shipment', 'common']);
@@ -114,7 +94,6 @@ export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
       }
     >
       <AdditionalInfoSection draft={draft} />
-      <DatesSection draft={draft} />
       <RelatedDocumentsSection draft={draft} />
     </DetailPanelPortal>
   );

--- a/packages/requisitions/src/CustomerRequisition/DetailView/SidePanel.tsx
+++ b/packages/requisitions/src/CustomerRequisition/DetailView/SidePanel.tsx
@@ -13,6 +13,8 @@ import {
   PanelRow,
   PanelField,
   ColorSelectButton,
+  useFormatDate,
+  DatePickerInput,
 } from '@openmsupply-client/common';
 import { isRequisitionEditable } from '../../utils';
 import { CustomerRequisition } from '../../types';
@@ -59,6 +61,24 @@ const RelatedDocumentsSection: FC<SidePanelProps> = () => {
   );
 };
 
+const DatesSection: FC<SidePanelProps> = ({ draft }) => {
+  const t = useTranslation(['common', 'distribution']);
+  const d = useFormatDate();
+  return (
+    <DetailPanelSection
+      title={t('heading.related-documents', { ns: 'distribution' })}
+    >
+      <Grid container gap={0.5}>
+        <PanelRow>
+          <PanelLabel>Order date:</PanelLabel>
+
+          <DatePickerInput value={draft.orderDate} onChange={() => {}} />
+        </PanelRow>
+      </Grid>
+    </DetailPanelSection>
+  );
+};
+
 export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
   const { success } = useNotification();
   const t = useTranslation(['outbound-shipment', 'common']);
@@ -94,6 +114,7 @@ export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
       }
     >
       <AdditionalInfoSection draft={draft} />
+      <DatesSection draft={draft} />
       <RelatedDocumentsSection draft={draft} />
     </DetailPanelPortal>
   );

--- a/packages/requisitions/src/CustomerRequisition/DetailView/Toolbar.tsx
+++ b/packages/requisitions/src/CustomerRequisition/DetailView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   useTranslation,
   useNotification,
   useTableStore,
+  DatePickerInput,
 } from '@openmsupply-client/common';
 import { NameSearchInput } from '@openmsupply-client/system/src/Name';
 import { CustomerRequisition, CustomerRequisitionLine } from '../../types';
@@ -51,34 +52,62 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
         alignItems="flex-end"
       >
         <Grid item display="flex" flex={1}>
-          <Box display="flex" flex={1} flexDirection="column" gap={1}>
-            {draft.otherParty && (
+          <Box display="flex" flexDirection="row" gap={4}>
+            <Box display="flex" flex={1} flexDirection="column" gap={1}>
+              {draft.otherParty && (
+                <InputWithLabelRow
+                  label={t('label.customer-name')}
+                  Input={
+                    <NameSearchInput
+                      type="customer"
+                      disabled={!isRequisitionEditable(draft)}
+                      value={draft.otherParty}
+                      onChange={name => {
+                        draft.updateOtherParty(name);
+                      }}
+                    />
+                  }
+                />
+              )}
               <InputWithLabelRow
-                label={t('label.customer-name')}
+                label={t('label.customer-ref')}
                 Input={
-                  <NameSearchInput
-                    type="customer"
+                  <BasicTextInput
                     disabled={!isRequisitionEditable(draft)}
-                    value={draft.otherParty}
-                    onChange={name => {
-                      draft.updateOtherParty(name);
-                    }}
+                    size="small"
+                    sx={{ width: 250 }}
+                    value={draft.theirReference}
+                    onChange={e =>
+                      draft.update('theirReference', e.target.value)
+                    }
                   />
                 }
               />
-            )}
-            <InputWithLabelRow
-              label={t('label.customer-ref')}
-              Input={
-                <BasicTextInput
-                  disabled={!isRequisitionEditable(draft)}
-                  size="small"
-                  sx={{ width: 250 }}
-                  value={draft.theirReference}
-                  onChange={e => draft.update('theirReference', e.target.value)}
+            </Box>
+            <Box display="flex" flex={1} flexDirection="column" gap={1}>
+              {draft.otherParty && (
+                <InputWithLabelRow
+                  label={t('label.order-date')}
+                  Input={
+                    <DatePickerInput
+                      disabled={!isRequisitionEditable(draft)}
+                      value={draft.orderDate}
+                      onChange={draft.updateOrderDate}
+                    />
+                  }
                 />
-              }
-            />
+              )}
+              <InputWithLabelRow
+                label={t('label.requisition-date')}
+                Input={
+                  <DatePickerInput
+                    disabled={!isRequisitionEditable(draft)}
+                    value={draft.requisitionDate}
+                    onChange={draft.updateRequisitionDate}
+                  />
+                }
+              />
+            </Box>
           </Box>
         </Grid>
         <DropdownMenu

--- a/packages/requisitions/src/CustomerRequisition/DetailView/Toolbar.tsx
+++ b/packages/requisitions/src/CustomerRequisition/DetailView/Toolbar.tsx
@@ -85,18 +85,17 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
               />
             </Box>
             <Box display="flex" flex={1} flexDirection="column" gap={1}>
-              {draft.otherParty && (
-                <InputWithLabelRow
-                  label={t('label.order-date')}
-                  Input={
-                    <DatePickerInput
-                      disabled={!isRequisitionEditable(draft)}
-                      value={draft.orderDate}
-                      onChange={draft.updateOrderDate}
-                    />
-                  }
-                />
-              )}
+              <InputWithLabelRow
+                label={t('label.order-date')}
+                Input={
+                  <DatePickerInput
+                    disabled={!isRequisitionEditable(draft)}
+                    value={draft.orderDate}
+                    onChange={draft.updateOrderDate}
+                  />
+                }
+              />
+
               <InputWithLabelRow
                 label={t('label.requisition-date')}
                 Input={

--- a/packages/requisitions/src/CustomerRequisition/DetailView/api.ts
+++ b/packages/requisitions/src/CustomerRequisition/DetailView/api.ts
@@ -54,7 +54,7 @@ const createUpdateCustomerRequisitionInput = (
     comment: patch.comment,
     id: patch.id,
     otherPartyId: patch.otherPartyId,
-    orderDate: patch.orderDate,
+    orderDate: patch.orderDate?.toISOString(),
     theirReference: patch.theirReference,
   };
 };
@@ -101,6 +101,10 @@ export const getCustomerRequisitionDetailViewApi = (
 
     return {
       ...requisition,
+      orderDate: requisition.orderDate ? new Date(requisition.orderDate) : null,
+      requisitionDate: requisition.requisitionDate
+        ? new Date(requisition.requisitionDate)
+        : null,
       lines,
       otherParty,
       otherPartyName: otherParty.name,

--- a/packages/requisitions/src/CustomerRequisition/DetailView/reducer.ts
+++ b/packages/requisitions/src/CustomerRequisition/DetailView/reducer.ts
@@ -32,6 +32,18 @@ const RequisitionActionCreator = {
       payload: { value },
     };
   },
+  updateOrderDate: (value: Date): RequisitionAction => {
+    return {
+      type: RequisitionActionType.UpdateOrderDate,
+      payload: { value },
+    };
+  },
+  updateRequisitionDate: (value: Date): RequisitionAction => {
+    return {
+      type: RequisitionActionType.UpdateRequisitionDate,
+      payload: { value },
+    };
+  },
 };
 
 export const getInitialState = (): CustomerRequisitionStateShape => ({
@@ -66,6 +78,18 @@ export const reducer = (
             dispatch(RequisitionActionCreator.update(key, value));
           };
 
+          state.draft.updateOrderDate = (value: Date) => {
+            dispatch(RequisitionActionCreator.updateOrderDate(value));
+          };
+
+          state.draft.updateRequisitionDate = (value: Date) => {
+            dispatch(RequisitionActionCreator.updateRequisitionDate(value));
+          };
+
+          state.draft.update = (key: string, value: string) => {
+            dispatch(RequisitionActionCreator.update(key, value));
+          };
+
           break;
         }
 
@@ -84,12 +108,22 @@ export const reducer = (
           if (key === 'color') {
             state.draft.color = value as string;
           }
-          if (key === 'orderDate') {
-            state.draft.orderDate = value as string;
-          }
+
           if (key === 'theirReference') {
             state.draft.theirReference = value as string;
           }
+
+          break;
+        }
+
+        case RequisitionActionType.UpdateOrderDate: {
+          state.draft.orderDate = action.payload.value;
+          break;
+        }
+
+        case RequisitionActionType.UpdateRequisitionDate: {
+          state.draft.requisitionDate = action.payload.value;
+          break;
         }
       }
 

--- a/packages/requisitions/src/SupplierRequisition/DetailView/Toolbar.tsx
+++ b/packages/requisitions/src/SupplierRequisition/DetailView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   useTranslation,
   useNotification,
   useTableStore,
+  DatePickerInput,
 } from '@openmsupply-client/common';
 import { NameSearchInput } from '@openmsupply-client/system/src/Name';
 import { SupplierRequisition, SupplierRequisitionLine } from '../../types';
@@ -51,34 +52,50 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
         alignItems="flex-end"
       >
         <Grid item display="flex" flex={1}>
-          <Box display="flex" flex={1} flexDirection="column" gap={1}>
-            {draft.otherParty && (
+          <Box display="flex" flexDirection="row" gap={4}>
+            <Box display="flex" flex={1} flexDirection="column" gap={1}>
+              {draft.otherParty && (
+                <InputWithLabelRow
+                  label={t('label.supplier-name')}
+                  Input={
+                    <NameSearchInput
+                      type="supplier"
+                      disabled={!isRequisitionEditable(draft)}
+                      value={draft.otherParty}
+                      onChange={name => {
+                        draft.updateOtherParty(name);
+                      }}
+                    />
+                  }
+                />
+              )}
               <InputWithLabelRow
-                label={t('label.supplier-name')}
+                label={t('label.supplier-ref')}
                 Input={
-                  <NameSearchInput
-                    type="supplier"
+                  <BasicTextInput
                     disabled={!isRequisitionEditable(draft)}
-                    value={draft.otherParty}
-                    onChange={name => {
-                      draft.updateOtherParty(name);
-                    }}
+                    size="small"
+                    sx={{ width: 250 }}
+                    value={draft.theirReference}
+                    onChange={e =>
+                      draft.update('theirReference', e.target.value)
+                    }
                   />
                 }
               />
-            )}
-            <InputWithLabelRow
-              label={t('label.supplier-ref')}
-              Input={
-                <BasicTextInput
-                  disabled={!isRequisitionEditable(draft)}
-                  size="small"
-                  sx={{ width: 250 }}
-                  value={draft.theirReference}
-                  onChange={e => draft.update('theirReference', e.target.value)}
-                />
-              }
-            />
+            </Box>
+            <Box display="flex" flex={1} flexDirection="column" gap={1}>
+              <InputWithLabelRow
+                label={t('label.requisition-date')}
+                Input={
+                  <DatePickerInput
+                    disabled={!isRequisitionEditable(draft)}
+                    value={draft.requisitionDate}
+                    onChange={draft.updateRequisitionDate}
+                  />
+                }
+              />
+            </Box>
           </Box>
         </Grid>
         <DropdownMenu

--- a/packages/requisitions/src/SupplierRequisition/DetailView/api.ts
+++ b/packages/requisitions/src/SupplierRequisition/DetailView/api.ts
@@ -54,7 +54,7 @@ const createUpdateSupplierRequisitionInput = (
     comment: patch.comment,
     id: patch.id,
     otherPartyId: patch.otherPartyId,
-    orderDate: patch.orderDate,
+    orderDate: patch.orderDate?.toISOString(),
     theirReference: patch.theirReference,
   };
 };
@@ -103,6 +103,10 @@ export const getSupplierRequisitionDetailViewApi = (
       ...requisition,
       lines,
       otherParty,
+      orderDate: requisition.orderDate ? new Date(requisition.orderDate) : null,
+      requisitionDate: requisition.requisitionDate
+        ? new Date(requisition.requisitionDate)
+        : null,
       otherPartyName: otherParty.name,
     };
   },

--- a/packages/requisitions/src/SupplierRequisition/DetailView/reducer.ts
+++ b/packages/requisitions/src/SupplierRequisition/DetailView/reducer.ts
@@ -33,6 +33,12 @@ const RequisitionActionCreator = {
       payload: { value },
     };
   },
+  updateRequisitionDate: (value: Date): RequisitionAction => {
+    return {
+      type: RequisitionActionType.UpdateRequisitionDate,
+      payload: { value },
+    };
+  },
 };
 
 export const getInitialState = (): SupplierRequisitionStateShape => ({
@@ -67,6 +73,10 @@ export const reducer = (
             dispatch(RequisitionActionCreator.update(key, value));
           };
 
+          state.draft.updateRequisitionDate = (value: Date) => {
+            dispatch(RequisitionActionCreator.updateRequisitionDate(value));
+          };
+
           break;
         }
 
@@ -85,12 +95,18 @@ export const reducer = (
           if (key === 'color') {
             state.draft.color = value as string;
           }
-          if (key === 'orderDate') {
-            state.draft.orderDate = value as string;
-          }
+
           if (key === 'theirReference') {
             state.draft.theirReference = value as string;
           }
+
+          break;
+        }
+
+        case RequisitionActionType.UpdateRequisitionDate: {
+          state.draft.requisitionDate = action.payload.value;
+
+          break;
         }
       }
 

--- a/packages/requisitions/src/types.ts
+++ b/packages/requisitions/src/types.ts
@@ -20,9 +20,14 @@ export type RequisitionAction =
     };
 
 export interface Requisition
-  extends Omit<RequisitionNode, '__typename' | 'lines' | 'otherParty'> {
+  extends Omit<
+    RequisitionNode,
+    '__typename' | 'lines' | 'otherParty' | 'orderDate' | 'requisitionDate'
+  > {
   lines: RequisitionLine[];
   otherParty: Name;
+  orderDate: Date | null;
+  requisitionDate: Date | null;
 }
 
 export interface RequisitionRow

--- a/packages/requisitions/src/types.ts
+++ b/packages/requisitions/src/types.ts
@@ -55,6 +55,8 @@ export interface SupplierRequisition extends Requisition {
   lines: SupplierRequisitionLine[];
   update: (key: string, value: string) => void;
   updateOtherParty: (value: Name) => void;
+  updateOrderDate: (value: Date) => void;
+  updateRequisitionDate: (value: Date) => void;
   upsertLine?: (line: SupplierRequisitionLine) => void;
   deleteLine?: (line: SupplierRequisitionLine) => void;
 }

--- a/packages/requisitions/src/types.ts
+++ b/packages/requisitions/src/types.ts
@@ -7,6 +7,8 @@ import {
 export enum RequisitionActionType {
   Update = 'Requisition/Update',
   UpdateOtherParty = 'Requisition/UpdateOtherParty',
+  UpdateOrderDate = 'Requisition/UpdateOrderDate',
+  UpdateRequisitionDate = 'Requisition/UpdateRequisitionDate',
 }
 
 export type RequisitionAction =
@@ -17,6 +19,14 @@ export type RequisitionAction =
   | {
       type: RequisitionActionType.UpdateOtherParty;
       payload: { value: Name };
+    }
+  | {
+      type: RequisitionActionType.UpdateOrderDate;
+      payload: { value: Date };
+    }
+  | {
+      type: RequisitionActionType.UpdateRequisitionDate;
+      payload: { value: Date };
     };
 
 export interface Requisition
@@ -55,6 +65,8 @@ export interface CustomerRequisition extends Requisition {
   lines: CustomerRequisitionLine[];
   update: (key: string, value: string) => void;
   updateOtherParty: (value: Name) => void;
+  updateOrderDate: (value: Date) => void;
+  updateRequisitionDate: (value: Date) => void;
   upsertLine?: (line: CustomerRequisitionLine) => void;
   deleteLine?: (line: CustomerRequisitionLine) => void;
 }

--- a/packages/requisitions/src/utils.ts
+++ b/packages/requisitions/src/utils.ts
@@ -30,6 +30,16 @@ export const placeholderSupplierRequisition: SupplierRequisition = {
       'Placeholder callback updateOtherParty has been triggered. This should never happen!'
     );
   },
+  updateRequisitionDate: () => {
+    throw new Error(
+      'Placeholder callback updateRequisitionDate has been triggered. This should never happen!'
+    );
+  },
+  updateOrderDate: () => {
+    throw new Error(
+      'Placeholder callback updateOrderDate has been triggered. This should never happen!'
+    );
+  },
 };
 
 export const placeholderCustomerRequisition: CustomerRequisition = {

--- a/packages/requisitions/src/utils.ts
+++ b/packages/requisitions/src/utils.ts
@@ -1,7 +1,4 @@
-import {
-  SupplierRequisitionNodeStatus,
-  SupplierRequisitionNodeStatus,
-} from '@openmsupply-client/common';
+import { SupplierRequisitionNodeStatus } from '@openmsupply-client/common';
 
 import { Requisition, SupplierRequisition, CustomerRequisition } from './types';
 
@@ -21,6 +18,8 @@ export const placeholderSupplierRequisition: SupplierRequisition = {
   otherPartyId: '',
   otherPartyName: '',
   status: SupplierRequisitionNodeStatus.Draft,
+  orderDate: null,
+  requisitionDate: null,
   update: () => {
     throw new Error(
       'Placeholder callback update has been triggered. This should never happen!'
@@ -49,6 +48,8 @@ export const placeholderCustomerRequisition: CustomerRequisition = {
   otherPartyId: '',
   otherPartyName: '',
   status: SupplierRequisitionNodeStatus.Draft,
+  orderDate: null,
+  requisitionDate: null,
   update: () => {
     throw new Error(
       'Placeholder callback update has been triggered. This should never happen!'
@@ -57,6 +58,16 @@ export const placeholderCustomerRequisition: CustomerRequisition = {
   updateOtherParty: () => {
     throw new Error(
       'Placeholder callback updateOtherParty has been triggered. This should never happen!'
+    );
+  },
+  updateRequisitionDate: () => {
+    throw new Error(
+      'Placeholder callback updateRequisitionDate has been triggered. This should never happen!'
+    );
+  },
+  updateOrderDate: () => {
+    throw new Error(
+      'Placeholder callback updateOrderDate has been triggered. This should never happen!'
     );
   },
 };


### PR DESCRIPTION
Fixes #589

- Adds requisition + order date inputs to customer requisition
- Adds requisition date input to supplier requisition

I'm not sure where to put these was just trying to tick things off the list. Maybe should have waited for the meeting with dicky. I tried the side panel but thought that at least for customer requisitons that these dates were in a 'primary' position in mSupply so maybe they should go here - then wanted the consistency for supplier requisitions... even though i'm sure programs will throw everything into an inconsistent state