### PR TITLE
#450 can delete finalised invoices

### DIFF
--- a/packages/common/src/intl/locales/en/distribution.json
+++ b/packages/common/src/intl/locales/en/distribution.json
@@ -17,5 +17,10 @@
   "label.placeholder": "Placeholder",
   "label.add-batch": "Add batch",
   "label.order-date": "Order date",
-  "label.requisition-date": "Requisition date"
+  "label.requisition-date": "Requisition date",
+  "message.cant-delete-invoices": "Can only delete invoices with a status of 'New' or 'Allocated'",
+  "message.deleted-invoices": "Deleted {{number}} invoices",
+  "message.select-rows-to-delete": "Select rows to delete",
+  "message.cant-delete-requisitions": "Can only delete invoices with a status of 'New'",
+  "message.deleted-requisitions": "Deleted {{number}} invoices"
 }

--- a/packages/common/src/intl/locales/en/distribution.json
+++ b/packages/common/src/intl/locales/en/distribution.json
@@ -21,6 +21,6 @@
   "message.cant-delete-invoices": "Can only delete invoices with a status of 'New' or 'Allocated'",
   "message.deleted-invoices": "Deleted {{number}} invoices",
   "message.select-rows-to-delete": "Select rows to delete",
-  "message.cant-delete-requisitions": "Can only delete invoices with a status of 'New'",
-  "message.deleted-requisitions": "Deleted {{number}} invoices"
+  "message.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
+  "message.deleted-requisitions": "Deleted {{number}} requisitions"
 }

--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -4,5 +4,9 @@
     "label.finalised": "Finalised",
     "label.counted-num-of-packs": "Counted # of Packs",
     "label.add-batch": "Add batch",
-    "label.add-new-line": "Add a new line"
+    "label.add-new-line": "Add a new line",
+    "button.delete-lines": "Delete lines",
+    "message.cant-delete-stocktakes": "Can only delete stocktakes with a status of 'Suggested'",
+    "message.deleted-stocktakes": "Deleted {{number}} stocktakes",
+    "message.select-rows-to-delete": "Select rows to delete"
 }

--- a/packages/common/src/intl/locales/en/replenishment.json
+++ b/packages/common/src/intl/locales/en/replenishment.json
@@ -1,0 +1,8 @@
+{
+    "button.delete-lines": "Delete lines",
+    "message.cant-delete-invoices": "Can only delete invoices with a status of 'New'",
+    "message.deleted-invoices": "Deleted {{number}} invoices",
+    "message.select-rows-to-delete": "Select rows to delete",
+    "message.cant-delete-requisitions": "Can only delete invoices with a status of 'Draft'",
+    "message.deleted-requisitions": "Deleted {{number}} invoices"
+}

--- a/packages/common/src/intl/locales/en/replenishment.json
+++ b/packages/common/src/intl/locales/en/replenishment.json
@@ -3,6 +3,6 @@
     "message.cant-delete-invoices": "Can only delete invoices with a status of 'New'",
     "message.deleted-invoices": "Deleted {{number}} invoices",
     "message.select-rows-to-delete": "Select rows to delete",
-    "message.cant-delete-requisitions": "Can only delete invoices with a status of 'Draft'",
-    "message.deleted-requisitions": "Deleted {{number}} invoices"
+    "message.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
+    "message.deleted-requisitions": "Deleted {{number}} requisitions"
 }

--- a/packages/common/src/intl/locales/index.ts
+++ b/packages/common/src/intl/locales/index.ts
@@ -4,10 +4,12 @@ import * as common from './en/common.json';
 import * as dashboard from './en/dashboard.json';
 import * as distribution from './en/distribution.json';
 import * as inventory from './en/inventory.json';
+import * as replenishment from './en/distribution.json';
 
 export type LocaleKey =
   | keyof typeof app
   | keyof typeof dashboard
   | keyof typeof common
   | keyof typeof distribution
+  | keyof typeof replenishment
   | keyof typeof inventory;

--- a/packages/common/src/intl/locales/index.ts
+++ b/packages/common/src/intl/locales/index.ts
@@ -4,7 +4,7 @@ import * as common from './en/common.json';
 import * as dashboard from './en/dashboard.json';
 import * as distribution from './en/distribution.json';
 import * as inventory from './en/inventory.json';
