### PR TITLE
#445 delete inbound lines

### DIFF
--- a/packages/common/src/intl/locales/en/replenishment.json
+++ b/packages/common/src/intl/locales/en/replenishment.json
@@ -4,5 +4,6 @@
     "message.deleted-invoices": "Deleted {{number}} invoices",
     "message.select-rows-to-delete": "Select rows to delete",
     "message.cant-delete-requisitions": "Can only delete requisitions with a status of 'Draft'",
-    "message.deleted-requisitions": "Deleted {{number}} requisitions"
+    "message.deleted-requisitions": "Deleted {{number}} requisitions",
+    "message.deleted-lines": "Deleted {{number}} lines"
 }

--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -1014,6 +1014,25 @@ mutation upsertOutboundShipment(
   }
 }
 
+mutation deleteInboundShipmentLines($input: [DeleteInboundShipmentLineInput!]) {
+  batchInboundShipment(deleteInboundShipmentLines: $input) {
+    deleteInboundShipmentLines {
+      id
+      response {
+        ... on DeleteInboundShipmentLineError {
+          __typename
+          error {
+            description
+          }
+        }
+        ... on DeleteResponse {
+          id
+        }
+      }
+    }
+  }
+}
+
 mutation upsertInboundShipment(
   $deleteInboundShipmentLines: [DeleteInboundShipmentLineInput!]
   $insertInboundShipmentLines: [InsertInboundShipmentLineInput!]

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -2563,6 +2563,13 @@ export type UpsertOutboundShipmentMutationVariables = Exact<{
 
 export type UpsertOutboundShipmentMutation = { __typename?: 'Mutations', batchOutboundShipment: { __typename: 'BatchOutboundShipmentResponse', insertOutboundShipmentLines?: Array<{ __typename: 'InsertOutboundShipmentLineResponseWithId', id: string }> | null | undefined, updateOutboundShipments?: Array<{ __typename: 'UpdateOutboundShipmentResponseWithId', id: string }> | null | undefined, deleteOutboundShipmentLines?: Array<{ __typename: 'DeleteOutboundShipmentLineResponseWithId', id: string }> | null | undefined, updateOutboundShipmentLines?: Array<{ __typename: 'UpdateOutboundShipmentLineResponseWithId', id: string }> | null | undefined } };
 
+export type DeleteInboundShipmentLinesMutationVariables = Exact<{
+  input?: Maybe<Array<DeleteInboundShipmentLineInput> | DeleteInboundShipmentLineInput>;
+}>;
+
+
+export type DeleteInboundShipmentLinesMutation = { __typename?: 'Mutations', batchInboundShipment: { __typename?: 'BatchInboundShipmentResponse', deleteInboundShipmentLines?: Array<{ __typename?: 'DeleteInboundShipmentLineResponseWithId', id: string, response: { __typename: 'DeleteInboundShipmentLineError', error: { __typename?: 'BatchIsReserved', description: string } | { __typename?: 'CannotEditInvoice', description: string } | { __typename?: 'DatabaseError', description: string } | { __typename?: 'ForeignKeyError', description: string } | { __typename?: 'InvoiceDoesNotBelongToCurrentStore', description: string } | { __typename?: 'InvoiceLineBelongsToAnotherInvoice', description: string } | { __typename?: 'NotAnInboundShipment', description: string } | { __typename?: 'RecordNotFound', description: string } } | { __typename?: 'DeleteResponse', id: string } }> | null | undefined } };
+
 export type UpsertInboundShipmentMutationVariables = Exact<{
   deleteInboundShipmentLines?: Maybe<Array<DeleteInboundShipmentLineInput> | DeleteInboundShipmentLineInput>;
   insertInboundShipmentLines?: Maybe<Array<InsertInboundShipmentLineInput> | InsertInboundShipmentLineInput>;
@@ -3533,6 +3540,26 @@ export const UpsertOutboundShipmentDocument = gql`
   }
 }
     `;
+export const DeleteInboundShipmentLinesDocument = gql`
+    mutation deleteInboundShipmentLines($input: [DeleteInboundShipmentLineInput!]) {
+  batchInboundShipment(deleteInboundShipmentLines: $input) {
+    deleteInboundShipmentLines {
+      id
+      response {
+        ... on DeleteInboundShipmentLineError {
+          __typename
+          error {
+            description
+          }
+        }
+        ... on DeleteResponse {
+          id
+        }
+      }
+    }
+  }
+}
+    `;
 export const UpsertInboundShipmentDocument = gql`
     mutation upsertInboundShipment($deleteInboundShipmentLines: [DeleteInboundShipmentLineInput!], $insertInboundShipmentLines: [InsertInboundShipmentLineInput!], $updateInboundShipmentLines: [UpdateInboundShipmentLineInput!], $updateInboundShipments: [UpdateInboundShipmentInput!]) {
   batchInboundShipment(
@@ -3747,6 +3774,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     upsertOutboundShipment(variables?: UpsertOutboundShipmentMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertOutboundShipmentMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<UpsertOutboundShipmentMutation>(UpsertOutboundShipmentDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertOutboundShipment');
+    },
+    deleteInboundShipmentLines(variables?: DeleteInboundShipmentLinesMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<DeleteInboundShipmentLinesMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteInboundShipmentLinesMutation>(DeleteInboundShipmentLinesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteInboundShipmentLines');
     },
     upsertInboundShipment(variables?: UpsertInboundShipmentMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertInboundShipmentMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<UpsertInboundShipmentMutation>(UpsertInboundShipmentDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertInboundShipment');
@@ -4220,6 +4250,23 @@ export const mockStockCountsQuery = (resolver: ResponseResolver<GraphQLRequest<S
 export const mockUpsertOutboundShipmentMutation = (resolver: ResponseResolver<GraphQLRequest<UpsertOutboundShipmentMutationVariables>, GraphQLContext<UpsertOutboundShipmentMutation>, any>) =>
   graphql.mutation<UpsertOutboundShipmentMutation, UpsertOutboundShipmentMutationVariables>(
     'upsertOutboundShipment',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockDeleteInboundShipmentLinesMutation((req, res, ctx) => {
+ *   const { input } = req.variables;
+ *   return res(
+ *     ctx.data({ batchInboundShipment })
+ *   )
+ * })
+ */
+export const mockDeleteInboundShipmentLinesMutation = (resolver: ResponseResolver<GraphQLRequest<DeleteInboundShipmentLinesMutationVariables>, GraphQLContext<DeleteInboundShipmentLinesMutation>, any>) =>
+  graphql.mutation<DeleteInboundShipmentLinesMutation, DeleteInboundShipmentLinesMutationVariables>(
+    'deleteInboundShipmentLines',
     resolver
   )
 

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -13,8 +13,8 @@ import {
   useTableStore,
 } from '@openmsupply-client/common';
 import { NameSearchInput } from '@openmsupply-client/system/src/Name';
-import { useInboundFields } from './api';
-import { InboundShipment, InboundShipmentItem } from '../../types';
+import { useDeleteInboundLine, useInboundFields, useInboundItems } from './api';
+import { InboundShipment } from '../../types';
 import { isInboundEditable } from '../../utils';
 
 interface ToolbarProps {
@@ -23,6 +23,9 @@ interface ToolbarProps {
 }
 
 export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
+  const { data } = useInboundItems();
+
+  const { mutate } = useDeleteInboundLine();
   const { otherParty, theirReference, update } = useInboundFields([
     'otherParty',
     'theirReference',
@@ -34,15 +37,19 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
   const { selectedRows } = useTableStore(state => ({
     selectedRows: Object.keys(state.rowState)
       .filter(id => state.rowState[id]?.isSelected)
-      .map(selectedId => draft.items.find(({ id }) => selectedId === id))
-      .filter(Boolean) as InboundShipmentItem[],
+      .map(selectedId => data.find(({ id }) => selectedId === id))
+      .filter(Boolean)
+      .map(({ batches }) => Object.values(batches))
+      .flat()
+      .map(({ id }) => id),
   }));
 
-  const deleteAction = () => {
+  const deleteAction = async () => {
     if (selectedRows && selectedRows?.length > 0) {
-      selectedRows.forEach(item => draft.deleteItem?.(item));
-      const successSnack = success(`Deleted ${selectedRows?.length} lines`);
-      successSnack();
+      const onSuccess = success(`Deleted ${selectedRows?.length} lines`);
+      mutate(selectedRows, {
+        onSuccess,
+      });
     } else {
       const infoSnack = info(t('label.select-rows-to-delete-them'));
       infoSnack();

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -24,14 +24,13 @@ interface ToolbarProps {
 
 export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
   const { data } = useInboundItems();
-
   const { mutate } = useDeleteInboundLine();
   const { otherParty, theirReference, update } = useInboundFields([
     'otherParty',
     'theirReference',
   ]);
 
-  const t = useTranslation(['distribution', 'common']);
+  const t = useTranslation(['replenishment', 'common']);
   const { success, info } = useNotification();
 
   const { selectedRows } = useTableStore(state => ({
@@ -46,7 +45,8 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
 
   const deleteAction = async () => {
     if (selectedRows && selectedRows?.length > 0) {
-      const onSuccess = success(`Deleted ${selectedRows?.length} lines`);
+      const number = selectedRows?.length;
+      const onSuccess = success(t('message.deleted-lines', { number }));
       mutate(selectedRows, {
         onSuccess,
       });

--- a/packages/invoices/src/InboundShipment/DetailView/api.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/api.ts
@@ -473,8 +473,9 @@ const getCreateDeleteInboundLineInput =
 
 const getDeleteInboundLinesQuery =
   (api: OmSupplyApi, invoiceId: string) => (ids: string[]) => {
+    const createDeleteLineInput = getCreateDeleteInboundLineInput(invoiceId);
     return api.deleteInboundShipmentLines({
-      input: ids.map(getCreateDeleteInboundLineInput(invoiceId)),
+      input: ids.map(createDeleteLineInput),
     });
   };
 

--- a/packages/mock-server/src/worker/handlers/invoice/index.ts
+++ b/packages/mock-server/src/worker/handlers/invoice/index.ts
@@ -35,8 +35,10 @@ const deleteInboundShipmentLines = mockDeleteInboundShipmentLinesMutation(
   (req, res, ctx) => {
     const { variables } = req;
 
-    if (Array.isArray(variables)) {
-      variables.map(input => MutationService.invoiceLine.inbound.remove(input));
+    if (Array.isArray(variables.input)) {
+      variables.input.map(input =>
+        MutationService.invoiceLine.inbound.remove(input)
+      );
     } else {
       MutationService.invoiceLine.inbound.remove(
         variables.input as DeleteInboundShipmentLineInput

--- a/packages/mock-server/src/worker/handlers/invoice/index.ts
+++ b/packages/mock-server/src/worker/handlers/invoice/index.ts
@@ -11,7 +11,10 @@ import {
   DeleteInboundShipmentInput,
   BatchInboundShipmentInput,
   BatchOutboundShipmentInput,
+  mockDeleteInboundShipmentLinesMutation,
   mockUpdateInboundShipmentMutation,
+  DeleteInboundShipmentLineInput,
+  DeleteInboundShipmentLinesMutation,
 } from '@openmsupply-client/common/src/types';
 import { ResolverService } from '../../../api/resolvers';
 import { Invoice as InvoiceSchema } from '../../../schema/Invoice';
@@ -27,6 +30,26 @@ const invoiceQuery = mockInvoiceQuery((req, res, ctx) => {
     })
   );
 });
+
+const deleteInboundShipmentLines = mockDeleteInboundShipmentLinesMutation(
+  (req, res, ctx) => {
+    const { variables } = req;
+
+    if (Array.isArray(variables)) {
+      variables.map(input => MutationService.invoiceLine.inbound.remove(input));
+    } else {
+      MutationService.invoiceLine.inbound.remove(
+        variables.input as DeleteInboundShipmentLineInput
+      );
+    }
+
+    const response: DeleteInboundShipmentLinesMutation = {
+      batchInboundShipment: { deleteInboundShipmentLines: null },
+    };
+
+    return res(ctx.data(response));
+  }
+);
 
 const invoicesQuery = mockInvoicesQuery((req, res, ctx) => {
   return res(
@@ -341,4 +364,5 @@ export const InvoiceHandlers = [
   upsertInboundShipmentMutation,
   upsertOutboundShipmentMutation,
   updateInboundShipmentMutation,
+  deleteInboundShipmentLines,
 ];


### PR DESCRIPTION
Fixes #445 

- Still need to add grouping here so I suppose this might change slightly, still as we will need to know if currently grouped, then the IDs are for summary items and so need to find the real invoice lines, otherwise they're for normal lines and we can just use the IDs.

