### PR TITLE
#645 debounced mutations

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -33,3 +33,4 @@ export * from './useToggle';
 export * from './useContentAreaHeight';
 export * from './useFilterBy';
 export * from './useNotification';
+export * from './useBufferState';

--- a/packages/common/src/hooks/useBufferState/index.tsx
+++ b/packages/common/src/hooks/useBufferState/index.tsx
@@ -1,0 +1,1 @@
+export * from './useBufferState';

--- a/packages/common/src/hooks/useBufferState/useBufferState.stories.tsx
+++ b/packages/common/src/hooks/useBufferState/useBufferState.stories.tsx
@@ -1,0 +1,57 @@
+import React, { FC, useState } from 'react';
+import { Story } from '@storybook/react';
+import { useBufferState } from './useBufferState';
+import { Box, TextField, Typography } from '@mui/material';
+import { useDebounceCallback } from '@common/hooks';
+
+export default {
+  title: 'Hooks/useBufferState',
+};
+
+const UsingBufferState: FC<{
+  value: string;
+  setValue: (newVal: string) => void;
+}> = ({ value, setValue }) => {
+  const [buffer, setBuffer] = useBufferState(value);
+
+  return (
+    <TextField
+      value={buffer}
+      onChange={e => {
+        setBuffer(e.target.value);
+        setValue(e.target.value);
+      }}
+    />
+  );
+};
+
+const Template: Story = () => {
+  const [val, setVal] = useState('');
+  const debouncedCallback = useDebounceCallback(
+    (val: string) => setVal(val),
+    []
+  );
+
+  return (
+    <Box gap={2} flexDirection="row" display="flex" alignItems="center">
+      <Box display="flex" flexDirection="column" gap={4} flex={1}>
+        <Typography>
+          When editing the normal text field, the state is set instantly. When
+          editing the text field using a buffered state, the internal state of
+          the text input is set, but the top level state is lagged by the
+          debounce.
+        </Typography>
+        <Box display="flex" flexDirection="column">
+          <Typography>Normal text field</Typography>
+          <TextField value={val} onChange={e => setVal(e.target.value)} />
+        </Box>
+        <Box display="flex" flexDirection="column">
+          <Typography>Buffered text field</Typography>
+          <UsingBufferState value={val} setValue={debouncedCallback} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export const UseBufferState = Template.bind({});

--- a/packages/common/src/hooks/useBufferState/useBufferState.ts
+++ b/packages/common/src/hooks/useBufferState/useBufferState.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+
+// It is generally discouraged to sync props and state. Generally, you should just use
+// props. Other times, you may want to seed some state with props (useState(props.value))
+// it is rare that you should try to sync state and props - essentially, this is the same
+// as seeding your state with props, however, new prop values can update the state. This occurs
+// when there is some other side effect that is able to update the content of some component -
+// i.e. if a network request results in different values for some prop than what a component
+// was initially mounted with. If you can, try to avoid using this hook and find a different way
+// but if there isn't one, here you go!
+export const useBufferState = <T>(
+  value: T
+): [T, Dispatch<SetStateAction<T>>] => {
+  const [buffer, setBuffer] = useState(value);
+
+  useEffect(() => {
+    setBuffer(value);
+  }, [value]);
+
+  return [buffer, setBuffer];
+};

--- a/packages/common/src/ui/components/inputs/TextArea/BufferedTextArea.tsx
+++ b/packages/common/src/ui/components/inputs/TextArea/BufferedTextArea.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react';
+import { StandardTextFieldProps } from '@mui/material/TextField';
+import { BasicTextInput } from '../TextInput';
+
+export const BufferedTextArea: FC<StandardTextFieldProps> = ({
+  value,
+  onChange,
+  maxRows = 4,
+  minRows = 4,
+  InputProps,
+  ...props
+}) => {
+  const [buffer, setBuffer] = React.useState(value);
+
+  React.useEffect(() => {
+    setBuffer(value);
+  }, [value]);
+
+  return (
+    <BasicTextInput
+      sx={{ width: '100%' }}
+      InputProps={{
+        ...InputProps,
+        sx: {
+          backgroundColor: 'white',
+          ...InputProps?.sx,
+        },
+      }}
+      multiline
+      value={buffer}
+      onChange={e => {
+        const newVal = e.target.value;
+        onChange?.(e);
+        setBuffer(newVal);
+      }}
+      maxRows={maxRows}
+      minRows={minRows}
+      {...props}
+    />
+  );
+};

--- a/packages/common/src/ui/components/inputs/TextArea/TextArea.tsx
+++ b/packages/common/src/ui/components/inputs/TextArea/TextArea.tsx
@@ -9,33 +9,21 @@ export const TextArea: FC<StandardTextFieldProps> = ({
   minRows = 4,
   InputProps,
   ...props
-}) => {
-  const [buffer, setBuffer] = React.useState(value);
-
-  React.useEffect(() => {
-    setBuffer(value);
-  }, [value]);
-
-  return (
-    <BasicTextInput
-      sx={{ width: '100%' }}
-      InputProps={{
-        ...InputProps,
-        sx: {
-          backgroundColor: 'white',
-          ...InputProps?.sx,
-        },
-      }}
-      multiline
-      value={buffer}
-      onChange={e => {
-        const newVal = e.target.value;
-        onChange?.(e);
-        setBuffer(newVal);
-      }}
-      maxRows={maxRows}
-      minRows={minRows}
-      {...props}
-    />
-  );
-};
+}) => (
+  <BasicTextInput
+    sx={{ width: '100%' }}
+    InputProps={{
+      ...InputProps,
+      sx: {
+        backgroundColor: 'white',
+        ...InputProps?.sx,
+      },
+    }}
+    multiline
+    value={value}
+    onChange={onChange}
+    maxRows={maxRows}
+    minRows={minRows}
+    {...props}
+  />
+);

