### PR TITLE
#160 table parameters in url

### DIFF
--- a/packages/common/src/hooks/usePagination/usePagination.ts
+++ b/packages/common/src/hooks/usePagination/usePagination.ts
@@ -1,6 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
-
+import { useSearchParameters } from '../useSearchParameters';
 export interface Pagination {
   page: number;
   offset: number;
@@ -18,11 +17,9 @@ export interface PaginationState extends PaginationController {
 }
 
 export const usePagination = (initialFirst = 20): PaginationState => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const getPageFromSearchParams = () => {
-    const paramPage = Number(searchParams.get('page'));
-    return Number.isNaN(paramPage) ? 0 : Math.max(0, paramPage - 1);
-  };
+  const searchParams = useSearchParameters();
+  const getPageFromSearchParams = () =>
+    Math.max(0, searchParams.getNumber('page') - 1);
   const [first, onChangeFirst] = useState(initialFirst);
   const [offset, onChangeOffset] = useState(0);
   const [page, onChangePage] = useState(getPageFromSearchParams());
@@ -32,7 +29,7 @@ export const usePagination = (initialFirst = 20): PaginationState => {
   useEffect(() => {
     onChangeOffset(page * first);
     pageRef.current = page;
-    setSearchParams({ page: String(page + 1) });
+    searchParams.set({ page: String(page + 1) });
   }, [first, page]);
 
   useEffect(() => {

--- a/packages/common/src/hooks/usePagination/usePagination.ts
+++ b/packages/common/src/hooks/usePagination/usePagination.ts
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 export interface Pagination {
   page: number;
@@ -17,16 +18,28 @@ export interface PaginationState extends PaginationController {
 }
 
 export const usePagination = (initialFirst = 20): PaginationState => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const getPageFromSearchParams = () => {
+    const paramPage = Number(searchParams.get('page'));
+    return Number.isNaN(paramPage) ? 0 : Math.max(0, paramPage - 1);
+  };
   const [first, onChangeFirst] = useState(initialFirst);
   const [offset, onChangeOffset] = useState(0);
-  const [page, onChangePage] = useState(0);
+  const [page, onChangePage] = useState(getPageFromSearchParams());
 
   const pageRef = useRef(page);
 
   useEffect(() => {
     onChangeOffset(page * first);
     pageRef.current = page;
+    setSearchParams({ page: String(page + 1) });
   }, [first, page]);
+
+  useEffect(() => {
+    const newPage = getPageFromSearchParams();
+    onChangeOffset(newPage * first);
+    pageRef.current = newPage;
+  }, [location]);
 
   const nextPage = () => {
     onChangePage(pageRef.current + 1);

--- a/packages/common/src/hooks/useSearchParameters/index.ts
+++ b/packages/common/src/hooks/useSearchParameters/index.ts
@@ -1,0 +1,1 @@
+export * from './useSearchParameters';

--- a/packages/common/src/hooks/useSearchParameters/useSearchParameters.test.tsx
+++ b/packages/common/src/hooks/useSearchParameters/useSearchParameters.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter, useSearchParams } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
+
+import { useSearchParameters } from './useSearchParameters';
+
+const ShowParams = () => {
+  const params: Record<string, string> = {};
+  const [searchParams] = useSearchParams();
+  searchParams.forEach((value, key) => (params[key] = value));
+  return <pre>{JSON.stringify(params)}</pre>;
+};
+
+const Component: React.FC = () => {
+  const searchParams = useSearchParameters();
+
+  return (
+    <div>
+      <button onClick={() => searchParams.set({ test: 'one' })}>
+        test-one
+      </button>
+      <button onClick={() => searchParams.set({ test: 'two' })}>
+        test-two
+      </button>
+      <button onClick={() => searchParams.set({ id: '9' })}>id-nine</button>
+      <ShowParams />
+    </div>
+  );
+};
+
+const Example = () => (
+  <MemoryRouter initialEntries={['/test']}>
+    <Routes>
+      <Route path="test" element={<Component />} />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe('useSearchParameters', () => {
+  it('has a blank initial state', () => {
+    const { getByText } = render(<Example />);
+
+    expect(getByText('{}')).toBeInTheDocument();
+  });
+
+  it('correctly sets search parameter value', () => {
+    const { getByRole, getByText } = render(<Example />);
+
+    const node = getByRole('button', { name: /test-one/i });
+    act(() => node.click());
+
+    expect(getByText('{"test":"one"}')).toBeInTheDocument();
+  });
+
+  it('correctly updates search parameter value', () => {
+    const { getByRole, getByText } = render(<Example />);
+
+    const node1 = getByRole('button', { name: /test-one/i });
+    act(() => node1.click());
+
+    const node2 = getByRole('button', { name: /test-two/i });
+    act(() => node2.click());
+
+    expect(getByText('{"test":"two"}')).toBeInTheDocument();
+  });
+
+  it('correctly adds a search parameter without changing others', () => {
+    const { getByRole, getByText } = render(<Example />);
+
+    const node1 = getByRole('button', { name: /test-one/i });
+    act(() => node1.click());
+
+    const node2 = getByRole('button', { name: /id-nine/i });
+    act(() => node2.click());
+
+    expect(getByText('{"test":"one","id":"9"}')).toBeInTheDocument();
+  });
+});

--- a/packages/common/src/hooks/useSearchParameters/useSearchParameters.ts
+++ b/packages/common/src/hooks/useSearchParameters/useSearchParameters.ts
@@ -1,0 +1,26 @@
+import { useSearchParams } from 'react-router-dom';
+
+interface SearchParams {
+  get: (key: string) => string | null;
+  set: (params: Record<string, string>) => void;
+  getNumber: (key: string) => number;
+}
+
+export const useSearchParameters = (): SearchParams => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const searchParameters = {
+    get: (key: string) => searchParams.get(String(key)),
+    set: (params: Record<string, string>) => {
+      const oldParams: Record<string, string> = {};
+      searchParams.forEach((v, k) => (oldParams[k] = v));
+      setSearchParams({ ...oldParams, ...params });
+    },
+    getNumber: (key: string) => {
+      const value = Number(searchParams.get(key));
+      return Number.isNaN(value) ? 0 : value;
+    },
+  };
+
+  return searchParameters;
+};

--- a/packages/common/src/hooks/useSortBy/useSortBy.ts
+++ b/packages/common/src/hooks/useSortBy/useSortBy.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { useSearchParameters } from '../useSearchParameters';
 
 export interface SortRule<T> {
   key: keyof T | string;
@@ -24,9 +25,11 @@ export const useSortBy = <T>({
   key: initialSortKey,
   isDesc: initialIsDesc = false,
 }: SortRule<T>): SortState<T> => {
+  const searchParams = useSearchParameters();
+  const descParam = searchParams.get('desc');
   const [sortBy, setSortBy] = useState<SortBy<T>>({
-    key: initialSortKey,
-    isDesc: initialIsDesc,
+    key: searchParams.get('sort') ?? initialSortKey,
+    isDesc: descParam ? descParam === 'true' : initialIsDesc,
     direction: getDirection(initialIsDesc),
   });
 
@@ -42,6 +45,11 @@ export const useSortBy = <T>({
         isDesc: newIsDesc,
         direction: getDirection(newIsDesc),
       };
+
+      searchParams.set({
+        sort: String(newSortBy.key),
+        desc: String(newIsDesc),
+      });
 
       return newSortBy;
     });

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -36,6 +36,13 @@ export const DataTable = <T extends DomainObject>({
     if (data.length) setActiveRows(data.map(({ id }) => id as string));
   }, [data]);
 
+  // guard against a page number being set which is greater than the data allows
+  useEffect(() => {
+    if (!pagination || !onChangePage || !pagination.total) return;
+    const { page, first, total } = pagination;
+    if (page * first > total) onChangePage(0);
+  }, [pagination]);
+
   if (isLoading)
     return (
       <Box


### PR DESCRIPTION
Fixes #160 

Adds url parameters to keep `page` `sort` & `desc`
Thought about filtering and decided not ( the filter types were more complex than just having a search term in the URL parameters ). Now reconsidering.. maybe later?

