### PR TITLE
#556 update gql schema 2

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: ["./packages/common/src/schema.graphql", "./packages/common/src/additions.schema.graphql"]
+schema: ["https://demo-open.msupply.org:8000/graphql", "./packages/common/src/additions.schema.graphql"]
 documents: './packages/common/src/operations.graphql'
 generates:
   ./packages/common/src/types/schema.ts:

--- a/packages/common/src/additions.schema.graphql
+++ b/packages/common/src/additions.schema.graphql
@@ -662,3 +662,21 @@ type StockCountsConnector {
 
 union InvoiceCountsResponse = InvoiceCountsConnector | ConnectorError
 union StockCountsResponse = StockCountsConnector | ConnectorError
+
+input BatchOutboundShipmentInput {
+  insertOutboundShipments: [InsertOutboundShipmentInput!]
+  insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!]
+  updateOutboundShipmentLines: [UpdateOutboundShipmentLineInput!]
+  deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!]
+  updateOutboundShipments: [UpdateOutboundShipmentInput!]
+  deleteOutboundShipments: [String!]
+}
+
+input BatchInboundShipmentInput {
+  insertOutboundShipments: [InsertInboundShipmentInput!]
+  insertInboundShipmentLines: [InsertInboundShipmentLineInput!]
+  updateInboundShipmentLines: [UpdateInboundShipmentLineInput!]
+  deleteInboundShipmentLines: [DeleteInboundShipmentLineInput!]
+  updateInboundShipments: [UpdateInboundShipmentInput!]
+  deleteInboundShipments: [DeleteInboundShipmentInput!]
+}

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -91,6 +91,46 @@ query invoice($id: String!) {
             numberOfPacks
             packSize
             note
+            item {
+              ... on ItemNode {
+                id
+                name
+                code
+                isVisible
+                availableBatches {
+                  ... on StockLineConnector {
+                    totalCount
+                    nodes {
+                      id
+                      availableNumberOfPacks
+                      costPricePerPack
+                      itemId
+                      onHold
+                      packSize
+                      sellPricePerPack
+                      storeId
+                      totalNumberOfPacks
+                    }
+                  }
+                  ... on ConnectorError {
+                    __typename
+                    error {
+                      description
+                    }
+                  }
+                }
+              }
+              ... on ItemError {
+                __typename
+                error {
+                  ... on InternalError {
+                    __typename
+                    description
+                    fullError
+                  }
+                }
+              }
+            }
 
             # itemUnit
             locationName

--- a/packages/common/src/schema.graphql
+++ b/packages/common/src/schema.graphql
@@ -1104,21 +1104,3 @@ type UpdateOutboundShipmentResponseWithId {
 union UserRegisterResponse = UserRegisterError | RegisteredUser
 
 union UserResponse = UserError | User
-
-input BatchOutboundShipmentInput {
-  insertOutboundShipments: [InsertOutboundShipmentInput!]
-  insertOutboundShipmentLines: [InsertOutboundShipmentLineInput!]
-  updateOutboundShipmentLines: [UpdateOutboundShipmentLineInput!]
-  deleteOutboundShipmentLines: [DeleteOutboundShipmentLineInput!]
-  updateOutboundShipments: [UpdateOutboundShipmentInput!]
-  deleteOutboundShipments: [String!]
-}
-
-input BatchInboundShipmentInput {
-  insertOutboundShipments: [InsertInboundShipmentInput!]
-  insertInboundShipmentLines: [InsertInboundShipmentLineInput!]
-  updateInboundShipmentLines: [UpdateInboundShipmentLineInput!]
-  deleteInboundShipmentLines: [DeleteInboundShipmentLineInput!]
-  updateInboundShipments: [UpdateInboundShipmentInput!]
-  deleteInboundShipments: [DeleteInboundShipmentInput!]
-}

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -13,7 +13,21 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /**
+   * Implement the DateTime<Utc> scalar
+   *
+   * The input/output is a string in RFC3339 format.
+   */
   DateTime: string;
+  /**
+   * ISO 8601 calendar date without timezone.
+   * Format: %Y-%m-%d
+   *
+   * # Examples
+   *
+   * * `1994-11-13`
+   * * `2000-02-24`
+   */
   NaiveDate: string;
 };
 
@@ -25,9 +39,11 @@ export type AccessDenied = LogoutErrorInterface & UserErrorInterface & {
 
 export type AuthToken = {
   __typename?: 'AuthToken';
+  /** Bearer token */
   token: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type AuthTokenError = {
   __typename?: 'AuthTokenError';
   error: AuthTokenErrorInterface;
@@ -58,15 +74,6 @@ export type BatchCustomerRequisitionResponse = {
   updateCustomerRequisitions?: Maybe<Array<UpdateCustomerRequisitionResponseWithId>>;
 };
 
-export type BatchInboundShipmentInput = {
-  deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineInput>>;
-  deleteInboundShipments?: Maybe<Array<DeleteInboundShipmentInput>>;
-  insertInboundShipmentLines?: Maybe<Array<InsertInboundShipmentLineInput>>;
-  insertOutboundShipments?: Maybe<Array<InsertInboundShipmentInput>>;
-  updateInboundShipmentLines?: Maybe<Array<UpdateInboundShipmentLineInput>>;
-  updateInboundShipments?: Maybe<Array<UpdateInboundShipmentInput>>;
-};
-
 export type BatchInboundShipmentResponse = {
   __typename?: 'BatchInboundShipmentResponse';
   deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineResponseWithId>>;
@@ -82,22 +89,16 @@ export type BatchIsReserved = DeleteInboundShipmentLineErrorInterface & UpdateIn
   description: Scalars['String'];
 };
 
-export type BatchOutboundShipmentInput = {
-  deleteOutboundShipmentLines?: Maybe<Array<DeleteOutboundShipmentLineInput>>;
-  deleteOutboundShipments?: Maybe<Array<Scalars['String']>>;
-  insertOutboundShipmentLines?: Maybe<Array<InsertOutboundShipmentLineInput>>;
-  insertOutboundShipments?: Maybe<Array<InsertOutboundShipmentInput>>;
-  updateOutboundShipmentLines?: Maybe<Array<UpdateOutboundShipmentLineInput>>;
-  updateOutboundShipments?: Maybe<Array<UpdateOutboundShipmentInput>>;
-};
-
 export type BatchOutboundShipmentResponse = {
   __typename?: 'BatchOutboundShipmentResponse';
   deleteOutboundShipmentLines?: Maybe<Array<DeleteOutboundShipmentLineResponseWithId>>;
+  deleteOutboundShipmentServiceLines?: Maybe<Array<DeleteOutboundShipmentServiceLineResponseWithId>>;
   deleteOutboundShipments?: Maybe<Array<DeleteOutboundShipmentResponseWithId>>;
   insertOutboundShipmentLines?: Maybe<Array<InsertOutboundShipmentLineResponseWithId>>;
+  insertOutboundShipmentServiceLines?: Maybe<Array<InsertOutboundShipmentServiceLineResponseWithId>>;
   insertOutboundShipments?: Maybe<Array<InsertOutboundShipmentResponseWithId>>;
   updateOutboundShipmentLines?: Maybe<Array<UpdateOutboundShipmentLineResponseWithId>>;
+  updateOutboundShipmentServiceLines?: Maybe<Array<UpdateOutboundShipmentServiceLineResponseWithId>>;
   updateOutboundShipments?: Maybe<Array<UpdateOutboundShipmentResponseWithId>>;
 };
 
@@ -165,11 +166,12 @@ export type CannotDeleteInvoiceWithLines = DeleteInboundShipmentErrorInterface &
   lines: InvoiceLineConnector;
 };
 
-export type CannotEditFinalisedInvoice = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+export type CannotEditFinalisedInvoice = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
   __typename?: 'CannotEditFinalisedInvoice';
   description: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type ConnectorError = {
   __typename?: 'ConnectorError';
   error: ConnectorErrorInterface;
@@ -190,7 +192,7 @@ export enum CustomerRequisitionNodeStatus {
   New = 'NEW'
 }
 
-export type DatabaseError = AuthTokenErrorInterface & ConnectorErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UserErrorInterface & UserRegisterErrorInterface & {
+export type DatabaseError = AuthTokenErrorInterface & ConnectorErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UserErrorInterface & UserRegisterErrorInterface & {
   __typename?: 'DatabaseError';
   description: Scalars['String'];
   fullError: Scalars['String'];
@@ -226,6 +228,7 @@ export type DeleteCustomerRequisitionResponseWithId = {
   response?: Maybe<DeleteCustomerRequisitionResponse>;
 };
 
+/** Generic Error Wrapper */
 export type DeleteInboundShipmentError = {
   __typename?: 'DeleteInboundShipmentError';
   error: DeleteInboundShipmentErrorInterface;
@@ -239,6 +242,7 @@ export type DeleteInboundShipmentInput = {
   id: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type DeleteInboundShipmentLineError = {
   __typename?: 'DeleteInboundShipmentLineError';
   error: DeleteInboundShipmentLineErrorInterface;
@@ -269,6 +273,22 @@ export type DeleteInboundShipmentResponseWithId = {
   response: DeleteInboundShipmentResponse;
 };
 
+export type DeleteLocationError = {
+  __typename?: 'DeleteLocationError';
+  error: DeleteLocationErrorInterface;
+};
+
+export type DeleteLocationErrorInterface = {
+  description: Scalars['String'];
+};
+
+export type DeleteLocationInput = {
+  id: Scalars['String'];
+};
+
+export type DeleteLocationResponse = DeleteLocationError | DeleteResponse;
+
+/** Generic Error Wrapper */
 export type DeleteOutboundShipmentError = {
   __typename?: 'DeleteOutboundShipmentError';
   error: DeleteOutboundShipmentErrorInterface;
@@ -278,6 +298,7 @@ export type DeleteOutboundShipmentErrorInterface = {
   description: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type DeleteOutboundShipmentLineError = {
   __typename?: 'DeleteOutboundShipmentLineError';
   error: DeleteOutboundShipmentLineErrorInterface;
@@ -306,6 +327,29 @@ export type DeleteOutboundShipmentResponseWithId = {
   __typename?: 'DeleteOutboundShipmentResponseWithId';
   id: Scalars['String'];
   response: DeleteOutboundShipmentResponse;
+};
+
+/** Generic Error Wrapper */
+export type DeleteOutboundShipmentServiceLineError = {
+  __typename?: 'DeleteOutboundShipmentServiceLineError';
+  error: DeleteOutboundShipmentServiceLineErrorInterface;
+};
+
+export type DeleteOutboundShipmentServiceLineErrorInterface = {
+  description: Scalars['String'];
+};
+
+export type DeleteOutboundShipmentServiceLineInput = {
+  id: Scalars['String'];
+  invoiceId: Scalars['String'];
+};
+
+export type DeleteOutboundShipmentServiceLineResponse = DeleteOutboundShipmentServiceLineError | DeleteResponse;
+
+export type DeleteOutboundShipmentServiceLineResponseWithId = {
+  __typename?: 'DeleteOutboundShipmentServiceLineResponseWithId';
+  id: Scalars['String'];
+  response: DeleteOutboundShipmentServiceLineResponse;
 };
 
 export type DeleteResponse = {
@@ -362,23 +406,33 @@ export type DeleteSupplierRequisitionResponseWithId = {
 };
 
 export type EqualFilterBooleanInput = {
+  equalAny?: Maybe<Array<Scalars['Boolean']>>;
   equalTo?: Maybe<Scalars['Boolean']>;
+  notEqualTo?: Maybe<Scalars['Boolean']>;
 };
 
 export type EqualFilterInvoiceStatusInput = {
+  equalAny?: Maybe<Array<InvoiceNodeStatus>>;
   equalTo?: Maybe<InvoiceNodeStatus>;
+  notEqualTo?: Maybe<InvoiceNodeStatus>;
 };
 
 export type EqualFilterInvoiceTypeInput = {
+  equalAny?: Maybe<Array<InvoiceNodeType>>;
   equalTo?: Maybe<InvoiceNodeType>;
+  notEqualTo?: Maybe<InvoiceNodeType>;
 };
 
 export type EqualFilterNumberInput = {
+  equalAny?: Maybe<Array<Scalars['Int']>>;
   equalTo?: Maybe<Scalars['Int']>;
+  notEqualTo?: Maybe<Scalars['Int']>;
 };
 
 export type EqualFilterStringInput = {
+  equalAny?: Maybe<Array<Scalars['String']>>;
   equalTo?: Maybe<Scalars['String']>;
+  notEqualTo?: Maybe<Scalars['String']>;
 };
 
 export type FinalisedInvoiceIsNotEditableError = UpdateOutboundShipmentErrorInterface & {
@@ -394,7 +448,7 @@ export enum ForeignKey {
   StockLineId = 'stockLineId'
 }
 
-export type ForeignKeyError = DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+export type ForeignKeyError = DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
   __typename?: 'ForeignKeyError';
   description: Scalars['String'];
   key: ForeignKey;
@@ -451,6 +505,7 @@ export type InsertCustomerRequisitionResponseWithId = {
   response?: Maybe<InsertCustomerRequisitionResponse>;
 };
 
+/** Generic Error Wrapper */
 export type InsertInboundShipmentError = {
   __typename?: 'InsertInboundShipmentError';
   error: InsertInboundShipmentErrorInterface;
@@ -470,6 +525,7 @@ export type InsertInboundShipmentInput = {
   theirReference?: Maybe<Scalars['String']>;
 };
 
+/** Generic Error Wrapper */
 export type InsertInboundShipmentLineError = {
   __typename?: 'InsertInboundShipmentLineError';
   error: InsertInboundShipmentLineErrorInterface;
@@ -508,6 +564,25 @@ export type InsertInboundShipmentResponseWithId = {
   response: InsertInboundShipmentResponse;
 };
 
+export type InsertLocationError = {
+  __typename?: 'InsertLocationError';
+  error: InsertLocationErrorInterface;
+};
+
+export type InsertLocationErrorInterface = {
+  description: Scalars['String'];
+};
+
+export type InsertLocationInput = {
+  code: Scalars['String'];
+  id: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  onHold?: Maybe<Scalars['Boolean']>;
+};
+
+export type InsertLocationResponse = InsertLocationError | LocationNode;
+
+/** Generic Error Wrapper */
 export type InsertOutboundShipmentError = {
   __typename?: 'InsertOutboundShipmentError';
   error: InsertOutboundShipmentErrorInterface;
@@ -520,13 +595,16 @@ export type InsertOutboundShipmentErrorInterface = {
 export type InsertOutboundShipmentInput = {
   color?: Maybe<Scalars['String']>;
   comment?: Maybe<Scalars['String']>;
+  /** The new invoice id provided by the client */
   id: Scalars['String'];
   onHold?: Maybe<Scalars['Boolean']>;
+  /** The other party must be an customer of the current store */
   otherPartyId: Scalars['String'];
   status?: Maybe<InvoiceNodeStatus>;
   theirReference?: Maybe<Scalars['String']>;
 };
 
+/** Generic Error Wrapper */
 export type InsertOutboundShipmentLineError = {
   __typename?: 'InsertOutboundShipmentLineError';
   error: InsertOutboundShipmentLineErrorInterface;
@@ -558,6 +636,33 @@ export type InsertOutboundShipmentResponseWithId = {
   __typename?: 'InsertOutboundShipmentResponseWithId';
   id: Scalars['String'];
   response: InsertOutboundShipmentResponse;
+};
+
+/** Generic Error Wrapper */
+export type InsertOutboundShipmentServiceLineError = {
+  __typename?: 'InsertOutboundShipmentServiceLineError';
+  error: InsertOutboundShipmentServiceLineErrorInterface;
+};
+
+export type InsertOutboundShipmentServiceLineErrorInterface = {
+  description: Scalars['String'];
+};
+
+export type InsertOutboundShipmentServiceLineInput = {
+  id: Scalars['String'];
+  invoiceId: Scalars['String'];
+  itemId: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  note?: Maybe<Scalars['String']>;
+  totalAfterTax?: Maybe<Scalars['Float']>;
+};
+
+export type InsertOutboundShipmentServiceLineResponse = InsertOutboundShipmentServiceLineError | InvoiceLineNode;
+
+export type InsertOutboundShipmentServiceLineResponseWithId = {
+  __typename?: 'InsertOutboundShipmentServiceLineResponseWithId';
+  id: Scalars['String'];
+  response: InsertOutboundShipmentServiceLineResponse;
 };
 
 export type InsertStocktakeInput = {
@@ -645,7 +750,7 @@ export type InsertSupplierRequisitionResponseWithId = {
   response?: Maybe<InsertSupplierRequisitionResponse>;
 };
 
-export type InternalError = AuthTokenErrorInterface & LogoutErrorInterface & RefreshTokenErrorInterface & UserErrorInterface & UserRegisterErrorInterface & {
+export type InternalError = AuthTokenErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & LogoutErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UserErrorInterface & UserRegisterErrorInterface & {
   __typename?: 'InternalError';
   description: Scalars['String'];
   fullError: Scalars['String'];
@@ -661,6 +766,7 @@ export type InvalidToken = RefreshTokenErrorInterface & {
   description: Scalars['String'];
 };
 
+/** Generic Connector */
 export type InvoiceConnector = {
   __typename?: 'InvoiceConnector';
   nodes: Array<InvoiceNode>;
@@ -681,7 +787,7 @@ export type InvoiceCountsCreated = {
 
 export type InvoiceCountsResponse = ConnectorError | InvoiceCountsConnector;
 
-export type InvoiceDoesNotBelongToCurrentStore = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+export type InvoiceDoesNotBelongToCurrentStore = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
   __typename?: 'InvoiceDoesNotBelongToCurrentStore';
   description: Scalars['String'];
 };
@@ -699,12 +805,13 @@ export type InvoiceFilterInput = {
   type?: Maybe<EqualFilterInvoiceTypeInput>;
 };
 
-export type InvoiceLineBelongsToAnotherInvoice = DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+export type InvoiceLineBelongsToAnotherInvoice = DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
   __typename?: 'InvoiceLineBelongsToAnotherInvoice';
   description: Scalars['String'];
   invoice: InvoiceResponse;
 };
 
+/** Generic Connector */
 export type InvoiceLineConnector = {
   __typename?: 'InvoiceLineConnector';
   nodes: Array<InvoiceLineNode>;
@@ -723,6 +830,7 @@ export type InvoiceLineNode = {
   costPricePerPack: Scalars['Float'];
   expiryDate?: Maybe<Scalars['NaiveDate']>;
   id: Scalars['String'];
+  item: ItemResponse;
   itemCode: Scalars['String'];
   itemId: Scalars['String'];
   itemName: Scalars['String'];
@@ -761,8 +869,17 @@ export type InvoiceNode = {
 };
 
 export enum InvoiceNodeStatus {
+  /**
+   * For outbound shipments: When an invoice is CONFIRMED available_number_of_packs and
+   * total_number_of_packs get updated when items are added to the invoice.
+   */
   Confirmed = 'CONFIRMED',
+  /**
+   * For outbound shipments: In DRAFT mode only the available_number_of_packs in a stock line gets
+   * updated when items are added to the invoice.
+   */
   Draft = 'DRAFT',
+  /** A FINALISED invoice can't be edited nor deleted. */
   Finalised = 'FINALISED'
 }
 
@@ -792,12 +909,18 @@ export enum InvoiceSortFieldInput {
 }
 
 export type InvoiceSortInput = {
+  /**
+   * Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
   desc?: Maybe<Scalars['Boolean']>;
+  /** Sort query result by `key` */
   key: InvoiceSortFieldInput;
 };
 
 export type InvoicesResponse = ConnectorError | InvoiceConnector;
 
+/** Generic Connector */
 export type ItemConnector = {
   __typename?: 'ItemConnector';
   nodes: Array<ItemNode>;
@@ -807,6 +930,11 @@ export type ItemConnector = {
 export type ItemDoesNotMatchStockLine = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
   __typename?: 'ItemDoesNotMatchStockLine';
   description: Scalars['String'];
+};
+
+export type ItemError = {
+  __typename?: 'ItemError';
+  error: ItemResponseError;
 };
 
 export type ItemFilterInput = {
@@ -825,13 +953,22 @@ export type ItemNode = {
   unitName?: Maybe<Scalars['String']>;
 };
 
+export type ItemResponse = ItemError | ItemNode;
+
+export type ItemResponseError = InternalError;
+
 export enum ItemSortFieldInput {
   Code = 'code',
   Name = 'name'
 }
 
 export type ItemSortInput = {
+  /**
+   * Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
   desc?: Maybe<Scalars['Boolean']>;
+  /** Sort query result by `key` */
   key: ItemSortFieldInput;
 };
 
@@ -842,6 +979,7 @@ export type LineDoesNotReferenceStockLine = UpdateOutboundShipmentLineErrorInter
   description: Scalars['String'];
 };
 
+/** Generic Connector */
 export type LocationConnector = {
   __typename?: 'LocationConnector';
   nodes: Array<LocationNode>;
@@ -852,6 +990,13 @@ export type LocationFilterInput = {
   code?: Maybe<EqualFilterStringInput>;
   id?: Maybe<EqualFilterStringInput>;
   name?: Maybe<EqualFilterStringInput>;
+};
+
+export type LocationInUse = DeleteLocationErrorInterface & {
+  __typename?: 'LocationInUse';
+  description: Scalars['String'];
+  invoiceLines: InvoiceLineConnector;
+  stockLines: StockLineConnector;
 };
 
 export type LocationIsOnHold = InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
@@ -881,7 +1026,12 @@ export enum LocationSortFieldInput {
 }
 
 export type LocationSortInput = {
+  /**
+   * Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
   desc?: Maybe<Scalars['Boolean']>;
+  /** Sort query result by `key` */
   key: LocationSortFieldInput;
 };
 
@@ -889,9 +1039,11 @@ export type LocationsResponse = ConnectorError | LocationConnector;
 
 export type Logout = {
   __typename?: 'Logout';
+  /** User id of the logged out user */
   userId: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type LogoutError = {
   __typename?: 'LogoutError';
   error: LogoutErrorInterface;
@@ -914,8 +1066,10 @@ export type Mutations = {
   deleteCustomerRequisitionLine: DeleteCustomerRequisitionLineResponse;
   deleteInboundShipment: DeleteInboundShipmentResponse;
   deleteInboundShipmentLine: DeleteInboundShipmentLineResponse;
+  deleteLocation: DeleteLocationResponse;
   deleteOutboundShipment: DeleteOutboundShipmentResponse;
   deleteOutboundShipmentLine: DeleteOutboundShipmentLineResponse;
+  deleteOutboundShipmentServiceLine: DeleteOutboundShipmentServiceLineResponse;
   deleteStocktake: DeleteStocktakeResponse;
   deleteSupplierRequisition: DeleteSupplierRequisitionResponse;
   deleteSupplierRequisitionLine: DeleteSupplierRequisitionLineResponse;
@@ -923,8 +1077,10 @@ export type Mutations = {
   insertCustomerRequisitionLine: InsertCustomerRequisitionLineResponse;
   insertInboundShipment: InsertInboundShipmentResponse;
   insertInboundShipmentLine: InsertInboundShipmentLineResponse;
+  insertLocation: InsertLocationResponse;
   insertOutboundShipment: InsertOutboundShipmentResponse;
   insertOutboundShipmentLine: InsertOutboundShipmentLineResponse;
+  insertOutboundShipmentServiceLine: InsertOutboundShipmentServiceLineResponse;
   insertStocktake: InsertStocktakeResponse;
   insertSupplierRequisition: InsertSupplierRequisitionResponse;
   insertSupplierRequisitionLine: InsertSupplierRequisitionLineResponse;
@@ -933,8 +1089,10 @@ export type Mutations = {
   updateCustomerRequisitionLine: UpdateCustomerRequisitionLineResponse;
   updateInboundShipment: UpdateInboundShipmentResponse;
   updateInboundShipmentLine: UpdateInboundShipmentLineResponse;
+  updateLocation: UpdateLocationResponse;
   updateOutboundShipment: UpdateOutboundShipmentResponse;
   updateOutboundShipmentLine: UpdateOutboundShipmentLineResponse;
+  updateOutboundShipmentServiceLine: UpdateOutboundShipmentServiceLineResponse;
   updateStocktake: UpdateStocktakeResponse;
   updateSupplierRequisition: UpdateSupplierRequisitionResponse;
   updateSupplierRequisitionLine: UpdateSupplierRequisitionLineResponse;
@@ -963,10 +1121,13 @@ export type MutationsBatchInboundShipmentArgs = {
 
 export type MutationsBatchOutboundShipmentArgs = {
   deleteOutboundShipmentLines?: Maybe<Array<DeleteOutboundShipmentLineInput>>;
+  deleteOutboundShipmentServiceLines?: Maybe<Array<DeleteOutboundShipmentServiceLineInput>>;
   deleteOutboundShipments?: Maybe<Array<Scalars['String']>>;
   insertOutboundShipmentLines?: Maybe<Array<InsertOutboundShipmentLineInput>>;
+  insertOutboundShipmentServiceLines?: Maybe<Array<InsertOutboundShipmentServiceLineInput>>;
   insertOutboundShipments?: Maybe<Array<InsertOutboundShipmentInput>>;
   updateOutboundShipmentLines?: Maybe<Array<UpdateOutboundShipmentLineInput>>;
+  updateOutboundShipmentServiceLines?: Maybe<Array<UpdateOutboundShipmentServiceLineInput>>;
   updateOutboundShipments?: Maybe<Array<UpdateOutboundShipmentInput>>;
 };
 
@@ -1011,6 +1172,11 @@ export type MutationsDeleteInboundShipmentLineArgs = {
 };
 
 
+export type MutationsDeleteLocationArgs = {
+  input: DeleteLocationInput;
+};
+
+
 export type MutationsDeleteOutboundShipmentArgs = {
   id: Scalars['String'];
 };
@@ -1018,6 +1184,11 @@ export type MutationsDeleteOutboundShipmentArgs = {
 
 export type MutationsDeleteOutboundShipmentLineArgs = {
   input: DeleteOutboundShipmentLineInput;
+};
+
+
+export type MutationsDeleteOutboundShipmentServiceLineArgs = {
+  input: DeleteOutboundShipmentServiceLineInput;
 };
 
 
@@ -1056,6 +1227,11 @@ export type MutationsInsertInboundShipmentLineArgs = {
 };
 
 
+export type MutationsInsertLocationArgs = {
+  input: InsertLocationInput;
+};
+
+
 export type MutationsInsertOutboundShipmentArgs = {
   input: InsertOutboundShipmentInput;
 };
@@ -1063,6 +1239,11 @@ export type MutationsInsertOutboundShipmentArgs = {
 
 export type MutationsInsertOutboundShipmentLineArgs = {
   input: InsertOutboundShipmentLineInput;
+};
+
+
+export type MutationsInsertOutboundShipmentServiceLineArgs = {
+  input: InsertOutboundShipmentServiceLineInput;
 };
 
 
@@ -1106,6 +1287,11 @@ export type MutationsUpdateInboundShipmentLineArgs = {
 };
 
 
+export type MutationsUpdateLocationArgs = {
+  input: UpdateLocationInput;
+};
+
+
 export type MutationsUpdateOutboundShipmentArgs = {
   input: UpdateOutboundShipmentInput;
 };
@@ -1113,6 +1299,11 @@ export type MutationsUpdateOutboundShipmentArgs = {
 
 export type MutationsUpdateOutboundShipmentLineArgs = {
   input: UpdateOutboundShipmentLineInput;
+};
+
+
+export type MutationsUpdateOutboundShipmentServiceLineArgs = {
+  input: UpdateOutboundShipmentServiceLineInput;
 };
 
 
@@ -1130,6 +1321,7 @@ export type MutationsUpdateSupplierRequisitionLineArgs = {
   input: UpdateSupplierRequisitionLineInput;
 };
 
+/** Generic Connector */
 export type NameConnector = {
   __typename?: 'NameConnector';
   nodes: Array<NameNode>;
@@ -1137,9 +1329,13 @@ export type NameConnector = {
 };
 
 export type NameFilterInput = {
+  /** Filter by code */
   code?: Maybe<SimpleStringFilterInput>;
+  /** Filter by customer property */
   isCustomer?: Maybe<Scalars['Boolean']>;
+  /** Filter by supplier property */
   isSupplier?: Maybe<Scalars['Boolean']>;
+  /** Filter by name */
   name?: Maybe<SimpleStringFilterInput>;
 };
 
@@ -1160,7 +1356,12 @@ export enum NameSortFieldInput {
 }
 
 export type NameSortInput = {
+  /**
+   * Sort query result is sorted descending or ascending (if not provided the default is
+   * ascending)
+   */
   desc?: Maybe<Scalars['Boolean']>;
+  /** Sort query result by `key` */
   key: NameSortFieldInput;
 };
 
@@ -1171,6 +1372,7 @@ export type NoRefreshTokenProvided = RefreshTokenErrorInterface & {
   description: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type NodeError = {
   __typename?: 'NodeError';
   error: NodeErrorInterface;
@@ -1185,12 +1387,17 @@ export type NotARefreshToken = RefreshTokenErrorInterface & {
   description: Scalars['String'];
 };
 
+export type NotAServiceItem = DeleteOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
+  __typename?: 'NotAServiceItem';
+  description: Scalars['String'];
+};
+
 export type NotAnInboundShipment = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & InsertInboundShipmentLineErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & {
   __typename?: 'NotAnInboundShipment';
   description: Scalars['String'];
 };
 
-export type NotAnOutboundShipment = DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+export type NotAnOutboundShipment = DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
   __typename?: 'NotAnOutboundShipment';
   description: Scalars['String'];
 };
@@ -1230,23 +1437,41 @@ export type PaginationError = ConnectorErrorInterface & {
   rangeError: RangeError;
 };
 
+/**
+ * Pagination input.
+ *
+ * Option to limit the number of returned items and/or queries large lists in "pages".
+ */
 export type PaginationInput = {
+  /** Max number of returned items */
   first?: Maybe<Scalars['Int']>;
+  /** First returned item is at the `offset` position in the full list */
   offset?: Maybe<Scalars['Int']>;
 };
 
 export type Queries = {
   __typename?: 'Queries';
   apiVersion: Scalars['String'];
+  /**
+   * Retrieves a new auth bearer and refresh token
+   * The refresh token is returned as a cookie
+   */
   authToken: AuthTokenResponse;
   invoice: InvoiceResponse;
   invoiceCounts: InvoiceCountsResponse;
   invoices: InvoicesResponse;
+  /** Query omSupply "item" entries */
   items: ItemsResponse;
+  /** Query omSupply "item" entries */
   locations: LocationsResponse;
   logout: LogoutResponse;
   me: UserResponse;
+  /** Query omSupply "name" entries */
   names: NamesResponse;
+  /**
+   * Retrieves a new auth bearer and refresh token
+   * The refresh token is returned as a cookie
+   */
   refreshToken: RefreshTokenResponse;
   requisition: RequisitionResponse;
   requisitions: RequisitionsResponse;
@@ -1333,21 +1558,28 @@ export enum RangeField {
   PackSize = 'packSize'
 }
 
-export type RecordAlreadyExist = InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & UserRegisterErrorInterface & {
+export type RecordAlreadyExist = InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & UserRegisterErrorInterface & {
   __typename?: 'RecordAlreadyExist';
   description: Scalars['String'];
 };
 
-export type RecordNotFound = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & NodeErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
+export type RecordBelongsToAnotherStore = DeleteLocationErrorInterface & UpdateLocationErrorInterface & {
+  __typename?: 'RecordBelongsToAnotherStore';
+  description: Scalars['String'];
+};
+
+export type RecordNotFound = DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & NodeErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & {
   __typename?: 'RecordNotFound';
   description: Scalars['String'];
 };
 
 export type RefreshToken = {
   __typename?: 'RefreshToken';
+  /** New Bearer token */
   token: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type RefreshTokenError = {
   __typename?: 'RefreshTokenError';
   error: RefreshTokenErrorInterface;
@@ -1457,7 +1689,9 @@ export type RequisitionSortInput = {
 export type RequisitionsResponse = ConnectorError | RequisitionConnector;
 
 export type SimpleStringFilterInput = {
+  /** Search term must be an exact match (case sensitive) */
   equalTo?: Maybe<Scalars['String']>;
+  /** Search term must be included in search candidate (case insensitive) */
   like?: Maybe<Scalars['String']>;
 };
 
@@ -1475,6 +1709,7 @@ export type StockLineAlreadyExistsInInvoice = InsertOutboundShipmentLineErrorInt
   line: InvoiceLineResponse;
 };
 
+/** Generic Connector */
 export type StockLineConnector = {
   __typename?: 'StockLineConnector';
   nodes: Array<StockLineNode>;
@@ -1597,6 +1832,16 @@ export type TokenExpired = RefreshTokenErrorInterface & {
   description: Scalars['String'];
 };
 
+export enum UniqueValueKey {
+  Code = 'code'
+}
+
+export type UniqueValueViolation = InsertLocationErrorInterface & UpdateLocationErrorInterface & {
+  __typename?: 'UniqueValueViolation';
+  description: Scalars['String'];
+  field: UniqueValueKey;
+};
+
 export type UpdateCustomerRequisitionInput = {
   color?: Maybe<Scalars['String']>;
   comment?: Maybe<Scalars['String']>;
@@ -1647,6 +1892,7 @@ export type UpdateCustomerRequisitionResponseWithId = {
   response?: Maybe<UpdateCustomerRequisitionResponse>;
 };
 
+/** Generic Error Wrapper */
 export type UpdateInboundShipmentError = {
   __typename?: 'UpdateInboundShipmentError';
   error: UpdateInboundShipmentErrorInterface;
@@ -1666,6 +1912,7 @@ export type UpdateInboundShipmentInput = {
   theirReference?: Maybe<Scalars['String']>;
 };
 
+/** Generic Error Wrapper */
 export type UpdateInboundShipmentLineError = {
   __typename?: 'UpdateInboundShipmentLineError';
   error: UpdateInboundShipmentLineErrorInterface;
@@ -1704,6 +1951,25 @@ export type UpdateInboundShipmentResponseWithId = {
   response: UpdateInboundShipmentResponse;
 };
 
+export type UpdateLocationError = {
+  __typename?: 'UpdateLocationError';
+  error: UpdateLocationErrorInterface;
+};
+
+export type UpdateLocationErrorInterface = {
+  description: Scalars['String'];
+};
+
+export type UpdateLocationInput = {
+  code?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  onHold?: Maybe<Scalars['Boolean']>;
+};
+
+export type UpdateLocationResponse = LocationNode | UpdateLocationError;
+
+/** Generic Error Wrapper */
 export type UpdateOutboundShipmentError = {
   __typename?: 'UpdateOutboundShipmentError';
   error: UpdateOutboundShipmentErrorInterface;
@@ -1716,13 +1982,24 @@ export type UpdateOutboundShipmentErrorInterface = {
 export type UpdateOutboundShipmentInput = {
   color?: Maybe<Scalars['String']>;
   comment?: Maybe<Scalars['String']>;
+  /** The new invoice id provided by the client */
   id: Scalars['String'];
   onHold?: Maybe<Scalars['Boolean']>;
+  /**
+   * The other party must be a customer of the current store.
+   * This field can be used to change the other_party of an invoice
+   */
   otherPartyId?: Maybe<Scalars['String']>;
+  /**
+   * When changing the status from DRAFT to CONFIRMED or FINALISED the total_number_of_packs for
+   * existing invoice items gets updated.
+   */
   status?: Maybe<InvoiceNodeStatus>;
+  /** External invoice reference, e.g. purchase or shipment number */
   theirReference?: Maybe<Scalars['String']>;
 };
 
+/** Generic Error Wrapper */
 export type UpdateOutboundShipmentLineError = {
   __typename?: 'UpdateOutboundShipmentLineError';
   error: UpdateOutboundShipmentLineErrorInterface;
@@ -1754,6 +2031,33 @@ export type UpdateOutboundShipmentResponseWithId = {
   __typename?: 'UpdateOutboundShipmentResponseWithId';
   id: Scalars['String'];
   response: UpdateOutboundShipmentResponse;
+};
+
+/** Generic Error Wrapper */
+export type UpdateOutboundShipmentServiceLineError = {
+  __typename?: 'UpdateOutboundShipmentServiceLineError';
+  error: UpdateOutboundShipmentServiceLineErrorInterface;
+};
+
+export type UpdateOutboundShipmentServiceLineErrorInterface = {
+  description: Scalars['String'];
+};
+
+export type UpdateOutboundShipmentServiceLineInput = {
+  id: Scalars['String'];
+  invoiceId: Scalars['String'];
+  itemId?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  note?: Maybe<Scalars['String']>;
+  totalAfterTax?: Maybe<Scalars['Float']>;
+};
+
+export type UpdateOutboundShipmentServiceLineResponse = InvoiceLineNode | UpdateOutboundShipmentServiceLineError;
+
+export type UpdateOutboundShipmentServiceLineResponseWithId = {
+  __typename?: 'UpdateOutboundShipmentServiceLineResponseWithId';
+  id: Scalars['String'];
+  response: UpdateOutboundShipmentServiceLineResponse;
 };
 
 export type UpdateStocktakeInput = {
@@ -1841,10 +2145,13 @@ export type UpdateSupplierRequisitionResponseWithId = {
 
 export type User = {
   __typename?: 'User';
+  /** The user's email address */
   email?: Maybe<Scalars['String']>;
+  /** Internal user id */
   userId: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type UserError = {
   __typename?: 'UserError';
   error: UserErrorInterface;
@@ -1859,6 +2166,7 @@ export type UserNameDoesNotExist = AuthTokenErrorInterface & {
   description: Scalars['String'];
 };
 
+/** Generic Error Wrapper */
 export type UserRegisterError = {
   __typename?: 'UserRegisterError';
   error: UserRegisterErrorInterface;
@@ -1883,7 +2191,7 @@ export type InvoiceQueryVariables = Exact<{
 }>;
 
 
-export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null | undefined, entryDatetime: string, invoiceNumber: number, onHold: boolean, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } }, lines: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename?: 'PaginationError', description: string } } | { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: string | null | undefined, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null | undefined, locationName?: string | null | undefined, sellPricePerPack: number, stockLine?: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: string | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null | undefined } | null | undefined }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type InvoiceQuery = { __typename?: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null | undefined, entryDatetime: string, invoiceNumber: number, onHold: boolean, otherPartyId: string, otherPartyName: string, status: InvoiceNodeStatus, theirReference?: string | null | undefined, type: InvoiceNodeType, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } }, lines: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename?: 'PaginationError', description: string } } | { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', batch?: string | null | undefined, costPricePerPack: number, expiryDate?: string | null | undefined, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null | undefined, locationName?: string | null | undefined, sellPricePerPack: number, item: { __typename: 'ItemError', error: { __typename: 'InternalError', description: string, fullError: string } } | { __typename?: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, availableBatches: { __typename: 'ConnectorError', error: { __typename?: 'DatabaseError', description: string } | { __typename?: 'PaginationError', description: string } } | { __typename?: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename?: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } }, stockLine?: { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null | undefined, costPricePerPack: number, expiryDate?: string | null | undefined, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null | undefined } | null | undefined }> }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type StocktakeQueryVariables = Exact<{
   stocktakeId: Scalars['String'];
@@ -2205,6 +2513,46 @@ export const InvoiceDocument = gql`
             numberOfPacks
             packSize
             note
+            item {
+              ... on ItemNode {
+                id
+                name
+                code
+                isVisible
+                availableBatches {
+                  ... on StockLineConnector {
+                    totalCount
+                    nodes {
+                      id
+                      availableNumberOfPacks
+                      costPricePerPack
+                      itemId
+                      onHold
+                      packSize
+                      sellPricePerPack
+                      storeId
+                      totalNumberOfPacks
+                    }
+                  }
+                  ... on ConnectorError {
+                    __typename
+                    error {
+                      description
+                    }
+                  }
+                }
+              }
+              ... on ItemError {
+                __typename
+                error {
+                  ... on InternalError {
+                    __typename
+                    description
+                    fullError
+                  }
+                }
+              }
+            }
             locationName
             sellPricePerPack
             stockLine {

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -74,6 +74,15 @@ export type BatchCustomerRequisitionResponse = {
   updateCustomerRequisitions?: Maybe<Array<UpdateCustomerRequisitionResponseWithId>>;
 };
 
+export type BatchInboundShipmentInput = {
+  deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineInput>>;
+  deleteInboundShipments?: Maybe<Array<DeleteInboundShipmentInput>>;
+  insertInboundShipmentLines?: Maybe<Array<InsertInboundShipmentLineInput>>;
+  insertOutboundShipments?: Maybe<Array<InsertInboundShipmentInput>>;
+  updateInboundShipmentLines?: Maybe<Array<UpdateInboundShipmentLineInput>>;
+  updateInboundShipments?: Maybe<Array<UpdateInboundShipmentInput>>;
+};
+
 export type BatchInboundShipmentResponse = {
   __typename?: 'BatchInboundShipmentResponse';
   deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineResponseWithId>>;
@@ -87,6 +96,15 @@ export type BatchInboundShipmentResponse = {
 export type BatchIsReserved = DeleteInboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & {
   __typename?: 'BatchIsReserved';
   description: Scalars['String'];
+};
+
+export type BatchOutboundShipmentInput = {
+  deleteOutboundShipmentLines?: Maybe<Array<DeleteOutboundShipmentLineInput>>;
+  deleteOutboundShipments?: Maybe<Array<Scalars['String']>>;
+  insertOutboundShipmentLines?: Maybe<Array<InsertOutboundShipmentLineInput>>;
+  insertOutboundShipments?: Maybe<Array<InsertOutboundShipmentInput>>;
+  updateOutboundShipmentLines?: Maybe<Array<UpdateOutboundShipmentLineInput>>;
+  updateOutboundShipments?: Maybe<Array<UpdateOutboundShipmentInput>>;
 };
 
 export type BatchOutboundShipmentResponse = {

--- a/packages/invoices/src/InboundShipment/DetailView/api.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/api.ts
@@ -1,6 +1,6 @@
 import {
-  InvoiceQuery,
   InvoiceLineConnector,
+  InvoiceQuery,
   InvoicePriceResponse,
   ConnectorError,
   NameResponse,

--- a/packages/invoices/src/types.ts
+++ b/packages/invoices/src/types.ts
@@ -38,7 +38,9 @@ export type InboundShipmentStatus =
 // | InvoiceNodeStatus.Delivered
 // | 'VERIFIED';
 
-export interface InvoiceLine extends InvoiceLineNode, DomainObject {
+export interface InvoiceLine
+  extends Omit<InvoiceLineNode, 'item'>,
+    DomainObject {
   stockLine?: StockLine;
   stockLineId: string;
   invoiceId: string;
@@ -123,7 +125,7 @@ export type OutboundShipmentAction =
       payload: { item: OutboundShipmentSummaryItem };
     };
 
-export interface OutboundShipmentRow extends InvoiceLine {
+export interface OutboundShipmentRow extends Omit<InvoiceLine, 'item'> {
   updateNumberOfPacks?: (quantity: number) => void;
 
   stockLineId: string;
@@ -158,7 +160,7 @@ export interface OutboundShipment extends Omit<Invoice, 'lines'> {
   upsertLine?: (line: OutboundShipmentRow) => void;
   deleteLine?: (line: OutboundShipmentRow) => void;
 }
-export interface InboundShipmentRow extends InvoiceLine {
+export interface InboundShipmentRow extends Omit<InvoiceLine, 'item'> {
   updateNumberOfPacks?: (quantity: number) => void;
   update?: (key: string, value: string) => void;
   stockLineId: string;

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -25,6 +25,7 @@
     "@openmsupply-client/requisitions": "^0.0.0",
     "apollo-server": "^3.1.1",
     "faker": "^5.5.3",
+    "graphql-tools": "^8.2.0",
     "knex": "^0.95.11",
     "lodash.chunk": "^4.2.0",
     "nodemon": "^2.0.13",

--- a/packages/mock-server/src/api/resolvers/invoiceLine.ts
+++ b/packages/mock-server/src/api/resolvers/invoiceLine.ts
@@ -1,3 +1,4 @@
+import { itemResolver } from './item';
 import { createListResponse } from './utils';
 import { ResolvedInvoiceLine, ListResponse } from './../../data/types';
 import { db } from './../../data/database';
@@ -6,10 +7,12 @@ import { stockLineResolver } from './stockLine';
 export const invoiceLineResolver = {
   byId: (id: string): ResolvedInvoiceLine => {
     const invoiceLine = db.get.byId.invoiceLine(id);
+    const item = itemResolver.byId(invoiceLine.itemId);
 
     return {
       __typename: 'InvoiceLineNode',
       ...invoiceLine,
+      item,
       stockLine: invoiceLine.stockLineId
         ? stockLineResolver.byId(invoiceLine.stockLineId)
         : undefined,

--- a/packages/mock-server/src/data/types.ts
+++ b/packages/mock-server/src/data/types.ts
@@ -63,7 +63,8 @@ export interface ResolvedStockLine extends StockLine {
   item: Item;
 }
 
-export interface InvoiceLine extends Omit<InvoiceLineNode, 'location'> {
+export interface InvoiceLine
+  extends Omit<InvoiceLineNode, 'location' | 'item'> {
   id: string;
   itemName: string;
   location?: Location;
@@ -84,6 +85,7 @@ export interface InvoiceLine extends Omit<InvoiceLineNode, 'location'> {
 export interface ResolvedInvoiceLine extends InvoiceLine {
   __typename: 'InvoiceLineNode';
   stockLine?: ResolvedStockLine;
+  item: ResolvedItem;
 }
 
 export interface Invoice extends Omit<InvoiceNode, 'lines' | 'otherParty'> {

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -1,10 +1,20 @@
 require('graphql-import-node/register');
+import { loadSchemaSync } from '@graphql-tools/load';
 
+import { UrlLoader } from '@graphql-tools/url-loader';
 import { ApolloServer } from 'apollo-server';
 import { Schema } from './schema';
+import { mergeTypeDefs } from '@graphql-tools/merge';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const typeDefs = require('@openmsupply-client/common/src/schema.graphql');
+const typeDefs2 = require('@openmsupply-client/common/src/additions.schema.graphql');
+const remoteSchema = loadSchemaSync(
+  'https://demo-open.msupply.org:8000/graphql',
+  {
+    loaders: [new UrlLoader()],
+  }
+);
+const typeDefs = mergeTypeDefs([remoteSchema, typeDefs2]);
 
 const resolvers = {
   Queries: {
@@ -24,7 +34,6 @@ const resolvers = {
 };
 
 const server = new ApolloServer({ typeDefs, resolvers });
-
 server.listen().then(({ url }) => {
   console.log(
     `🚀🚀🚀 Server   @ ${url}         🚀🚀🚀\n🤖🤖🤖 GraphiQL @ ${url}graphiql 🤖🤖🤖`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@apollo/client@~3.2.5 || ~3.3.0 || ~3.4.0":
+  version "3.4.17"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.17.tgz#4972e19a49809e16d17c5adc67f45623a6dac135"
+  integrity sha512-MDt2rwMX1GqodiVEKJqmDmAz8xr0qJmq5PdWeIt0yDaT4GOkKYWZiWkyfhfv3raTk8PyJvbsNG9q2CqmUrlGfg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.0"
+    tslib "^2.3.0"
+    zen-observable-ts "~1.1.0"
+
 "@apollo/protobufjs@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.2.tgz#4bd92cd7701ccaef6d517cdb75af2755f049f87c"
@@ -1671,7 +1689,7 @@
     relay-compiler "12.0.0"
     tslib "~2.3.0"
 
-"@graphql-tools/schema@8.3.1", "@graphql-tools/schema@^8.0.0", "@graphql-tools/schema@^8.1.2", "@graphql-tools/schema@^8.3.1":
+"@graphql-tools/schema@8.3.1", "@graphql-tools/schema@^8.0.0", "@graphql-tools/schema@^8.1.2", "@graphql-tools/schema@^8.2.0", "@graphql-tools/schema@^8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.1.tgz#1ee9da494d2da457643b3c93502b94c3c4b68c74"
   dependencies:
@@ -1728,6 +1746,11 @@
     "@graphql-tools/utils" "^8.5.1"
     tslib "~2.3.0"
     value-or-promise "1.0.11"
+
+"@graphql-typed-document-node/core@^3.0.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -4673,6 +4696,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/zen-observable@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
+  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
+
 "@typescript-eslint/eslint-plugin@^4.28.4":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
@@ -4982,6 +5010,27 @@
 "@webpack-cli/serve@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
+
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
+  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
+  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  dependencies:
+    tslib "^2.3.0"
 
 "@xmldom/xmldom@^0.7.2":
   version "0.7.5"
@@ -9059,6 +9108,23 @@ graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
+graphql-tag@^2.12.3:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql-tools@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-8.2.0.tgz#493edc2760469f39d8334c6f20aa75ae91a7ab86"
+  integrity sha512-9axT/0exEzVCk+vMPykOPannlrA4VQNo6nuWgh25IJ5arPf92OKxvjSHAbm7dQIFmcWxE0hVvyD2rWHjDqZCgQ==
+  dependencies:
+    "@graphql-tools/schema" "^8.2.0"
+    tslib "~2.3.0"
+  optionalDependencies:
+    "@apollo/client" "~3.2.5 || ~3.3.0 || ~3.4.0"
+
 graphql-ws@^5.4.1:
   version "5.5.5"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.5.tgz#f375486d3f196e2a2527b503644693ae3a8670a9"
@@ -12515,6 +12581,14 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
 
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -15183,6 +15257,11 @@ symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -15538,6 +15617,13 @@ ts-dedent@^2.0.0:
 ts-essentials@^2.0.3:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
+
+ts-invariant@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
+  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
+  dependencies:
+    tslib "^2.1.0"
 
 ts-log@^2.2.3:
   version "2.2.4"
@@ -16647,6 +16733,19 @@ yn@3.1.1:
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+
+zen-observable-ts@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
+  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+  dependencies:
+    "@types/zen-observable" "0.8.3"
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zustand@^3.5.7:
   version "3.6.3"


### PR DESCRIPTION
Fixes #556 

- Took me a bit longer to get working than I had hoped..
- Ok this is generating types from the demo server. Good idea? Maybe.
- It's also taking the type defs from the server and merging with the additions when starting our apollo server
- Means we might have some annoyances when types are changed and added, but I suppose best we deal with that asap..
- It's pretty outrageous the amount of changes I needed to hack in just because of `item` being added to `InvoiceLineNode`. Was quite infuriating, actually! The way we're parsing the response using the generated types means that you need to query for all the required fields otherwise typescript barfs. Ugh! For now I've just added the overfetching. I *think* a solution might be to use fragments to generate smaller types, but I've yet to try it yet. Thinking of waiting till we have better queries, but also don't want to wait too long. Sigh!
- This has really made me want to decouple the frontend types from the backend types as much as possible - the backend adding a required field to a type (where the frontend didn't even start using it yet!) shouldn't stop the frontend compiling, let a long take so much time to fix.. sorry rant over!