--- a/packages/common/src/ui/components/inputs/TextArea/TextArea.tsx
+++ b/packages/common/src/ui/components/inputs/TextArea/TextArea.tsx
@@ -9,21 +9,33 @@ export const TextArea: FC<StandardTextFieldProps> = ({
   minRows = 4,
   InputProps,
   ...props
-}) => (
-  <BasicTextInput
-    sx={{ width: '100%' }}
-    InputProps={{
-      ...InputProps,
-      sx: {
-        backgroundColor: 'white',
-        ...InputProps?.sx,
-      },
-    }}
-    multiline
-    value={value}
-    onChange={onChange}
-    maxRows={maxRows}
-    minRows={minRows}
-    {...props}
-  />
-);
+}) => {
+  const [buffer, setBuffer] = React.useState(value);
+
+  React.useEffect(() => {
+    setBuffer(value);
+  }, [value]);
+
+  return (
+    <BasicTextInput
+      sx={{ width: '100%' }}
+      InputProps={{
+        ...InputProps,
+        sx: {
+          backgroundColor: 'white',
+          ...InputProps?.sx,
+        },
+      }}
+      multiline
+      value={buffer}
+      onChange={e => {
+        const newVal = e.target.value;
+        onChange?.(e);
+        setBuffer(newVal);
+      }}
+      maxRows={maxRows}
+      minRows={minRows}
+      {...props}
+    />
+  );
+};

--- a/packages/common/src/ui/components/inputs/TextArea/index.ts
+++ b/packages/common/src/ui/components/inputs/TextArea/index.ts
@@ -1,1 +1,2 @@
 export * from './TextArea';
+export * from './BufferedTextArea';

--- a/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
+++ b/packages/common/src/ui/components/inputs/TextInput/BasicTextInput.tsx
@@ -1,12 +1,14 @@
 import React, { FC } from 'react';
 import { StandardTextFieldProps, TextField } from '@mui/material';
 
