### PR TITLE
limit server setup in tests

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { setScreenSize_ONLY_FOR_TESTING } from '@openmsupply-client/common';
-import { setupMockServer } from '@openmsupply-client/mock-server/src/worker/server';
 
 let mockStorage: Record<string, string> = {};
 
@@ -35,18 +34,6 @@ beforeEach(() => {
  */
 beforeEach(() => {
   setScreenSize_ONLY_FOR_TESTING(1440);
-});
-
-export const server = setupMockServer();
-
-beforeAll(() => {
-  // Establish requests interception layer before all tests.
-  server.listen();
-});
-afterAll(() => {
-  // Clean up after all tests are done, preventing this
-  // interception layer from affecting irrelevant tests.
-  server.close();
 });
 
 window.resizeTo = (width, height) => {

--- a/packages/common/src/hooks/useListData/useListData.test.tsx
+++ b/packages/common/src/hooks/useListData/useListData.test.tsx
@@ -7,8 +7,22 @@ import { Test, DomainObject } from '../../types';
 import { ListApi, useListData } from './useListData';
 import { ErrorBoundary } from '@common/components';
 import { TestingProvider } from '../../utils/testing';
+import { setupMockServer } from '@openmsupply-client/mock-server/src/worker/server';
 
 interface TestType extends Test, DomainObject {}
+
+const server = setupMockServer();
+
+beforeAll(() => {
+  // Establish requests interception layer before all tests.
+  server.listen();
+});
+
+afterAll(() => {
+  // Clean up after all tests are done, preventing this
+  // interception layer from affecting irrelevant tests.
+  server.close();
+});
 
 beforeEach(() => {
   jest.spyOn(console, 'error');

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.test.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.test.tsx
@@ -5,10 +5,24 @@ import { Route } from 'react-router';
 
 import { TestingProvider, TestingRouter } from '@openmsupply-client/common';
 import { AppBar } from '@openmsupply-client/host/src/components';
+import { setupMockServer } from '@openmsupply-client/mock-server/src/worker/server';
 
 import { OutboundShipmentListView } from './ListView';
 
 jest.setTimeout(10000);
+
+const server = setupMockServer();
+
+beforeAll(() => {
+  // Establish requests interception layer before all tests.
+  server.listen();
+});
+
+afterAll(() => {
+  // Clean up after all tests are done, preventing this
+  // interception layer from affecting irrelevant tests.
+  server.close();
+});
 
 describe('OutboundShipmentListView', () => {
   it('Renders all the headers for the list', async () => {


### PR DESCRIPTION
Fixes #554 

Spent a while exploring various options and landed here. It was getting very involved trying to encapsulate and isolate the mock data generation.. and even then the `beforeAll` in `jest-setup.ts`wasn't keeping global state across the test suite, only for each test file. so I went back to the original problem, which is that the server was being instantiated for every test file and then the data generated for every test within every file. Simple solution was to lift that out and only setup the server for tests that use it (3 of them). Tests now run faster ( originally running ~80s now around 60s for the suite )