### PR TITLE
Font fun

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
-import '@fontsource/inter';
+import '@fontsource/inter/variable.css';
+// import "@fontsource/inter/variable-italic.css"; // Italic variant: not currently used
 import React from 'react';
 import { CssBaseline } from '@mui/material';
 import { addDecorator } from '@storybook/react';

--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -143,15 +143,15 @@ const themeOptions = {
   },
   typography: {
     body1: {
-      fontFamily: 'Inter,Arial',
+      fontFamily: 'InterVariable',
       fontSize: 14,
       lineHeight: 1.71,
       color: '#1c1c28',
     },
-    fontFamily: 'Inter,Arial',
+    fontFamily: 'InterVariable',
     th: { color: '#1c1c28', fontSize: 14, fontWeight: 700 },
     h6: {
-      fontFamily: 'Inter,Arial',
+      fontFamily: 'InterVariable',
       fontSize: 16,
       color: '#555770',
     },

--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -143,15 +143,15 @@ const themeOptions = {
   },
   typography: {
     body1: {
-      fontFamily: 'Inter',
+      fontFamily: 'Inter,Arial',
       fontSize: 14,
       lineHeight: 1.71,
       color: '#1c1c28',
     },
-    fontFamily: 'Inter',
+    fontFamily: 'Inter,Arial',
     th: { color: '#1c1c28', fontSize: 14, fontWeight: 700 },
     h6: {
-      fontFamily: 'Inter',
+      fontFamily: 'Inter,Arial',
       fontSize: 16,
       color: '#555770',
     },

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -79,14 +79,14 @@ export const DataTable = <T extends DomainObject>({
       <MuiTable sx={{ display: 'block', flex: 1 }}>
         <TableHead
           sx={{
-            backgroundColor: 'background.white',
+            backgroundColor: dense ? 'transparent' : 'background.white',
             flex: 1,
             display: 'flex',
             flexDirection: 'column',
             position: 'sticky',
             top: 0,
             zIndex: 10,
-            boxShadow: theme => theme.shadows[2],
+            boxShadow: dense ? null : theme => theme.shadows[2],
           }}
         >
           <HeaderRow dense={dense}>

--- a/packages/host/public/index.html
+++ b/packages/host/public/index.html
@@ -1,8 +1,10 @@
 <html>
   <head>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Inter"
     />
     <script type="text/javascript" src="/config.js"></script>
   </head>

--- a/packages/host/public/index.html
+++ b/packages/host/public/index.html
@@ -1,11 +1,5 @@
 <html>
   <head>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <script type="text/javascript" src="/config.js"></script>
   </head>
 

--- a/packages/host/src/App.tsx
+++ b/packages/host/src/App.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react';
 import Host from './Host';
+import '@fontsource/inter/variable.css';
+// import "@fontsource/inter/variable-italic.css"; // Italic variant: not currently used
 
 const App: FC = () => {
   return <Host />;

--- a/packages/host/webpack.config.js
+++ b/packages/host/webpack.config.js
@@ -65,6 +65,14 @@ module.exports = env => {
             },
           },
         },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.(woff|woff2|ttf|eot)$/,
+          use: 'file-loader?name=fonts/[name].[ext]!static',
+        },
       ],
     },
     plugins: [


### PR DESCRIPTION
Fixes #492 - kinda. Possibly makes it worse

Spent a while looking at options, since I've had the fout show for me too! Found it hard to replicate actually, so decided after much playing around, that it isn't a huge problem.. and also that it might be better to have the text show than to delay display of the site. We already have react suspense, and if you are using chrome or firefox, there is a 3s FOIT (flash of invisible text) time anyway before the default font is used and then updated to the correct font.

I did add a fallback of `Arial` rather than the serif default, this is much closer to `Inter` so the fout is less obvious, maybe?

And then made things a little worse, possibly, by adding in the font weights that we are using - I did wonder why the fonts weren't looking exactly the same as in zeplin. turns out we weren't loading all the weights.

Then went offroad a little and fixed the table headers, which were looking like this:

### Stocktake
<img width="988" alt="Screen Shot 2021-12-21 at 11 08 10 AM" src="https://user-images.githubusercontent.com/9192912/146839985-edf3cb73-bdfc-4301-8765-2ccb46fe6d45.png">

### Outbound shipment
<img width="994" alt="Screen Shot 2021-12-21 at 11 07 25 AM" src="https://user-images.githubusercontent.com/9192912/146840054-cf2321c2-81d4-47c9-a99c-8454e98520fd.png">


and now look better 😀 
### Stocktake
<img width="982" alt="Screen Shot 2021-12-21 at 11 09 01 AM" src="https://user-images.githubusercontent.com/9192912/146840075-4f629e17-1432-4b65-9d21-4bb838af4f2d.png">


### Outbound shipment
<img width="996" alt="Screen Shot 2021-12-21 at 11 09 35 AM" src="https://user-images.githubusercontent.com/9192912/146840068-a1a4d0de-e616-4479-891b-b069f01e28e7.png">

