### PR TITLE
#479 ts path aliases

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const toPath = filePath => path.join(process.cwd(), filePath);
 
 module.exports = {
@@ -21,6 +22,7 @@ module.exports = {
           '@emotion/core': toPath('node_modules/@emotion/react'),
           'emotion-theming': toPath('node_modules/@emotion/react'),
         },
+        plugins: [new TsconfigPathsPlugin()],
       },
     };
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig');
+
 module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
@@ -6,5 +9,13 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   moduleNameMapper: {
     'react-i18next': '<rootDir>/__mocks__/react-i18next.ts',
+    ...pathsToModuleNameMapper(compilerOptions.paths, {
+      prefix: '<rootDir>',
+    }),
+  },
+  globals: {
+    'ts-jest': {
+      diagnostics: true,
+    },
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,4 @@ module.exports = {
       prefix: '<rootDir>',
     }),
   },
-  globals: {
-    'ts-jest': {
-      diagnostics: true,
-    },
-  },
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "msw": "^0.35.0",
     "msw-storybook-addon": "^1.5.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "tsconfig-paths-webpack-plugin": "^3.5.2"
   },
   "lint-staged": {
     "src/**/*.+(js|json|ts|tsx)": [

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "msw-storybook-addon": "^1.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "ts-jest": "^27.1.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2"
   },
   "lint-staged": {

--- a/packages/common/src/hooks/useAppBarRect/useAppBarRect.test.tsx
+++ b/packages/common/src/hooks/useAppBarRect/useAppBarRect.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { renderHook } from '@testing-library/react-hooks';
-import { useAppBarRect, useAppBarRectStore } from '../../hooks/useAppBarRect';
+import { useAppBarRect, useAppBarRectStore } from '@common/hooks';
 
 const original = {
   innerWidth: window.innerWidth,

--- a/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.test.tsx
+++ b/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useContentAreaHeight } from '.';
-import { useAppTheme } from '../../styles';
+import { useAppTheme } from '@common/styles';
 
 describe('useContentAreaHeight', () => {
   beforeEach(() => {

--- a/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.tsx
+++ b/packages/common/src/hooks/useContentAreaHeight/useContentAreaHeight.tsx
@@ -1,6 +1,6 @@
 import { useAppBarRectStore } from '../useAppBarRect';
 import { useWindowDimensions } from '../useWindowDimensions';
-import { useAppTheme } from '../../styles';
+import { useAppTheme } from '@common/styles';
 
 export const useContentAreaHeight = (): number => {
   const { height: appBarHeight } = useAppBarRectStore();

--- a/packages/common/src/hooks/useDebounce/useDebouncedValue.stories.tsx
+++ b/packages/common/src/hooks/useDebounce/useDebouncedValue.stories.tsx
@@ -4,7 +4,7 @@ import { useDebouncedValue } from './useDebouncedValue';
 import { TextField, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { useDebounceCallback } from '.';
-import { BaseButton } from '../../ui/components/buttons';
+import { BaseButton } from '@common/components';
 
 export default {
   title: 'Hooks/useDebounce',

--- a/packages/common/src/hooks/useDetailPanel.tsx
+++ b/packages/common/src/hooks/useDetailPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import create from 'zustand';
-import { useTranslation } from '../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 import { SidebarIcon, ButtonWithIcon } from '../ui';
 
 type DetailPanelController = {

--- a/packages/common/src/hooks/useDialog/useDialog.stories.tsx
+++ b/packages/common/src/hooks/useDialog/useDialog.stories.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { useDialog } from './useDialog';
 import { Story } from '@storybook/react';
 
-import { DialogButton } from '../../ui/components/buttons/standard/DialogButton';
-import { BaseButton } from '../../ui/components/buttons/standard/BaseButton';
+import { BaseButton, DialogButton } from '@common/components';
 
 export default {
   title: 'Hooks/useDialog',

--- a/packages/common/src/hooks/useDialog/useDialog.test.tsx
+++ b/packages/common/src/hooks/useDialog/useDialog.test.tsx
@@ -3,7 +3,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { TestingProvider } from '@openmsupply-client/common';
 
 import { useDialog } from './useDialog';
-import { DialogButton } from '../../ui/components/buttons';
+import { DialogButton } from '@common/components';
 
 describe('useDialog', () => {
   const DialogExample: React.FC = () => {

--- a/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import { Slide } from '../../ui/animations';
-import { BasicModal } from '../../ui/components/modals/BasicModal';
-import { ModalTitle } from '../../ui/components/modals/ModalTitle';
+import { BasicModal, ModalTitle } from '@common/components';
 
 export interface ButtonProps {
   icon?: React.ReactElement;

--- a/packages/common/src/hooks/useIsScreen/useIsScreen.ts
+++ b/packages/common/src/hooks/useIsScreen/useIsScreen.ts
@@ -1,5 +1,5 @@
 import { useMediaQuery, Breakpoint } from '@mui/material';
-import { useAppTheme } from './../../styles/useAppTheme';
+import { useAppTheme } from '@common/styles';
 
 export const useIsScreen = (breakpoint: Breakpoint): boolean => {
   const theme = useAppTheme();

--- a/packages/common/src/hooks/useListData/useListData.test.tsx
+++ b/packages/common/src/hooks/useListData/useListData.test.tsx
@@ -5,7 +5,7 @@ import { render, waitFor } from '@testing-library/react';
 import { request, gql } from 'graphql-request';
 import { Test, DomainObject } from '../../types';
 import { ListApi, useListData } from './useListData';
-import { ErrorBoundary } from '../../ui/components/errors';
+import { ErrorBoundary } from '@common/components';
 import { TestingProvider } from '../../utils/testing';
 
 interface TestType extends Test, DomainObject {}

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -1,4 +1,4 @@
-import { DomainObject } from './../../types/index';
+import { DomainObject } from '@common/types';
 import { SortRule, SortBy } from './../useSortBy';
 import { UseMutateAsyncFunction } from 'react-query';
 import { useQueryClient, useMutation, useQuery } from 'react-query';

--- a/packages/common/src/hooks/useListData/useListData.ts
+++ b/packages/common/src/hooks/useListData/useListData.ts
@@ -5,7 +5,7 @@ import { useQueryClient, useMutation, useQuery } from 'react-query';
 import { QueryParams, useQueryParams } from '../useQueryParams';
 import { FilterBy } from '../useFilterBy';
 import { ClientError } from 'graphql-request';
-import { useNotification } from '../../hooks';
+import { useNotification } from '@common/hooks';
 
 export interface ListApi<T extends DomainObject> {
   onRead: ({

--- a/packages/common/src/hooks/useNotification/useNotification.stories.tsx
+++ b/packages/common/src/hooks/useNotification/useNotification.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Story } from '@storybook/react';
 
 import { useNotification } from './useNotification';
-import { BaseButton } from '../../ui/components/buttons';
+import { BaseButton } from '@common/components';
 
 export default {
   title: 'Hooks/useNotification',

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.test.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 import { TestingProvider } from '../../utils/testing';
-import { useTheme } from '../../styles';
+import { useTheme } from '@common/styles';
 import { renderHook } from '@testing-library/react-hooks';
 import { useQueryParams } from './useQueryParams';
 

--- a/packages/common/src/hooks/useRowRenderCount/useRowRenderCount.stories.tsx
+++ b/packages/common/src/hooks/useRowRenderCount/useRowRenderCount.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Story } from '@storybook/react';
 import { StoryProvider } from '../../utils';
 import { useRowRenderCount } from './useRowRenderCount';
-import { useTheme } from '../../styles';
+import { useTheme } from '@common/styles';
 import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
 

--- a/packages/common/src/hooks/useRowRenderCount/useRowRenderCount.test.tsx
+++ b/packages/common/src/hooks/useRowRenderCount/useRowRenderCount.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { waitFor } from '@testing-library/dom';
 import { renderHook } from '@testing-library/react-hooks';
 import { AppBar } from '@openmsupply-client/host/src/components';
-import { useTheme } from '../../styles';
+import { useTheme } from '@common/styles';
 import { TestingProvider, TestingRouter } from '../../utils';
 import { useRowRenderCount } from './useRowRenderCount';
 import { useAppBarRectStore } from '../useAppBarRect';

--- a/packages/common/src/hooks/useRowRenderCount/useRowRenderCount.ts
+++ b/packages/common/src/hooks/useRowRenderCount/useRowRenderCount.ts
@@ -1,4 +1,4 @@
-import { useTheme } from '../../styles';
+import { useTheme } from '@common/styles';
 import { useWindowDimensions } from '../useWindowDimensions';
 import { useAppBarRectStore } from '../useAppBarRect';
 

--- a/packages/common/src/hooks/useSortBy/useSortBy.stories.tsx
+++ b/packages/common/src/hooks/useSortBy/useSortBy.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSortBy } from './useSortBy';
 import { Story } from '@storybook/react';
 
-import { BaseButton } from '../../ui/components/buttons';
+import { BaseButton } from '@common/components';
 
 export default {
   title: 'Hooks/useSortBy',

--- a/packages/common/src/hooks/useToggle/useToggle.stories.tsx
+++ b/packages/common/src/hooks/useToggle/useToggle.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { useToggle } from './useToggle';
 import { Story } from '@storybook/react';
-import { BaseButton } from '../../ui/components/buttons';
+import { BaseButton } from '@common/components';
 
 export default {
   title: 'Hooks/useToggle',

--- a/packages/common/src/localStorage/keys.ts
+++ b/packages/common/src/localStorage/keys.ts
@@ -1,4 +1,4 @@
-import { SupportedLocales } from '../intl/intlHelpers';
+import { SupportedLocales } from '@common/intl';
 
 export type LocalStorageRecord = {
   '/appdrawer/open': boolean;

--- a/packages/common/src/localStorage/useLocalStorage.test.tsx
+++ b/packages/common/src/localStorage/useLocalStorage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { LocalStorage } from '.';
-import { BaseButton } from '../ui/components/buttons';
+import { BaseButton } from '@common/components';
 import { useLocalStorage } from './useLocalStorage';
 
 const UseLocalStorageExample = () => {

--- a/packages/common/src/styles/RTLProvider.test.tsx
+++ b/packages/common/src/styles/RTLProvider.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React, { FC } from 'react';
 import { act } from 'react-dom/test-utils';
-import { useI18N } from '../intl/intlHelpers';
+import { useI18N } from '@common/intl';
 import { LocalStorage } from '../localStorage';
 import { RTLProvider } from './RTLProvider';
 

--- a/packages/common/src/styles/RTLProvider.tsx
+++ b/packages/common/src/styles/RTLProvider.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { useRtl } from '../intl/intlHelpers';
+import { useRtl } from '@common/intl';
 
 export const RTLProvider: FC = props => {
   const isRtl = useRtl();

--- a/packages/common/src/styles/useAppTheme.test.tsx
+++ b/packages/common/src/styles/useAppTheme.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React, { FC } from 'react';
 import { act } from 'react-dom/test-utils';
-import { useI18N } from '../intl/intlHelpers';
+import { useI18N } from '@common/intl';
 import { useAppTheme } from './useAppTheme';
 
 describe('useAppTheme', () => {

--- a/packages/common/src/styles/useAppTheme.ts
+++ b/packages/common/src/styles/useAppTheme.ts
@@ -2,7 +2,7 @@ import { Direction } from '@mui/material/styles';
 import { Theme } from '@mui/material';
 import { useState, useEffect } from 'react';
 import theme from './theme';
-import { useRtl } from '../intl/intlHelpers';
+import { useRtl } from '@common/intl';
 
 export const useAppTheme = (): Theme => {
   const [currentTheme, setTheme] = useState(theme);

--- a/packages/common/src/ui/animations/Grow.stories.tsx
+++ b/packages/common/src/ui/animations/Grow.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Grow } from '.';
-import { UnhappyMan } from '../icons/UnhappyMan';
+import { UnhappyMan } from '@common/icons';
 
 const Template: ComponentStory<typeof Grow> = args => (
   <Grow in {...args}>

--- a/packages/common/src/ui/components/buttons/ButtonShowcase.stories.tsx
+++ b/packages/common/src/ui/components/buttons/ButtonShowcase.stories.tsx
@@ -2,13 +2,13 @@ import React, { FC, useState } from 'react';
 import { Grid, Paper, Typography } from '@mui/material';
 import { Story } from '@storybook/react';
 import { FlatButton } from './FlatButton';
-import { BookIcon, TruckIcon } from '../../icons';
+import { BookIcon, TruckIcon } from '@common/icons';
 import { BaseButton, ButtonWithIcon } from '.';
 import { DialogButton, IconButton } from '../buttons';
 import { Color } from '../menus';
 import { ToggleButton } from './ToggleButton';
 import { ColorSelectButton } from './ColorSelectButton';
-import { useTranslation } from '../../../intl';
+import { useTranslation } from '@common/intl';
 import { StoryProvider } from '../../../utils/testing';
 
 const getOnClick = (someText: string) => () => {

--- a/packages/common/src/ui/components/buttons/ColorSelectButton.tsx
+++ b/packages/common/src/ui/components/buttons/ColorSelectButton.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 import { ColorMenu, Color } from '../menus';
 import { IconButton } from './IconButton';
-import { CircleIcon } from '../../icons';
+import { CircleIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
 
 interface ColorSelectButtonProps {

--- a/packages/common/src/ui/components/buttons/ColorSelectButton.tsx
+++ b/packages/common/src/ui/components/buttons/ColorSelectButton.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 import { ColorMenu, Color } from '../menus';
 import { IconButton } from './IconButton';
 import { CircleIcon } from '../../icons';
-import { useTranslation } from '../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 interface ColorSelectButtonProps {
   color: string;

--- a/packages/common/src/ui/components/buttons/FlatButton.stories.tsx
+++ b/packages/common/src/ui/components/buttons/FlatButton.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { FlatButton } from './FlatButton';
-import { BookIcon } from '../../icons';
+import { BookIcon } from '@common/icons';
 
 const Template: ComponentStory<typeof FlatButton> = args => (
   <Box>

--- a/packages/common/src/ui/components/buttons/IconButton.stories.tsx
+++ b/packages/common/src/ui/components/buttons/IconButton.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { IconButton } from './IconButton';
-import { BookIcon, SvgIconProps } from '../../icons';
+import { BookIcon, SvgIconProps } from '@common/icons';
 
 const Template: ComponentStory<React.FC<SvgIconProps>> = args => (
   <Box>

--- a/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.stories.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ButtonWithIcon } from './ButtonWithIcon';
-import { BookIcon } from '../../../icons';
+import { BookIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
 
 const Template: ComponentStory<typeof ButtonWithIcon> = () => {

--- a/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.stories.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.stories.tsx
@@ -3,7 +3,7 @@ import { Box } from '@mui/material';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ButtonWithIcon } from './ButtonWithIcon';
 import { BookIcon } from '../../../icons';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 const Template: ComponentStory<typeof ButtonWithIcon> = () => {
   const t = useTranslation('common');

--- a/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ButtonProps, Tooltip } from '@mui/material';
 import { ShrinkableBaseButton } from './ShrinkableBaseButton';
-import { useIsScreen } from '../../../../hooks/useIsScreen';
+import { useIsScreen } from '@common/hooks';
 
 interface ButtonWithIconProps extends ButtonProps {
   Icon: React.ReactNode;

--- a/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
+++ b/packages/common/src/ui/components/buttons/standard/DialogButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LocaleKey, useTranslation } from '../../../../intl';
-import { ArrowRightIcon, CheckIcon, XCircleIcon } from '../../../icons';
+import { LocaleKey, useTranslation } from '@common/intl';
+import { ArrowRightIcon, CheckIcon, XCircleIcon } from '@common/icons';
 import { ButtonWithIcon } from './ButtonWithIcon';
 
 type DialogButtonVariant = 'cancel' | 'next' | 'ok';

--- a/packages/common/src/ui/components/domain/Dashboard/StatsPanel.stories.tsx
+++ b/packages/common/src/ui/components/domain/Dashboard/StatsPanel.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { StatsPanel, Stat } from './StatsPanel';
 import { Box } from '@mui/material';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 const Template: ComponentStory<typeof StatsPanel> = () => {
   const [isLoading, setIsLoading] = React.useState(true);

--- a/packages/common/src/ui/components/domain/Dashboard/Widget.stories.tsx
+++ b/packages/common/src/ui/components/domain/Dashboard/Widget.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Widget } from './Widget';
 import { Typography } from '@mui/material';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 const Template: ComponentStory<typeof Widget> = () => {
   const t = useTranslation('app');

--- a/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.stories.tsx
+++ b/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.stories.tsx
@@ -7,7 +7,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import { StatusCrumbs } from './StatusCrumbs';
-import { LocaleKey, useTranslation } from '../../../../intl';
+import { LocaleKey, useTranslation } from '@common/intl';
 
 const statusTranslation: Record<string, LocaleKey> = {
   DRAFT: 'label.draft',

--- a/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.tsx
+++ b/packages/common/src/ui/components/domain/StatusCrumbs/StatusCrumbs.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import { ChevronDownIcon } from '../../../icons';
-import { useTranslation, useFormatDate } from '../../../../intl';
+import { ChevronDownIcon } from '@common/icons';
+import { useTranslation, useFormatDate } from '@common/intl';
 import { VerticalStepper } from '../../steppers/VerticalStepper';
 import { PaperPopover, PaperPopoverSection } from '../../popover';
-import { useIsSmallScreen } from '../../../../hooks';
+import { useIsSmallScreen } from '@common/hooks';
 import { styled } from '@mui/system';
 
 interface StatusCrumbsProps<StatusType extends string> {

--- a/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
+++ b/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
@@ -1,8 +1,8 @@
 import { Box, Typography } from '@mui/material';
 import React, { FC } from 'react';
 import { ErrorBoundaryFallbackProps } from './types';
-import UnhappyMan from '../../icons/UnhappyMan';
-import { useTranslation } from '../../../intl';
+import { UnhappyMan } from '@common/icons';
+import { useTranslation } from '@common/intl';
 import { BaseButton } from '../buttons';
 
 export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({

--- a/packages/common/src/ui/components/inputs/Checkbox/Checkbox.tsx
+++ b/packages/common/src/ui/components/inputs/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import {
   CheckboxEmptyIcon,
   CheckboxCheckedIcon,
   CheckboxIndeterminateIcon,
-} from '../../../icons';
+} from '@common/icons';
 
 export const Checkbox: FC<CheckboxProps> = props => {
   return (

--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect } from 'react';
-import { styled } from '../../../../styles';
+import { styled } from '@mui/material/styles';
 import RCInput, {
   CurrencyInputProps as RCInputProps,
 } from 'react-currency-input-field';

--- a/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
+++ b/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { BasicTextInput } from '../TextInput';
-import { SearchIcon } from '../../../icons';
-import { useDebounceCallback } from '../../../../hooks';
+import { SearchIcon } from '@common/icons';
+import { useDebounceCallback } from '@common/hooks';
 import { InlineSpinner } from '../../loading';
 
 interface SearchBarProps {

--- a/packages/common/src/ui/components/loading/BasicSpinner/BasicSpinner.tsx
+++ b/packages/common/src/ui/components/loading/BasicSpinner/BasicSpinner.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { CircularProgress, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 const Container = styled(Box)({
   display: 'flex',
   alignItems: 'center',

--- a/packages/common/src/ui/components/loading/InlineSpinner/InlineSpinner.tsx
+++ b/packages/common/src/ui/components/loading/InlineSpinner/InlineSpinner.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { CircularProgress, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 interface InlineSpinnerProps {
   color?: 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ColorMenu } from './ColorMenu';
 import { StoryProvider } from '../../../../utils';
 import { IconButton } from '../../buttons';
-import { CircleIcon } from '../../../icons';
+import { CircleIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
 
 export default {

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.stories.tsx
@@ -6,7 +6,7 @@ import { ColorMenu } from './ColorMenu';
 import { StoryProvider } from '../../../../utils';
 import { IconButton } from '../../buttons';
 import { CircleIcon } from '../../../icons';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 export default {
   title: 'Menus/ColorMenu',

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
@@ -5,7 +5,7 @@ import { IconButton } from '../../buttons';
 import { TestingProvider } from '../../../../utils';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
-import { CircleIcon } from '../../../icons';
+import { CircleIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
 
 describe('ColorMenu', () => {

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.test.tsx
@@ -6,7 +6,7 @@ import { TestingProvider } from '../../../../utils';
 import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 import { CircleIcon } from '../../../icons';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 describe('ColorMenu', () => {
   const TestColorMenu = ({ onClick }: { onClick: (color: Color) => void }) => {

--- a/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
+++ b/packages/common/src/ui/components/menus/ColorMenu/ColorMenu.tsx
@@ -1,6 +1,6 @@
 import { Paper, Popover } from '@mui/material';
 import React, { FC } from 'react';
-import { CircleIcon } from '../../../icons';
+import { CircleIcon } from '@common/icons';
 
 export interface Color {
   hex: string;

--- a/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.stories.tsx
@@ -7,7 +7,7 @@ import {
   DownloadIcon,
   SuppliersIcon,
   ToolsIcon,
-} from '../../../icons';
+} from '@common/icons';
 
 export default {
   title: 'Menus/DropdownMenu',

--- a/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.tsx
+++ b/packages/common/src/ui/components/menus/DropdownMenu/DropdownMenu.tsx
@@ -12,7 +12,7 @@ import {
   styled,
 } from '@mui/material';
 
-import { ChevronDownIcon } from '../../../icons';
+import { ChevronDownIcon } from '@common/icons';
 
 interface DropdownMenuItemProps extends MenuItemProps {
   IconComponent?: React.JSXElementConstructor<SvgIconProps>;

--- a/packages/common/src/ui/components/modals/ListSearch/ListSearch.stories.tsx
+++ b/packages/common/src/ui/components/modals/ListSearch/ListSearch.stories.tsx
@@ -3,7 +3,7 @@ import { Grid } from '@mui/material';
 import { Story } from '@storybook/react';
 import { ListSearch } from './ListSearch';
 import { BaseButton } from '../../buttons';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 export default {
   title: 'Modals/ListSearch',

--- a/packages/common/src/ui/components/modals/ListSearch/ListSearch.tsx
+++ b/packages/common/src/ui/components/modals/ListSearch/ListSearch.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AutocompleteList, BaseAutocompleteListProps } from '../../inputs';
-import { useWindowDimensions } from '../../../../hooks';
+import { useWindowDimensions } from '@common/hooks';
 import { BasicModal } from '../BasicModal';
 import { ModalTitle } from '../ModalTitle';
 

--- a/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/system';
 import { Typography } from '@mui/material';
 import { useLocation, Link } from 'react-router-dom';
 
-import { LocaleKey, useTranslation } from '../../../../intl';
+import { LocaleKey, useTranslation } from '@common/intl';
 
 interface UrlPart {
   path: string;

--- a/packages/common/src/ui/components/navigation/NavLink/NavLink.stories.tsx
+++ b/packages/common/src/ui/components/navigation/NavLink/NavLink.stories.tsx
@@ -4,8 +4,8 @@ import { Route } from 'react-router-dom';
 
 import { NavLink, NavLinkProps } from './NavLink';
 import { StoryProvider, TestingRouter } from '../../../../utils/testing';
-import { TruckIcon } from '../../../icons';
-import { useDrawer } from '../../../../hooks';
+import { TruckIcon } from '@common/icons';
+import { useDrawer } from '@common/hooks';
 import { Box } from '@mui/system';
 
 export default {

--- a/packages/common/src/ui/components/navigation/NavLink/NavLink.test.tsx
+++ b/packages/common/src/ui/components/navigation/NavLink/NavLink.test.tsx
@@ -3,9 +3,9 @@ import { Box } from '@mui/system';
 import { render } from '@testing-library/react';
 import { Route } from 'react-router';
 import { NavLink } from './NavLink';
-import { useDrawer } from '../../../../hooks';
+import { useDrawer } from '@common/hooks';
 import { TestingProvider, TestingRouter } from '../../../../utils/testing';
-import { TruckIcon } from '../../../icons';
+import { TruckIcon } from '@common/icons';
 
 const Wrapper: FC<{ collapsed: boolean }> = ({ collapsed }) => {
   const drawer = useDrawer();

--- a/packages/common/src/ui/components/navigation/NavLink/NavLink.tsx
+++ b/packages/common/src/ui/components/navigation/NavLink/NavLink.tsx
@@ -10,8 +10,7 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useMatch, Link } from 'react-router-dom';
-import { useDrawer } from '../../../../hooks/useDrawer';
-import { useDebounceCallback } from '../../../../hooks';
+import { useDrawer, useDebounceCallback } from '@common/hooks';
 
 const useSelectedNavMenuItem = (to: string, end: boolean): boolean => {
   // This nav menu item should be selected when lower level elements

--- a/packages/common/src/ui/components/panels/DetailPanelSection.tsx
+++ b/packages/common/src/ui/components/panels/DetailPanelSection.tsx
@@ -7,8 +7,8 @@ import {
   styled,
   Typography,
 } from '@mui/material';
-import { Divider } from '../../components/divider/Divider';
-import { ChevronDownIcon } from '../../icons';
+import { Divider } from '@common/components';
+import { ChevronDownIcon } from '@common/icons';
 
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
   backgroundColor: theme.palette.background.menu,

--- a/packages/common/src/ui/components/popover/BasePopover/BasePopover.tsx
+++ b/packages/common/src/ui/components/popover/BasePopover/BasePopover.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import Fade from '@mui/material/Fade';
 import Popper, { PopperProps } from '@mui/material/Popper';
-import { useAppTheme } from '../../../../styles';
+import { useAppTheme } from '@common/styles';
 
 export interface BasePopoverProps extends Omit<PopperProps, 'open'> {
   isOpen: boolean;

--- a/packages/common/src/ui/components/popover/BasePopover/Popover.stories.tsx
+++ b/packages/common/src/ui/components/popover/BasePopover/Popover.stories.tsx
@@ -3,7 +3,7 @@ import { Story } from '@storybook/react';
 import Box from '@mui/material/Box';
 import { BasePopover } from '../BasePopover';
 import { BaseButton } from '../../buttons';
-import { UnhappyMan } from '../../../icons';
+import { UnhappyMan } from '@common/icons';
 
 type VirtualElement = { getBoundingClientRect: () => DOMRect };
 

--- a/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
+++ b/packages/common/src/ui/components/popover/BasePopover/usePopover.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, FC, useState, useRef, MutableRefObject } from 'react';
 import { BasePopoverProps } from '.';
-import { useDebounceCallback } from '../../../../hooks/useDebounce';
+import { useDebounceCallback } from '@common/hooks';
 import { BasePopover } from './BasePopover';
 
 type VirtualElement = { getBoundingClientRect: () => DOMRect };

--- a/packages/common/src/ui/components/popover/HoverPopover/HoverPopover.stories.tsx
+++ b/packages/common/src/ui/components/popover/HoverPopover/HoverPopover.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { HoverPopover } from './HoverPopover';
-import { UnhappyMan } from '../../../icons';
+import { UnhappyMan } from '@common/icons';
 import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
 

--- a/packages/common/src/ui/components/popover/PaperPopover/Paperpopover.stories.tsx
+++ b/packages/common/src/ui/components/popover/PaperPopover/Paperpopover.stories.tsx
@@ -4,7 +4,7 @@ import { PaperPopover } from './PaperPopover';
 import { PaperPopoverSection } from '../../../components/popover';
 import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 
 export default {
   title: 'Popover/PaperPopover',

--- a/packages/common/src/ui/components/popover/PaperPopover/Paperpopover.stories.tsx
+++ b/packages/common/src/ui/components/popover/PaperPopover/Paperpopover.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { PaperPopover } from './PaperPopover';
-import { PaperPopoverSection } from '../../../components/popover';
+import { PaperPopoverSection } from '@common/components';
 import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
 import { useTranslation } from '@common/intl';

--- a/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
+++ b/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps, styled } from '@mui/system';
 import { Portal } from '@mui/material';
 import React, { FC, useEffect, useRef } from 'react';
-import { useHostContext } from '../../../../hooks';
+import { useHostContext } from '@common/hooks';
 
 const Container = styled('div')({
   display: 'flex',

--- a/packages/common/src/ui/components/portals/AppBarContent/AppBarContent.tsx
+++ b/packages/common/src/ui/components/portals/AppBarContent/AppBarContent.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps, styled } from '@mui/system';
 import { Portal } from '@mui/material';
 import React, { FC, useEffect, useRef } from 'react';
-import { useHostContext } from '../../../../hooks';
+import { useHostContext } from '@common/hooks';
 
 // TODO: Create a function which creates the two below components?
 // createPortalPair(refName) => { Container, Portal }

--- a/packages/common/src/ui/components/portals/AppFooter/AppFooter.tsx
+++ b/packages/common/src/ui/components/portals/AppFooter/AppFooter.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps } from '@mui/system';
 import { Portal, styled } from '@mui/material';
 import React, { FC, ReactNode, useEffect, useRef } from 'react';
-import { useHostContext } from '../../../../hooks';
+import { useHostContext } from '@common/hooks';
 
 const Container = styled('div')(({ theme }) => ({
   backgroundColor: theme.palette.background.menu,

--- a/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -10,7 +10,7 @@ import {
   Portal,
 } from '@mui/material';
 import { useDetailPanelStore, useHostContext } from '../../../../hooks';
-import { useTranslation } from '../../../../intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 import { FlatButton } from '../../buttons';
 import { CloseIcon } from '../../../icons';
 import { Divider } from '../../divider/Divider';

--- a/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -9,10 +9,10 @@ import {
   useTheme,
   Portal,
 } from '@mui/material';
-import { useDetailPanelStore, useHostContext } from '../../../../hooks';
+import { useDetailPanelStore, useHostContext } from '@common/hooks';
 import { useTranslation } from '@common/intl';
 import { FlatButton } from '../../buttons';
-import { CloseIcon } from '../../../icons';
+import { CloseIcon } from '@common/icons';
 import { Divider } from '../../divider/Divider';
 
 export interface DetailPanelPortalProps {

--- a/packages/common/src/ui/components/remote/RemoteComponent.tsx
+++ b/packages/common/src/ui/components/remote/RemoteComponent.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { useRemoteScript } from '../../../hooks/useRemoteScript';
+import { useRemoteScript } from '@common/hooks';
 import { loadAndInjectDeps } from '../../../hooks/useRemoteFn';
 
 interface RemoteComponentProps {

--- a/packages/common/src/ui/forms/Modal/ModalInput.tsx
+++ b/packages/common/src/ui/forms/Modal/ModalInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid } from '@mui/material';
 import { get, UseFormRegisterReturn, useFormState } from 'react-hook-form';
 
-import { BasicTextInput } from '../../components/inputs/TextInput/BasicTextInput';
+import { BasicTextInput } from '@common/components';
 
 export interface ModalInputProps {
   defaultValue?: unknown;

--- a/packages/common/src/ui/forms/Modal/ModalNumericInput.tsx
+++ b/packages/common/src/ui/forms/Modal/ModalNumericInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid } from '@mui/material';
 import { get, UseFormRegisterReturn, useFormState } from 'react-hook-form';
 
-import { NumericTextInput } from '../../components/inputs/TextInput/NumericTextInput';
+import { NumericTextInput } from '@common/components';
 
 export interface ModalNumericInputProps {
   defaultValue?: unknown;

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -15,7 +15,7 @@ import { TableProps } from './types';
 import { DataRow } from './components/DataRow/DataRow';
 import { PaginationRow } from './columns/PaginationRow';
 import { HeaderCell, HeaderRow } from './components/Header';
-import { DomainObject } from '../../../types';
+import { DomainObject } from '@common/types';
 import { useTranslation } from '../../../intl';
 import { useTableStore } from './context';
 

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -16,7 +16,7 @@ import { DataRow } from './components/DataRow/DataRow';
 import { PaginationRow } from './columns/PaginationRow';
 import { HeaderCell, HeaderRow } from './components/Header';
 import { DomainObject } from '@common/types';
-import { useTranslation } from '../../../intl';
+import { useTranslation } from '@common/intl';
 import { useTableStore } from './context';
 
 export const DataTable = <T extends DomainObject>({

--- a/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { DomainObject } from '../../../../types';
+import { DomainObject } from '@common/types';
 import { Checkbox } from '../../../components/inputs/Checkbox';
 import { useTableStore, TableStore } from '../context';
 import { ColumnAlign, ColumnDefinition, GenericColumnKey } from './types';

--- a/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { DomainObject } from '@common/types';
-import { Checkbox } from '../../../components/inputs/Checkbox';
+import { Checkbox } from '@common/components';
 import { useTableStore, TableStore } from '../context';
 import { ColumnAlign, ColumnDefinition, GenericColumnKey } from './types';
 

--- a/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
@@ -2,7 +2,7 @@ import { InputAdornment, Tooltip, Typography } from '@mui/material';
 import React, { useState, useEffect } from 'react';
 import { ColumnDefinition } from './types';
 import { DomainObject } from '@common/types';
-import { NumericTextInput } from '../../../components';
+import { NumericTextInput } from '@common/components';
 
 interface SomeQuantityEntity extends DomainObject {
   quantity: number;

--- a/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
@@ -1,7 +1,7 @@
 import { InputAdornment, Tooltip, Typography } from '@mui/material';
 import React, { useState, useEffect } from 'react';
 import { ColumnDefinition } from './types';
-import { DomainObject } from '../../../../types';
+import { DomainObject } from '@common/types';
 import { NumericTextInput } from '../../../components';
 
 interface SomeQuantityEntity extends DomainObject {

--- a/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
+++ b/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { DomainObject } from '../../../../../types';
+import { DomainObject } from '@common/types';
 import { ColumnAlign, ColumnDefinition } from '../types';
-import { useTranslation } from '../../../../../intl';
+import { useTranslation } from '@common/intl';
 
 export const getLineLabelColumn = <
   T extends DomainObject

--- a/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Color } from '../../../components';
 import { Box } from '@mui/system';
-import { DomainObject } from '../../../../types';
+import { DomainObject } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
 import { ColorSelectButton } from '../../../components/buttons';
 

--- a/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Color } from '../../../components';
 import { Box } from '@mui/system';
 import { DomainObject } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
-import { ColorSelectButton } from '../../../components/buttons';
+import { Color, ColorSelectButton } from '@common/components';
 
 interface DomainObjectWithRequiredFields extends DomainObject {
   color: string;

--- a/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { DomainObject } from '../../../../../types';
+import { DomainObject } from '@common/types';
 import { ColumnAlign, ColumnDefinition } from '../types';
 import { MessageSquareIcon } from '../../../../icons';
 import {
   PaperPopover,
   PaperPopoverSection,
 } from '../../../../components/popover';
-import { useTranslation } from '../../../../../intl';
+import { useTranslation } from '@common/intl';
 
 interface DomainObjectWithComment extends DomainObject {
   note?: string | null;

--- a/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { DomainObject } from '@common/types';
 import { ColumnAlign, ColumnDefinition } from '../types';
-import { MessageSquareIcon } from '../../../../icons';
-import {
-  PaperPopover,
-  PaperPopoverSection,
-} from '../../../../components/popover';
+import { MessageSquareIcon } from '@common/icons';
+import { PaperPopover, PaperPopoverSection } from '@common/components';
 import { useTranslation } from '@common/intl';
 
 interface DomainObjectWithComment extends DomainObject {

--- a/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
+++ b/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Box, Typography, Pagination } from '@mui/material';
 import { useTableStore } from '../../context';
-import { useTranslation } from '../../../../../intl';
+import { useTranslation } from '@common/intl';
 
 interface PaginationRowProps {
   offset: number;

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { ColumnAlign, ColumnDefinition } from '../types';
 import { useExpanded, useTableStore } from '../../context';
 import { IconButton } from '../../../../components/buttons';
-import { DomainObject } from '../../../../../types';
-import { ChevronDownIcon, ChevronsDownIcon } from '../../../../icons';
-import { useTranslation } from '../../../../../intl';
+import { DomainObject } from '@common/types';
+import { ChevronDownIcon, ChevronsDownIcon } from '@common/icons';
+import { useTranslation } from '@common/intl';
 
 type RowExpandLabels = {
   header: string;

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/material';
 import React from 'react';
 import { ColumnAlign, ColumnDefinition } from '../types';
 import { useExpanded, useTableStore } from '../../context';
-import { IconButton } from '../../../../components/buttons';
+import { IconButton } from '@common/components';
 import { DomainObject } from '@common/types';
 import { ChevronDownIcon, ChevronsDownIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -1,7 +1,7 @@
 import { JSXElementConstructor } from 'react';
 import { SortBy } from '../../../../hooks';
 import { useTranslation, useFormatDate } from './../../../../intl';
-import { DomainObject } from './../../../../types';
+import { DomainObject } from '@common/types';
 import { LocaleKey } from '../../../../intl';
 
 export interface CellProps<T extends DomainObject> {

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -1,8 +1,7 @@
 import { JSXElementConstructor } from 'react';
-import { SortBy } from '../../../../hooks';
-import { useTranslation, useFormatDate } from './../../../../intl';
+import { SortBy } from '@common/hooks';
+import { useTranslation, useFormatDate, LocaleKey } from '@common/intl';
 import { DomainObject } from '@common/types';
-import { LocaleKey } from '../../../../intl';
 
 export interface CellProps<T extends DomainObject> {
   rowData: T;

--- a/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
-import { CurrencyInput } from '../../../../../components/inputs';
-import { DomainObject } from '../../../../../../types';
-import { useDebounceCallback } from '../../../../../../hooks';
+import { CurrencyInput } from '@common/components';
+import { DomainObject } from '@common/types';
+import { useDebounceCallback } from '@common/hooks';
 
 type DomainObjectWithUpdater<T> = T &
   DomainObject & { update?: (key: string, value: string) => void };

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
 import { BasicTextInput } from '../../../../../components/inputs/TextInput';
-import { DomainObject } from '../../../../../../types';
+import { DomainObject } from '@common/types';
 import { useDebounceCallback } from '../../../../../../hooks';
 
 type DomainObjectWithUpdater<T> = T &

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
-import { BasicTextInput } from '../../../../../components/inputs/TextInput';
+import { BasicTextInput } from '@common/components';
 import { DomainObject } from '@common/types';
-import { useDebounceCallback } from '../../../../../../hooks';
+import { useDebounceCallback } from '@common/hooks';
 
 type DomainObjectWithUpdater<T> = T &
   DomainObject & { update?: (key: string, value: string) => void };

--- a/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
 import { BasicTextInput } from '../../../../../components/inputs/TextInput';
-import { DomainObject } from '../../../../../../types';
+import { DomainObject } from '@common/types';
 import { useDebounceCallback } from '../../../../../../hooks';
 
 type DomainObjectWithUpdater<T> = T &

--- a/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
-import { BasicTextInput } from '../../../../../components/inputs/TextInput';
+import { BasicTextInput } from '@common/components';
 import { DomainObject } from '@common/types';
-import { useDebounceCallback } from '../../../../../../hooks';
+import { useDebounceCallback } from '@common/hooks';
 
 type DomainObjectWithUpdater<T> = T &
   DomainObject & { update?: (key: string, value: string) => void };

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { Column } from '../../columns/types';
-import { DomainObject } from '../../../../../types';
+import { DomainObject } from '@common/types';
 import { useExpanded, useDisabled } from '../../context';
 import { Collapse } from '@mui/material';
 interface DataRowProps<T extends DomainObject> {

--- a/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import { Table, TableHead } from '@mui/material';
 import { HeaderCell, HeaderRow } from './Header';
-import { useSortBy } from '../../../../../hooks/useSortBy';
+import { useSortBy } from '@common/hooks';
 import { useColumns } from '../../hooks';
 import { Item } from '@common/types';
 

--- a/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -4,7 +4,7 @@ import { Table, TableHead } from '@mui/material';
 import { HeaderCell, HeaderRow } from './Header';
 import { useSortBy } from '../../../../../hooks/useSortBy';
 import { useColumns } from '../../hooks';
-import { Item } from '../../../../../types';
+import { Item } from '@common/types';
 
 export default {
   title: 'Table/HeaderRow',

--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -3,7 +3,7 @@ import { waitFor, render } from '@testing-library/react';
 import { HeaderCell, HeaderRow } from './Header';
 import userEvent from '@testing-library/user-event';
 import { useColumns } from '../../hooks';
-import { Item } from '../../../../../types';
+import { Item } from '@common/types';
 import { TestingProvider } from '../../../../../utils';
 
 describe('HeaderRow', () => {

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { TableCell, TableRow, TableSortLabel } from '@mui/material';
 import { Column } from '../../columns/types';
 import { SortDescIcon } from '../../../../icons';
-import { DomainObject } from '../../../../../types';
+import { DomainObject } from '@common/types';
 import { useDebounceCallback } from '../../../../../hooks';
 
 export const HeaderRow: FC<{ dense?: boolean }> = ({ dense, ...props }) => (

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 import { TableCell, TableRow, TableSortLabel } from '@mui/material';
 import { Column } from '../../columns/types';
-import { SortDescIcon } from '../../../../icons';
+import { SortDescIcon } from '@common/icons';
 import { DomainObject } from '@common/types';
-import { useDebounceCallback } from '../../../../../hooks';
+import { useDebounceCallback } from '@common/hooks';
 
 export const HeaderRow: FC<{ dense?: boolean }> = ({ dense, ...props }) => (
   <TableRow

--- a/packages/common/src/ui/layout/tables/components/index.tsx
+++ b/packages/common/src/ui/layout/tables/components/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { CellProps, HeaderProps } from '../columns/types';
-import { DomainObject } from '../../../../types';
-import { useTranslation, useFormatDate } from '../../../../intl';
+import { DomainObject } from '@common/types';
+import { useTranslation, useFormatDate } from '@common/intl';
 
 export * from './DataRow';
 export * from './Cells';

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { ColumnAlign, ColumnFormat } from '../../columns';
 import { useColumns } from './useColumns';
-import { DomainObject } from '../../../../../types';
+import { DomainObject } from '@common/types';
 
 interface Test extends DomainObject {
   id: string;

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -10,7 +10,7 @@ import {
 import { useFormatDate, useFormatNumber } from '@common/intl';
 import { BasicCell, BasicHeader } from '../../components';
 import { getDateOrNull } from '../../../../../utils';
-import { SortBy } from '../../../../../hooks';
+import { SortBy } from '@common/hooks';
 import { ColumnDefinitionSetBuilder, ColumnKey } from '../../utils';
 
 const getColumnWidths = <T extends DomainObject>(

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -1,5 +1,5 @@
 import { DependencyList, useMemo } from 'react';
-import { DomainObject } from '../../../../../types';
+import { DomainObject } from '@common/types';
 import {
   ColumnDataAccessor,
   ColumnDefinition,
@@ -7,7 +7,7 @@ import {
   ColumnAlign,
   Column,
 } from '../../columns/types';
-import { useFormatDate, useFormatNumber } from '../../../../../intl';
+import { useFormatDate, useFormatNumber } from '@common/intl';
 import { BasicCell, BasicHeader } from '../../components';
 import { getDateOrNull } from '../../../../../utils';
 import { SortBy } from '../../../../../hooks';

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,7 +1,6 @@
 import { ReactNode, FC } from 'react';
-import { DomainObject } from './../../../types';
-import { Pagination } from '../../../hooks/usePagination';
-import { SortRule } from '../../../hooks/useSortBy';
+import { DomainObject } from '@common/types';
+import { Pagination, SortRule } from '@common/hooks';
 import { Column } from './columns/types';
 
 export interface QueryProps<D> {

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.test.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.test.ts
@@ -1,5 +1,5 @@
 import { ColumnDefinitionSetBuilder } from './ColumnDefinitionSetBuilder';
-import { DomainObject } from '../../../../types';
+import { DomainObject } from '@common/types';
 
 interface Invoice extends DomainObject {
   id: string;

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -1,6 +1,6 @@
 import { getCheckboxSelectionColumn } from '../columns/CheckboxSelectionColumn';
 import { ColumnAlign, ColumnFormat } from '../columns/types';
-import { DomainObject } from '../../../../types';
+import { DomainObject } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
 
 const createColumn = <T extends DomainObject>(

--- a/packages/common/src/utils/testing.tsx
+++ b/packages/common/src/utils/testing.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
-import AppThemeProvider from '../styles/ThemeProvider';
-import { SupportedLocales } from '../intl/intlHelpers';
+import { AppThemeProvider } from '@common/styles';
+import { SupportedLocales } from '@common/intl';
 import mediaQuery from 'css-mediaquery';
 import { SnackbarProvider } from 'notistack';
 import { QueryClientProvider, QueryClient } from 'react-query';

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"],
   "compilerOptions": {
-    "noEmit": true
+    "rootDir": "./src"
   }
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
+  "include": ["./src"],
   "compilerOptions": {
     "rootDir": "./src"
   }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"],
   "compilerOptions": {
-    "noEmit": true
+    "rootDir": "./src"
   }
 }

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"],
   "compilerOptions": {
-    "noEmit": true
+    "rootDir": "./src"
   }
 }

--- a/packages/host/src/components/LanguageMenu.tsx
+++ b/packages/host/src/components/LanguageMenu.tsx
@@ -7,7 +7,7 @@ import {
   useI18N,
   useTranslation,
 } from '@openmsupply-client/common';
-import { SupportedLocales } from '@openmsupply-client/common/src/intl/intlHelpers';
+import { SupportedLocales } from '@common/intl';
 import { useNavigate } from 'react-router';
 
 interface LanguageMenuItemProps {

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
     "rootDir": "./src"
   }
 }

--- a/packages/host/webpack.config.js
+++ b/packages/host/webpack.config.js
@@ -8,6 +8,7 @@ const path = require('path');
 // const deps = require('./package.json').dependencies;
 const BundleAnalyzerPlugin =
   require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = env => {
   const isProduction = !!env.production;
@@ -34,6 +35,7 @@ module.exports = env => {
     },
     resolve: {
       extensions: ['.js', '.css', '.ts', '.tsx'],
+      plugins: [new TsconfigPathsPlugin()],
     },
     output: {
       publicPath: isProduction ? '/' : 'http://localhost:3003/',

--- a/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -70,7 +70,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
             Input={
               <DatePickerInput
                 disabled={!isStocktakeEditable(draft)}
-                value={draft.stocktakeDate}
+                value={draft.stocktakeDatetime}
                 onChange={newDate => {
                   draft.updateStocktakeDatetime(newDate);
                 }}

--- a/packages/inventory/src/Stocktake/DetailView/api.ts
+++ b/packages/inventory/src/Stocktake/DetailView/api.ts
@@ -25,7 +25,7 @@ const linesGuard = (
   stocktakeLines: StocktakeLineConnector | ConnectorError
 ): StocktakeLineNode[] => {
   if (stocktakeLines.__typename === 'StocktakeLineConnector') {
-    return stocktakeLines.nodes;
+    return stocktakeLines.nodes ?? [];
   }
 
   if (stocktakeLines.__typename === 'ConnectorError') {
@@ -93,7 +93,6 @@ export const getStocktakeDetailViewApi = (
         ? new Date(stocktake.stocktakeDatetime)
         : null,
       entryDatetime: new Date(stocktake.entryDatetime),
-
       lines,
     };
   },

--- a/packages/inventory/src/Stocktake/DetailView/reducer.ts
+++ b/packages/inventory/src/Stocktake/DetailView/reducer.ts
@@ -74,7 +74,7 @@ const toLookup = <T, K extends keyof T & string>(
     if (!lookup[value]) {
       lookup[value] = [];
     }
-    lookup[value].push(thing);
+    (lookup[value] ?? []).push(thing);
   });
   return lookup;
 };
@@ -88,8 +88,9 @@ export const createStocktakeItem = (
     lines,
     itemName: () => ifTheSameElseDefault(lines, 'itemName', ''),
     itemCode: () => ifTheSameElseDefault(lines, 'itemCode', ''),
-    batch: () => ifTheSameElseDefault(lines, 'batch', '[multiple]'),
-    expiryDate: () => ifTheSameElseDefault(lines, 'expiryDate', '[multiple]'),
+    batch: () => ifTheSameElseDefault(lines, 'batch', '[multiple]') ?? '',
+    expiryDate: () =>
+      ifTheSameElseDefault(lines, 'expiryDate', '[multiple]') ?? '',
     countedNumPacks: () =>
       String(ifTheSameElseDefault(lines, 'countedNumPacks', '[multiple]')),
     snapshotNumPacks: () =>
@@ -101,7 +102,7 @@ export const createStocktakeItem = (
 const createStocktakeItems = (lines: StocktakeLine[]) => {
   const lookup = toLookup(lines, 'itemId');
   const ids = Object.keys(lookup);
-  return ids.map(id => createStocktakeItem(id, lookup[id]));
+  return ids.map(id => createStocktakeItem(id, lookup[id] ?? []));
 };
 
 export const reducer = (
@@ -123,23 +124,26 @@ export const reducer = (
 
         case DocumentActionType.Merge: {
           state.draft = {
+            ...state.draft,
             ...data,
             lines: createStocktakeItems(data?.lines ?? []),
             update: (key: string, value: string) => {
-              dispatch(StocktakeActionCreator.update(key, value));
+              dispatch?.(StocktakeActionCreator.update(key, value));
             },
             updateStocktakeDatetime: (newDate: Date | null) => {
-              dispatch(StocktakeActionCreator.updateStocktakeDatetime(newDate));
+              dispatch?.(
+                StocktakeActionCreator.updateStocktakeDatetime(newDate)
+              );
             },
             updateOnHold: () => {
-              dispatch(StocktakeActionCreator.updateOnHold());
+              dispatch?.(StocktakeActionCreator.updateOnHold());
             },
             updateStatus: (newStatus: StocktakeNodeStatus) =>
-              dispatch(StocktakeActionCreator.updateStatus(newStatus)),
+              dispatch?.(StocktakeActionCreator.updateStatus(newStatus)),
             sortBy: (column: Column<StocktakeItem>) =>
-              dispatch(StocktakeActionCreator.sortBy(column)),
+              dispatch?.(StocktakeActionCreator.sortBy(column)),
             upsertItem: (item: StocktakeItem) =>
-              dispatch(StocktakeActionCreator.upsertItem(item)),
+              dispatch?.(StocktakeActionCreator.upsertItem(item)),
           };
 
           break;

--- a/packages/inventory/src/Stocktake/ListView/api.ts
+++ b/packages/inventory/src/Stocktake/ListView/api.ts
@@ -53,7 +53,9 @@ const onDelete =
     throw new Error('Unknown');
   };
 
-const stocktakeToInput = (StocktakeRow: StocktakeRow): UpdateStocktakeInput => {
+const stocktakeToInput = (
+  StocktakeRow: Partial<StocktakeRow> & { id: string }
+): UpdateStocktakeInput => {
   return {
     ...StocktakeRow,
   };

--- a/packages/inventory/src/types.ts
+++ b/packages/inventory/src/types.ts
@@ -1,5 +1,5 @@
 import { Column } from './../../common/src/ui/layout/tables/columns/types';
-import { StocktakeLineNode } from './../../common/src/types/schema';
+import { StocktakeLineNode } from '@common/types';
 import { StocktakeNode, StocktakeNodeStatus } from '@openmsupply-client/common';
 
 export type StocktakeRow = Pick<
@@ -16,7 +16,7 @@ export interface StocktakeLine extends StocktakeLineNode {
   isCreated?: boolean;
   isDeleted?: boolean;
   isUpdated?: boolean;
-  update: (key: string, value: string) => void;
+  update?: (key: string, value: string) => void;
 }
 
 export interface StocktakeItem {
@@ -39,7 +39,7 @@ export interface Stocktake
     'lines' | '__typename' | 'stocktakeDatetime' | 'entryDatetime'
   > {
   lines: StocktakeLine[];
-  stocktakeDatetime: Date;
+  stocktakeDatetime: Date | null;
   entryDatetime: Date;
 }
 

--- a/packages/inventory/src/utils.ts
+++ b/packages/inventory/src/utils.ts
@@ -1,4 +1,4 @@
-import { useTranslation } from './../../common/src/intl/intlHelpers';
+import { useTranslation } from '@common/intl';
 import { StocktakeNodeStatus } from '@openmsupply-client/common';
 import { StocktakeItem, StocktakeLine, StocktakeController } from './types';
 
@@ -20,6 +20,15 @@ export const placeholderStocktake: StocktakeController = {
     throw new Error("Placeholder updater triggered - this shouldn't happen!");
   },
   updateOnHold: () => {
+    throw new Error("Placeholder updater triggered - this shouldn't happen!");
+  },
+  updateStatus: () => {
+    throw new Error("Placeholder updater triggered - this shouldn't happen!");
+  },
+  sortBy: () => {
+    throw new Error("Placeholder updater triggered - this shouldn't happen!");
+  },
+  upsertItem: () => {
     throw new Error("Placeholder updater triggered - this shouldn't happen!");
   },
 };

--- a/packages/inventory/tsconfig.json
+++ b/packages/inventory/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"],
   "compilerOptions": {
-    "noEmit": true
+    "rootDir": "./src"
   }
 }

--- a/packages/inventory/tsconfig.json
+++ b/packages/inventory/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "outDir": "./dist",
-  "rootDir": "./src"
+  "include": ["./src"],
+  "compilerOptions": {
+    "noEmit": true
+  }
 }

--- a/packages/invoices/tsconfig.json
+++ b/packages/invoices/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["./src"],
   "compilerOptions": {
-    "noEmit": true
+    "rootDir": "./src"
   }
 }

--- a/packages/mock-server/src/api/mutations/invoiceLine.ts
+++ b/packages/mock-server/src/api/mutations/invoiceLine.ts
@@ -15,7 +15,7 @@ import {
   InvoiceNodeType,
   InvoiceNodeStatus,
   DeleteResponse,
-} from '@openmsupply-client/common/src/types/schema';
+} from '@openmsupply-client/common/src/types';
 
 export const InvoiceLineMutation = {
   outbound: {

--- a/packages/mock-server/src/api/mutations/stocktake.ts
+++ b/packages/mock-server/src/api/mutations/stocktake.ts
@@ -6,7 +6,7 @@ import {
   UpdateStocktakeInput,
   DeleteStocktakeInput,
   DeleteResponse,
-} from '@openmsupply-client/common/src/types/schema';
+} from '@openmsupply-client/common/src/types';
 
 export const StocktakeMutation = {
   update: (input: UpdateStocktakeInput): ResolvedStocktake => {

--- a/packages/mock-server/src/api/mutations/stocktakeLine.ts
+++ b/packages/mock-server/src/api/mutations/stocktakeLine.ts
@@ -5,7 +5,7 @@ import {
   InsertStocktakeLineInput,
   DeleteStocktakeLineInput,
   DeleteResponse,
-} from './../../../../common/src/types/schema';
+} from '@openmsupply-client/common/src/types';
 import { db } from './../../data/database';
 
 export const StocktakeLineMutation = {

--- a/packages/mock-server/src/api/resolvers/invoice.ts
+++ b/packages/mock-server/src/api/resolvers/invoice.ts
@@ -1,7 +1,7 @@
 import { nameResolver } from './name';
 import { ListResponse } from './../../data/types';
 import { db, ResolvedInvoice, InvoiceListParameters } from './../../data';
-import { InvoiceSortFieldInput } from '@openmsupply-client/common/src/types/schema';
+import { InvoiceSortFieldInput } from '@openmsupply-client/common/src/types';
 import { getDataSorter } from '@openmsupply-client/common/src/utils/arrays/sorters';
 import { invoiceLineResolver } from './invoiceLine';
 import { createListResponse } from './utils';

--- a/packages/mock-server/tsconfig.json
+++ b/packages/mock-server/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
     "rootDir": "./src"
   }
 }

--- a/packages/requisitions/tsconfig.json
+++ b/packages/requisitions/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "outDir": "./dist",
-  "rootDir": "./src"
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.stories.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.stories.tsx
@@ -13,7 +13,7 @@ const Template: Story = () => {
 
   return (
     <ItemSearchInput
-      currentItem={selectedItem}
+      currentItem={selectedItem ?? undefined}
       onChange={item => {
         setSelectedItem(item);
       }}

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
@@ -6,10 +6,7 @@ import {
   styled,
 } from '@openmsupply-client/common';
 import { useItemsList } from '../../hooks/useItemsList';
-import {
-  Autocomplete,
-  defaultOptionMapper,
-} from '@openmsupply-client/common/src/ui/components/inputs/Autocomplete';
+import { Autocomplete, defaultOptionMapper } from '@openmsupply-client/common';
 
 const ItemOption = styled('li')(({ theme }) => ({
   color: theme.palette.gray.main,

--- a/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.stories.tsx
+++ b/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.stories.tsx
@@ -18,6 +18,7 @@ const Template: Story = () => {
       onChange={name => {
         setSelectedName(name);
       }}
+      type="customer"
     />
   );
 };

--- a/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.tsx
+++ b/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.tsx
@@ -4,7 +4,7 @@ import {
   Autocomplete,
   defaultOptionMapper,
   getDefaultOptionRenderer,
-} from '@openmsupply-client/common/src/ui/components/inputs/Autocomplete';
+} from '@common/components';
 import { useNames } from '../../hooks';
 
 const filterOptions = {

--- a/packages/system/src/Name/Components/NameSearchModal/NameSearchModal.stories.tsx
+++ b/packages/system/src/Name/Components/NameSearchModal/NameSearchModal.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { NameSearchModal } from './NameSearchModal';
-import { useToggle } from '@openmsupply-client/common';
-import { BaseButton } from '@openmsupply-client/common/src/ui/components/buttons';
+import { useToggle } from '@common/hooks';
+import { BaseButton } from '@common/components';
 
 export default {
   title: 'Name/NameSearchModal',
@@ -22,6 +22,7 @@ const Template: Story = () => {
           toggleOn();
           alert(JSON.stringify(name, null, 2));
         }}
+        type="customer"
       />
     </>
   );

--- a/packages/system/src/Name/Components/NameSearchModal/NameSearchModal.tsx
+++ b/packages/system/src/Name/Components/NameSearchModal/NameSearchModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Name, useTranslation } from '@openmsupply-client/common';
-import { ListSearch } from '@openmsupply-client/common/src/ui/components/modals/ListSearch';
+import { ListSearch } from '@common/components';
 import { useNames } from '../../hooks';
 
 interface NameSearchProps {

--- a/packages/system/tsconfig.json
+++ b/packages/system/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "outDir": "./dist",
-  "rootDir": "./src"
+  "include": ["./src"],
+  "compilerOptions": {
+    "noEmit": true
+  }
 }

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "outDir": "./dist",
-  "rootDir": "./src"
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@common/types": ["packages/common/src/types"],
       "@common/components": ["packages/common/src/ui/components"],
-      "@common/icons": ["packages/common/src/ui/icons"],
       "@common/hooks": ["packages/common/src/hooks"],
+      "@common/icons": ["packages/common/src/ui/icons"],
       "@common/intl": ["packages/common/src/intl"],
-      "@common/styles": ["packages/common/src/styles"]
+      "@common/styles": ["packages/common/src/styles"],
+      "@common/types": ["packages/common/src/types"]
     },
     "resolveJsonModule": true,
     "target": "es5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,15 @@
 {
   "files": ["./types/react-table-config.d.ts"],
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@common/types": ["packages/common/src/types"],
+      "@common/components": ["packages/common/src/ui/components"],
+      "@common/icons": ["packages/common/src/ui/icons"],
+      "@common/hooks": ["packages/common/src/hooks"],
+      "@common/intl": ["packages/common/src/intl"],
+      "@common/styles": ["packages/common/src/styles"]
+    },
     "resolveJsonModule": true,
     "target": "es5",
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,6 +1951,17 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@josephg/resolvable@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
@@ -6075,6 +6086,13 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -7900,6 +7918,114 @@ es6-shim@^0.35.5:
   version "0.35.6"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.6.tgz#d10578301a83af2de58b9eadb7c2c9945f7388a0"
 
+esbuild-android-arm64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.2.tgz#256b7cf2f9d382a2a92a4ff4e13187587c9b7c6a"
+  integrity sha512-hEixaKMN3XXCkoe+0WcexO4CcBVU5DCSUT+7P8JZiWZCbAjSkc9b6Yz2X5DSfQmRCtI/cQRU6TfMYrMQ5NBfdw==
+
+esbuild-darwin-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.2.tgz#891a59ce6bc3aded0265f982469b3eb9571b92f8"
+  integrity sha512-Uq8t0cbJQkxkQdbUfOl2wZqZ/AtLZjvJulR1HHnc96UgyzG9YlCLSDMiqjM+NANEy7/zzvwKJsy3iNC9wwqLJA==
+
+esbuild-darwin-arm64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.2.tgz#ab834fffa9c612b2901ca1e77e4695d4d8aa63a2"
+  integrity sha512-619MSa17sr7YCIrUj88KzQu2ESA4jKYtIYfLU/smX6qNgxQt3Y/gzM4s6sgJ4fPQzirvmXgcHv1ZNQAs/Xh48A==
+
+esbuild-freebsd-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.2.tgz#f7fc87a83f02de27d5a48472571efa1a432ae86d"
+  integrity sha512-aP6FE/ZsChZpUV6F3HE3x1Pz0paoYXycJ7oLt06g0G9dhJKknPawXCqQg/WMyD+ldCEZfo7F1kavenPdIT/SGQ==
+
+esbuild-freebsd-arm64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.2.tgz#bc8758420431106751f3180293cac0b5bc4ce2ee"
+  integrity sha512-LSm98WTb1QIhyS83+Po0KTpZNdd2XpVpI9ua5rLWqKWbKeNRFwOsjeiuwBaRNc+O32s9oC2ZMefETxHBV6VNkQ==
+
+esbuild-linux-32@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.2.tgz#0cc2dcd816d6d66e255bc7aeac139b1d04246812"
+  integrity sha512-8VxnNEyeUbiGflTKcuVc5JEPTqXfsx2O6ABwUbfS1Hp26lYPRPC7pKQK5Dxa0MBejGc50jy7YZae3EGQUQ8EkQ==
+
+esbuild-linux-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.2.tgz#c790f739aa75b15c153609ea3457153fbe4db93d"
+  integrity sha512-4bzMS2dNxOJoFIiHId4w+tqQzdnsch71JJV1qZnbnErSFWcR9lRgpSqWnTTFtv6XM+MvltRzSXC5wQ7AEBY6Hg==
+
+esbuild-linux-arm64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.2.tgz#96858a1f89ad30274dec780d0e3dd8b5691c6b0c"
+  integrity sha512-RlIVp0RwJrdtasDF1vTFueLYZ8WuFzxoQ1OoRFZOTyJHCGCNgh7xJIC34gd7B7+RT0CzLBB4LcM5n0LS+hIoww==
+
+esbuild-linux-arm@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.2.tgz#03e193225afa9b1215d2ec6efe8edf0c03eeed6f"
+  integrity sha512-PaylahvMHhH8YMfJPMKEqi64qA0Su+d4FNfHKvlKes/2dUe4QxgbwXT9oLVgy8iJdcFMrO7By4R8fS8S0p8aVQ==
+
+esbuild-linux-mips64le@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.2.tgz#972f218d2cb5125237376d40ad60a6e5356a782c"
+  integrity sha512-Fdwrq2roFnO5oetIiUQQueZ3+5soCxBSJswg3MvYaXDomj47BN6oAWMZgLrFh1oVrtWrxSDLCJBenYdbm2s+qQ==
+
+esbuild-linux-ppc64le@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.2.tgz#20b71622ac09142b0e523f633af0829def7fed6b"
+  integrity sha512-vxptskw8JfCDD9QqpRO0XnsM1osuWeRjPaXX1TwdveLogYsbdFtcuiuK/4FxGiNMUr1ojtnCS2rMPbY8puc5NA==
+
+esbuild-netbsd-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.2.tgz#dbd6a25117902ef67aa11d8779dd9c6bca7fbe82"
+  integrity sha512-I8+LzYK5iSNpspS9eCV9sW67Rj8FgMHimGri4mKiGAmN0pNfx+hFX146rYtzGtewuxKtTsPywWteHx+hPRLDsw==
+
+esbuild-openbsd-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.2.tgz#3c5f199eed459b2f88865548394c0b77383d9ca4"
+  integrity sha512-120HgMe9elidWUvM2E6mMf0csrGwx8sYDqUIJugyMy1oHm+/nT08bTAVXuwYG/rkMIqsEO9AlMxuYnwR6En/3Q==
+
+esbuild-sunos-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.2.tgz#900a681db6b76c6a7f60fc28d2bfe5b11698641c"
+  integrity sha512-Q3xcf9Uyfra9UuCFxoLixVvdigo0daZaKJ97TL2KNA4bxRUPK18wwGUk3AxvgDQZpRmg82w9PnkaNYo7a+24ow==
+
+esbuild-windows-32@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.2.tgz#61e0ba5bd95b277a55d2b997ac4c04dfe2559220"
+  integrity sha512-TW7O49tPsrq+N1sW8mb3m24j/iDGa4xzAZH4wHWwoIzgtZAYPKC0hpIhufRRG/LA30bdMChO9pjJZ5mtcybtBQ==
+
+esbuild-windows-64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.2.tgz#6ab59ef721ff75c682a1c8ae0570dabb637abddb"
+  integrity sha512-Rym6ViMNmi1E2QuQMWy0AFAfdY0wGwZD73BnzlsQBX5hZBuy/L+Speh7ucUZ16gwsrMM9v86icZUDrSN/lNBKg==
+
+esbuild-windows-arm64@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.2.tgz#aca2a4f83d2f0d1592ad4be832ed0045fc888cda"
+  integrity sha512-ZrLbhr0vX5Em/P1faMnHucjVVWPS+m3tktAtz93WkMZLmbRJevhiW1y4CbulBd2z0MEdXZ6emDa1zFHq5O5bSA==
+
+esbuild@~0.14.0:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.2.tgz#9c1e1a652549cc33e44885eea42ea2cc6267edc2"
+  integrity sha512-l076A6o/PIgcyM24s0dWmDI/b8RQf41uWoJu9I0M71CtW/YSw5T5NUeXxs5lo2tFQD+O4CW4nBHJXx3OY5NpXg==
+  optionalDependencies:
+    esbuild-android-arm64 "0.14.2"
+    esbuild-darwin-64 "0.14.2"
+    esbuild-darwin-arm64 "0.14.2"
+    esbuild-freebsd-64 "0.14.2"
+    esbuild-freebsd-arm64 "0.14.2"
+    esbuild-linux-32 "0.14.2"
+    esbuild-linux-64 "0.14.2"
+    esbuild-linux-arm "0.14.2"
+    esbuild-linux-arm64 "0.14.2"
+    esbuild-linux-mips64le "0.14.2"
+    esbuild-linux-ppc64le "0.14.2"
+    esbuild-netbsd-64 "0.14.2"
+    esbuild-openbsd-64 "0.14.2"
+    esbuild-sunos-64 "0.14.2"
+    esbuild-windows-32 "0.14.2"
+    esbuild-windows-64 "0.14.2"
+    esbuild-windows-arm64 "0.14.2"
+
 escalade@^3.0.2, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -8335,7 +8461,7 @@ fast-json-parse@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
 
@@ -10681,6 +10807,18 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.0:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
+  integrity sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.4"
+    picomatch "^2.2.3"
+
 jest-util@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.3.1.tgz#a58cdc7b6c8a560caac9ed6bdfc4e4ff23f80429"
@@ -10857,17 +10995,17 @@ json-to-pretty-yaml@^1.2.2:
     remedial "^1.0.7"
     remove-trailing-spaces "^1.0.6"
 
+json5@2.x, json5@^2.1.2, json5@^2.1.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2, json5@^2.1.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -11283,6 +11421,11 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -11431,7 +11574,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1, make-error@^1.1.1:
+make-error@1.x, make-error@^1, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
 
@@ -14375,15 +14518,15 @@ semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-
-semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -15544,6 +15687,21 @@ ts-essentials@^2.0.3:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
 
+ts-jest@^27.1.0:
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.0.tgz#8423cd48a47b4d66700a55702858fa5f9a415df0"
+  integrity sha512-ZouWlP03JMtzfNHg0ZeDrxAESYGmVhWyHtIl2/01kBbXaMbTr4Vhv6/GeMxUed6GFg/4ycMo+yU6Eo9gI16xTQ==
+  dependencies:
+    bs-logger "0.x"
+    esbuild "~0.14.0"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-log@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.4.tgz#d672cf904b33735eaba67a7395c93d45fba475b3"
@@ -16613,16 +16771,16 @@ yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
 
+yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.7:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.7:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
 
 yargs@^15.3.1:
   version "15.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,6 +4402,11 @@
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz#099b0712d824d15e2660c20e1c16e6a8381f308c"
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/jsonwebtoken@^8.5.0":
   version "8.5.5"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.5.tgz#da5f2f4baee88f052ef3e4db4c1a0afb46cff22c"
@@ -7786,7 +7791,7 @@ enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.8.0:
+enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.0:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   dependencies:
@@ -15574,6 +15579,25 @@ ts-node@^9:
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
+
+tsconfig-paths-webpack-plugin@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
+  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^3.9.0"
+
+tsconfig-paths@^3.9.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
+  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"


### PR DESCRIPTION
Fixes #479 

Have added aliases for 
- `@common/components`
- `@common/hooks`
- `@common/icons`
- `@common/intl`
- `@common/styles`
- `@common/types`

and updated the imports for a bunch of usages as examples.
Have left `mock-server` as that probably isn't a permanent feature and since that isn't using webpack it isn't as easy to do!

Found that the tsconfig wasn't valid for some of the packages and therefore when I fixed that, we had a bunch of compiler complaints 🙄  bit of an offroad to fix those - possibly not correctly, but it at least passes now.