-import * as replenishment from './en/distribution.json';
+import * as replenishment from './en/replenishment.json';
 
 export type LocaleKey =
   | keyof typeof app

--- a/packages/inventory/src/Stocktake/ListView/Toolbar.tsx
+++ b/packages/inventory/src/Stocktake/ListView/Toolbar.tsx
@@ -18,7 +18,7 @@ export const Toolbar: FC<{
   filter: FilterController;
   data?: StocktakeRow[];
 }> = ({ onDelete, data, filter }) => {
-  const t = useTranslation('distribution');
+  const t = useTranslation('inventory');
 
   const { success, info } = useNotification();
 

--- a/packages/inventory/src/Stocktake/ListView/Toolbar.tsx
+++ b/packages/inventory/src/Stocktake/ListView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   FilterController,
 } from '@openmsupply-client/common';
 import { StocktakeRow } from '../../types';
+import { canDeleteStocktake } from '../../utils';
 
 export const Toolbar: FC<{
   onDelete: (toDelete: StocktakeRow[]) => void;
@@ -29,11 +30,23 @@ export const Toolbar: FC<{
   }));
 
   const deleteAction = () => {
-    if (selectedRows && selectedRows?.length > 0) {
-      onDelete(selectedRows);
-      success(`Deleted ${selectedRows?.length} stocktakes`)();
+    const numberSelected = selectedRows.length;
+    if (selectedRows && numberSelected > 0) {
+      const canDeleteRows = selectedRows.every(canDeleteStocktake);
+      if (!canDeleteRows) {
+        const cannotDeleteSnack = info(t('message.cant-delete-stocktakes'));
+        cannotDeleteSnack();
+      } else {
+        onDelete(selectedRows);
+        const deletedMessage = t('messages.deleted-stocktakes', {
+          number: numberSelected,
+        });
+        const successSnack = success(deletedMessage);
+        successSnack();
+      }
     } else {
-      info('Select rows to delete them')();
+      const selectRowsSnack = info(t('message.select-rows-to-delete'));
+      selectRowsSnack();
     }
   };
 

--- a/packages/inventory/src/utils.ts
+++ b/packages/inventory/src/utils.ts
@@ -1,6 +1,11 @@
 import { useTranslation } from '@common/intl';
 import { StocktakeNodeStatus } from '@openmsupply-client/common';
-import { StocktakeItem, StocktakeLine, StocktakeController } from './types';
+import {
+  StocktakeItem,
+  StocktakeLine,
+  StocktakeController,
+  StocktakeRow,
+} from './types';
 
 export const placeholderStocktake: StocktakeController = {
   id: '',
@@ -76,3 +81,6 @@ export const getStocktakeTranslator =
 
     return t('label.finalised', { ns: 'inventory' });
   };
+
+export const canDeleteStocktake = (row: StocktakeRow): boolean =>
+  row.status === StocktakeNodeStatus.Suggested;

--- a/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
@@ -11,13 +11,14 @@ import {
   SearchBar,
 } from '@openmsupply-client/common';
 import { InvoiceRow } from '../../types';
+import { canDeleteInvoice } from '../../utils';
 
 export const Toolbar: FC<{
   onDelete: (toDelete: InvoiceRow[]) => void;
   filter: FilterController;
   data?: InvoiceRow[];
 }> = ({ onDelete, data, filter }) => {
-  const t = useTranslation();
+  const t = useTranslation('replenishment');
 
   const { success, info } = useNotification();
 
@@ -29,11 +30,23 @@ export const Toolbar: FC<{
   }));
 
   const deleteAction = () => {
-    if (selectedRows && selectedRows?.length > 0) {
-      onDelete(selectedRows);
-      success(`Deleted ${selectedRows?.length} invoices`)();
+    const numberSelected = selectedRows.length;
+    if (selectedRows && numberSelected > 0) {
+      const canDeleteRows = selectedRows.every(canDeleteInvoice);
+      if (!canDeleteRows) {
+        const cannotDeleteSnack = info(t('message.cant-delete-invoices'));
+        cannotDeleteSnack();
+      } else {
+        onDelete(selectedRows);
+        const deletedMessage = t('messages.deleted-invoices', {
+          number: numberSelected,
+        });
+        const successSnack = success(deletedMessage);
+        successSnack();
+      }
     } else {
-      info('Select rows to delete them')();
+      const selectRowsSnack = info(t('message.select-rows-to-delete'));
+      selectRowsSnack();
     }
   };
 

--- a/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   FilterController,
 } from '@openmsupply-client/common';
 import { InvoiceRow } from '../../types';