+export type BasicTextInputProps = StandardTextFieldProps;
+
 /**
  * Very basic TextInput component with some simple styling applied where you can
  * build your input on top.
  */
 
-export const BasicTextInput: FC<StandardTextFieldProps> = React.forwardRef(
+export const BasicTextInput: FC<BasicTextInputProps> = React.forwardRef(
   ({ sx, InputProps, error, ...props }, ref) => (
     <TextField
       ref={ref}

--- a/packages/common/src/ui/components/inputs/TextInput/BufferedTextInput.tsx
+++ b/packages/common/src/ui/components/inputs/TextInput/BufferedTextInput.tsx
@@ -24,7 +24,7 @@ export const BufferedTextInput: FC<BufferedTextInputProps> = ({
       value={buffer}
       onChange={e => {
         setBuffer(e.target.value);
-        onChange && onChange(e);
+        onChange?.(e);
       }}
     />
   );

--- a/packages/common/src/ui/components/inputs/TextInput/BufferedTextInput.tsx
+++ b/packages/common/src/ui/components/inputs/TextInput/BufferedTextInput.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from 'react';
+import { BasicTextInput, BasicTextInputProps } from './BasicTextInput';
+import { useBufferState } from '@common/hooks';
+
+export type BufferedTextInputProps = BasicTextInputProps;
+
+/**
+ * The intention/use case of/for this component is for debouncing text input.
+ * For example when triggering a debounced network request on typing values,
+ * but wanting the text input to properly update while also allowing for
+ * the component to be controlled.
+ */
+
+export const BufferedTextInput: FC<BufferedTextInputProps> = ({
+  value,
+  onChange,
+  ...rest
+}) => {
+  const [buffer, setBuffer] = useBufferState(value);
+
+  return (
+    <BasicTextInput
+      {...rest}
+      value={buffer}
+      onChange={e => {
+        setBuffer(e.target.value);
+        onChange && onChange(e);
+      }}
+    />
+  );
+};

--- a/packages/common/src/ui/components/inputs/TextInput/index.ts
+++ b/packages/common/src/ui/components/inputs/TextInput/index.ts
@@ -2,3 +2,4 @@ export * from './BasicTextInput';
 export * from './InputWithLabelRow';
 export * from './NumericTextInput';
 export * from './ReadOnlyInput';
+export * from './BufferedTextInput';

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -71,7 +71,7 @@ export const DetailView: FC = () => {
           updateInvoice({ status: getNextInboundStatus(draft?.status) });
         }}
       />
-      <SidePanel draft={draft} update={updateInvoice} />
+      <SidePanel draft={draft} />
 
       <Modal
         title={

--- a/packages/invoices/src/InboundShipment/DetailView/SidePanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/SidePanel.tsx
@@ -9,7 +9,7 @@ import {
   PanelField,
   PanelLabel,
   PanelRow,
-  TextArea,
+  BufferedTextArea,
   useNotification,
   useTranslation,
   // ColorSelectButton,
@@ -46,7 +46,7 @@ const AdditionalInfoSection: FC = () => {
         </PanelRow>
 
         <PanelLabel>{t('heading.comment')}</PanelLabel>
-        <TextArea
+        <BufferedTextArea
           disabled={!isEditable}
           onChange={e => update({ comment: e.target.value })}
           value={comment}

--- a/packages/invoices/src/InboundShipment/DetailView/SidePanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/SidePanel.tsx
@@ -14,15 +14,16 @@ import {
   useTranslation,
   // ColorSelectButton,
 } from '@openmsupply-client/common';
-import { isInboundEditable } from '../../utils';
 import { InboundShipment } from '../../types';
+import { useInboundFields, useIsInboundEditable } from './api';
 
 interface SidePanelProps {
   draft: InboundShipment;
-  update: (patch: Partial<InboundShipment>) => Promise<InboundShipment>;
 }
 
-const AdditionalInfoSection: FC<SidePanelProps> = ({ draft, update }) => {
+const AdditionalInfoSection: FC = () => {
+  const { comment, update } = useInboundFields('comment');
+  const isEditable = useIsInboundEditable();
   const t = useTranslation('common');
 
   return (
@@ -46,9 +47,9 @@ const AdditionalInfoSection: FC<SidePanelProps> = ({ draft, update }) => {
 
         <PanelLabel>{t('heading.comment')}</PanelLabel>
         <TextArea
-          disabled={!isInboundEditable(draft)}
+          disabled={!isEditable}
           onChange={e => update({ comment: e.target.value })}
-          value={draft.comment}
+          value={comment}
         />
       </Grid>
     </DetailPanelSection>
@@ -73,7 +74,7 @@ const AdditionalInfoSection: FC<SidePanelProps> = ({ draft, update }) => {
 //   );
 // };
 
-const RelatedDocumentsSection: FC<SidePanelProps> = () => {
+const RelatedDocumentsSection: FC = () => {
   const t = useTranslation(['common', 'distribution']);
   return (
     <DetailPanelSection
@@ -105,7 +106,7 @@ const RelatedDocumentsSection: FC<SidePanelProps> = () => {
   );
 };
 
-export const SidePanel: FC<SidePanelProps> = ({ draft, update }) => {
+export const SidePanel: FC<SidePanelProps> = ({ draft }) => {
   const { success } = useNotification();
   const t = useTranslation(['outbound-shipment', 'common']);
 
@@ -142,8 +143,8 @@ export const SidePanel: FC<SidePanelProps> = ({ draft, update }) => {
         </>
       }
     >
-      <AdditionalInfoSection draft={draft} update={update} />
-      <RelatedDocumentsSection draft={draft} update={update} />
+      <AdditionalInfoSection />
+      <RelatedDocumentsSection />
     </DetailPanelPortal>
   );
 };

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -3,7 +3,7 @@ import {
   AppBarContentPortal,
   Box,
   InputWithLabelRow,
-  BasicTextInput,
+  BufferedTextInput,
   Grid,
   DropdownMenu,
   DropdownMenuItem,
@@ -13,6 +13,7 @@ import {
   useTableStore,
 } from '@openmsupply-client/common';
 import { NameSearchInput } from '@openmsupply-client/system/src/Name';
+import { useInboundFields } from './api';
 import { InboundShipment, InboundShipmentItem } from '../../types';
 import { isInboundEditable } from '../../utils';
 
@@ -21,7 +22,12 @@ interface ToolbarProps {
   update: (patch: Partial<InboundShipment>) => Promise<InboundShipment>;
 }
 
-export const Toolbar: FC<ToolbarProps> = ({ draft, update }) => {
+export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
+  const { otherParty, theirReference, update } = useInboundFields([
+    'otherParty',
+    'theirReference',
+  ]);
+
   const t = useTranslation(['distribution', 'common']);
   const { success, info } = useNotification();
 
@@ -54,14 +60,14 @@ export const Toolbar: FC<ToolbarProps> = ({ draft, update }) => {
       >
         <Grid item display="flex" flex={1}>
           <Box display="flex" flex={1} flexDirection="column" gap={1}>
-            {draft.otherParty && (
+            {otherParty && (
               <InputWithLabelRow
                 label={t('label.supplier-name')}
                 Input={
                   <NameSearchInput
                     type="supplier"
                     disabled={!isInboundEditable(draft)}
-                    value={draft.otherParty}
+                    value={otherParty}
                     onChange={name => {
                       update({ otherParty: name });
                     }}
@@ -72,11 +78,11 @@ export const Toolbar: FC<ToolbarProps> = ({ draft, update }) => {
             <InputWithLabelRow
               label={t('label.supplier-ref')}
               Input={
-                <BasicTextInput
+                <BufferedTextInput
                   disabled={!isInboundEditable(draft)}
                   size="small"
                   sx={{ width: 250 }}
-                  value={draft?.theirReference ?? ''}
+                  value={theirReference ?? ''}
                   onChange={event => {
                     update({ theirReference: event.target.value });
                   }}

--- a/packages/mock-server/src/worker/handlers/invoice/index.ts
+++ b/packages/mock-server/src/worker/handlers/invoice/index.ts
@@ -1,3 +1,4 @@
+import { MutationService } from './../../../api/mutations/index';
 import {
   mockInvoiceQuery,
   mockInvoicesQuery,
@@ -10,6 +11,7 @@ import {
   DeleteInboundShipmentInput,
   BatchInboundShipmentInput,
   BatchOutboundShipmentInput,
+  mockUpdateInboundShipmentMutation,
 } from '@openmsupply-client/common/src/types';
 import { ResolverService } from '../../../api/resolvers';
 import { Invoice as InvoiceSchema } from '../../../schema/Invoice';
@@ -31,6 +33,14 @@ const invoicesQuery = mockInvoicesQuery((req, res, ctx) => {
     ctx.data({ invoices: ResolverService.invoice.list(req.variables) })
   );
 });
+
+const updateInboundShipmentMutation = mockUpdateInboundShipmentMutation(
+  (req, res, ctx) => {
+    const { input } = req.variables;
+    const updateInboundShipment = MutationService.invoice.inbound.update(input);
+    return res(ctx.data({ updateInboundShipment }));
+  }
+);
 
 const deleteInboundShipmentsMutation = mockDeleteInboundShipmentsMutation(
   (req, res, ctx) => {
@@ -330,4 +340,5 @@ export const InvoiceHandlers = [
   insertOutboundShipmentMutation,
   upsertInboundShipmentMutation,
   upsertOutboundShipmentMutation,
+  updateInboundShipmentMutation,
 ];

--- a/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.tsx
+++ b/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Name } from '@openmsupply-client/common';
+import { Name, useBufferState } from '@openmsupply-client/common';
 import {
   Autocomplete,
   defaultOptionMapper,
@@ -30,20 +30,24 @@ export const NameSearchInput: FC<NameSearchInputProps> = ({
   const isCustomerLookup = type === 'customer';
   const filter = isCustomerLookup ? { isCustomer: true } : { isSupplier: true };
   const { data, isLoading } = useNames(filter);
+  const [buffer, setBuffer] = useBufferState(value);
 
   return (
     <Autocomplete
       disabled={disabled}
       clearable={false}
       value={
-        value && {
-          ...value,
-          label: value.name,
+        buffer && {
+          ...buffer,
+          label: buffer.name,
         }
       }
       filterOptionConfig={filterOptions}
       loading={isLoading}
-      onChange={(_, name) => name && onChange(name)}
+      onChange={(_, name) => {
+        setBuffer(name);
+        name && onChange(name);
+      }}
       options={defaultOptionMapper(data?.nodes ?? [], 'name')}
       renderOption={getDefaultOptionRenderer('name')}
       width={`${width}px`}


### PR DESCRIPTION
Fixes #645 

- Went a bit further and was investigating some different ways to structure everything. Haven't got very far with that, but have added a hook `useInboundFields`. The idea being to get away from drilling the invoice down to every nook and cranny and instead, essentially use a selector hook closer to where data is used. This makes for a pretty clean and easy way to use the 'document'. I think the API is nice being able to destructure the values you ask for, though it could be going too far.
- I've added a 'buffer' state hook and debounced the api call. This means that inputs correctly 'update' their state, but the mutation is debounced. The problems I was trying to solve with this was that we could potentially have 'updates' come from the server (i.e. someone else editing the invoice), which means we can't use a 'default value'/'internal state' for the text inputs and also if we trigger the mutation on `blur` there is a race condition on pushing 'next status'. The second problem is still there and might mean that we should reduce the debounce timer. Alternatives include disabling the status change button by tracking focus or the debounce/mutation 'state' which I'd rather avoid but it might be inevitable as the debounce timer is a likely unsafe/inaccurate - but.. might do for now.