+import { canDeleteInvoice } from '../../utils';
 
 export const Toolbar: FC<{
   onDelete: (toDelete: InvoiceRow[]) => void;
@@ -29,11 +30,23 @@ export const Toolbar: FC<{
   }));
 
   const deleteAction = () => {
-    if (selectedRows && selectedRows?.length > 0) {
-      onDelete(selectedRows);
-      success(`Deleted ${selectedRows?.length} invoices`)();
+    const numberSelected = selectedRows.length;
+    if (selectedRows && numberSelected > 0) {
+      const canDeleteRows = selectedRows.every(canDeleteInvoice);
+      if (!canDeleteRows) {
+        const cannotDeleteSnack = info(t('message.cant-delete-invoices'));
+        cannotDeleteSnack();
+      } else {
+        onDelete(selectedRows);
+        const deletedMessage = t('messages.deleted-invoices', {
+          number: numberSelected,
+        });
+        const successSnack = success(deletedMessage);
+        successSnack();
+      }
     } else {
-      info('Select rows to delete them')();
+      const selectRowsSnack = info(t('message.select-rows-to-delete'));
+      selectRowsSnack();
     }
   };
 

--- a/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
@@ -38,7 +38,7 @@ export const Toolbar: FC<{
         cannotDeleteSnack();
       } else {
         onDelete(selectedRows);
-        const deletedMessage = t('messages.deleted-invoices', {
+        const deletedMessage = t('message.deleted-invoices', {
           number: numberSelected,
         });
         const successSnack = success(deletedMessage);

--- a/packages/invoices/src/utils.ts
+++ b/packages/invoices/src/utils.ts
@@ -12,6 +12,7 @@ import {
   InboundShipmentItem,
   InboundShipmentRow,
   Invoice,
+  InvoiceRow,
 } from './types';
 
 export const placeholderInbound: InboundShipment = {
@@ -211,3 +212,7 @@ export const flattenInboundItems = (
 ): InboundShipmentRow[] => {
   return summaryItems.map(({ batches }) => Object.values(batches)).flat();
 };
+
+export const canDeleteInvoice = (invoice: InvoiceRow): boolean =>
+  invoice.status === InvoiceNodeStatus.New ||
+  invoice.status === InvoiceNodeStatus.Allocated;

--- a/packages/requisitions/src/CustomerRequisition/ListView/Toolbar.tsx
+++ b/packages/requisitions/src/CustomerRequisition/ListView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   FilterController,
 } from '@openmsupply-client/common';
 import { RequisitionRow } from '../../types';
+import { canDeleteRequisition } from '../../utils';
 
 export const Toolbar: FC<{
   onDelete: (toDelete: RequisitionRow[]) => void;
@@ -29,11 +30,23 @@ export const Toolbar: FC<{
   }));
 
   const deleteAction = () => {
-    if (selectedRows && selectedRows?.length > 0) {
-      onDelete(selectedRows);
-      success(`Deleted ${selectedRows?.length} invoices`)();
+    const numberSelected = selectedRows.length;
+    if (selectedRows && numberSelected > 0) {
+      const canDeleteRows = selectedRows.every(canDeleteRequisition);
+      if (!canDeleteRows) {
+        const cannotDeleteSnack = info(t('message.cant-delete-requisitions'));
+        cannotDeleteSnack();
+      } else {
+        onDelete(selectedRows);
+        const deletedMessage = t('messages.deleted-requisitions', {
+          number: numberSelected,
+        });
+        const successSnack = success(deletedMessage);
+        successSnack();
+      }
     } else {
-      info('Select rows to delete them')();
+      const selectRowsSnack = info(t('message.select-rows-to-delete'));
+      selectRowsSnack();
     }
   };
 

--- a/packages/requisitions/src/CustomerRequisition/ListView/Toolbar.tsx
+++ b/packages/requisitions/src/CustomerRequisition/ListView/Toolbar.tsx
@@ -38,7 +38,7 @@ export const Toolbar: FC<{
         cannotDeleteSnack();
       } else {
         onDelete(selectedRows);
-        const deletedMessage = t('messages.deleted-requisitions', {
+        const deletedMessage = t('message.deleted-requisitions', {
           number: numberSelected,
         });
         const successSnack = success(deletedMessage);

--- a/packages/requisitions/src/SupplierRequisition/ListView/Toolbar.tsx
+++ b/packages/requisitions/src/SupplierRequisition/ListView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   FilterController,
 } from '@openmsupply-client/common';
 import { RequisitionRow } from '../../types';
+import { canDeleteRequisition } from '../../utils';
 
 export const Toolbar: FC<{
   onDelete: (toDelete: RequisitionRow[]) => void;
@@ -29,11 +30,23 @@ export const Toolbar: FC<{
   }));
 
   const deleteAction = () => {
-    if (selectedRows && selectedRows?.length > 0) {
-      onDelete(selectedRows);
-      success(`Deleted ${selectedRows?.length} invoices`)();
+    const numberSelected = selectedRows.length;
+    if (selectedRows && numberSelected > 0) {
+      const canDeleteRows = selectedRows.every(canDeleteRequisition);
+      if (!canDeleteRows) {
+        const cannotDeleteSnack = info(t('message.cant-delete-requisitions'));
+        cannotDeleteSnack();
+      } else {
+        onDelete(selectedRows);
+        const deletedMessage = t('messages.deleted-requisitions', {
+          number: numberSelected,
+        });
+        const successSnack = success(deletedMessage);
+        successSnack();
+      }
     } else {
-      info('Select rows to delete them')();
+      const selectRowsSnack = info(t('message.select-rows-to-delete'));
+      selectRowsSnack();
     }
   };
 

--- a/packages/requisitions/src/SupplierRequisition/ListView/Toolbar.tsx
+++ b/packages/requisitions/src/SupplierRequisition/ListView/Toolbar.tsx
@@ -38,7 +38,7 @@ export const Toolbar: FC<{
         cannotDeleteSnack();
       } else {
         onDelete(selectedRows);
-        const deletedMessage = t('messages.deleted-requisitions', {
+        const deletedMessage = t('message.deleted-requisitions', {
           number: numberSelected,
         });
         const successSnack = success(deletedMessage);

--- a/packages/requisitions/src/types.ts
+++ b/packages/requisitions/src/types.ts
@@ -43,7 +43,12 @@ export interface Requisition
 export interface RequisitionRow
   extends Pick<
     RequisitionNode,
-    'id' | 'comment' | 'otherPartyName' | 'otherPartyId' | 'theirReference'
+    | 'id'
+    | 'comment'
+    | 'otherPartyName'
+    | 'otherPartyId'
+    | 'theirReference'
+    | 'status'
   > {
   color: string;
   orderDate: Date | null;

--- a/packages/requisitions/src/utils.ts
+++ b/packages/requisitions/src/utils.ts
@@ -1,6 +1,11 @@
 import { SupplierRequisitionNodeStatus } from '@openmsupply-client/common';
 
-import { Requisition, SupplierRequisition, CustomerRequisition } from './types';
+import {
+  Requisition,
+  SupplierRequisition,
+  CustomerRequisition,
+  RequisitionRow,
+} from './types';
 
 export const placeholderSupplierRequisition: SupplierRequisition = {
   id: '',
@@ -111,3 +116,6 @@ export const getSupplierRequisitionStatuses =
     SupplierRequisitionNodeStatus.Finalised,
     SupplierRequisitionNodeStatus.Sent,
   ];
+
+export const canDeleteRequisition = (requisitionRow: RequisitionRow): boolean =>
+  requisitionRow.status === SupplierRequisitionNodeStatus.Draft;


### PR DESCRIPTION
Fixes #450 

- I went with just stopping the mutation if there are selected rows that can't be deleted. Maybe it's not the best, but should do for now?
- The problem being that if you disable the button if these rows are selected, there's no feedback as to why it's disabled. If you only delete the rows which can be deleted, what feedback are you to give? "Deleted X rows, couldn't delete Y rows as you can only delete rows with a status of Z"? Seemed confusing to me?