### PR TITLE
#677 inbound detail view crash

### DIFF
--- a/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.test.tsx
@@ -10,8 +10,8 @@ import { Route } from 'react-router';
 import { Breadcrumbs } from './Breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  it('Renders the name of the current route from the URL', () => {
-    const { getByText } = render(
+  it('does not renders the top level part of the current URL', () => {
+    const { queryByText } = render(
       <TestingProvider>
         <TestingRouter
           initialEntries={[RouteBuilder.create(AppRoute.Distribution).build()]}
@@ -21,9 +21,9 @@ describe('Breadcrumbs', () => {
       </TestingProvider>
     );
 
-    expect(getByText(/distribution/i));
+    expect(queryByText(/distribution/i)).not.toBeInTheDocument();
   });
-  it('Renders the names of the current routes from the URL', () => {
+  it('Renders the names of all the routes from the URL, excluding the first', () => {
     const { getByText } = render(
       <TestingProvider>
         <TestingRouter
@@ -38,10 +38,10 @@ describe('Breadcrumbs', () => {
       </TestingProvider>
     );
 
-    expect(getByText(/distribution/i));
+    expect(getByText(/outbound/i));
   });
 
-  it('Renders the non-last elements as links to the prior pages', () => {
+  it('Renders the non-last elements as links to the prior pages, excluding the first', () => {
     const { getByRole } = render(
       <TestingProvider>
         <TestingRouter
@@ -57,7 +57,6 @@ describe('Breadcrumbs', () => {
       </TestingProvider>
     );
 
-    expect(getByRole('link', { name: /distribution/i })).toBeInTheDocument();
     expect(getByRole('link', { name: /requisition/i })).toBeInTheDocument();
   });
 
@@ -98,10 +97,6 @@ describe('Breadcrumbs', () => {
       </TestingProvider>
     );
 
-    expect(getByRole('link', { name: /distribution/i })).toHaveAttribute(
-      'href',
-      '/distribution'
-    );
     expect(getByRole('link', { name: /requisition/i })).toHaveAttribute(
       'href',
       '/distribution/customer-requisition'

--- a/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.test.tsx
@@ -10,7 +10,7 @@ import { Route } from 'react-router';
 import { Breadcrumbs } from './Breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  it('does not renders the top level part of the current URL', () => {
+  it('does not render the top level part of the current URL', () => {
     const { queryByText } = render(
       <TestingProvider>
         <TestingRouter

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -16,17 +16,20 @@ export const BatchTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
       key: 'snapshotNumPacks',
       label: 'label.num-packs',
       width: 100,
+      setter: () => {},
     },
     {
       key: 'snapshotPackSize',
       label: 'label.pack-size',
       width: 100,
+      setter: () => {},
     },
     {
       key: 'countedNumPacks',
       label: 'label.counted-num-of-packs',
       width: 100,
       Cell: NumberInputCell,
+      setter: () => {},
     },
     'expiryDate',
   ]);
@@ -44,8 +47,14 @@ export const BatchTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
 export const PricingTable: FC<{ batches: StocktakeLine[] }> = ({ batches }) => {
   const t = useTranslation('inventory');
   const columns = useColumns<StocktakeLine>([
-    ['sellPricePerPack', { Cell: CurrencyInputCell, width: 200 }],
-    ['costPricePerPack', { Cell: CurrencyInputCell, width: 200 }],
+    [
+      'sellPricePerPack',
+      { Cell: CurrencyInputCell, width: 200, setter: () => {} },
+    ],
+    [
+      'costPricePerPack',
+      { Cell: CurrencyInputCell, width: 200, setter: () => {} },
+    ],
   ]);
 
   return (

--- a/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
@@ -68,7 +68,6 @@ export const Footer: FC<InboundDetailFooterProps> = ({ draft, save }) => {
   return (
     <AppFooterPortal
       Content={
-        !!onHold &&
         !!status && (
           <Box
             gap={2}

--- a/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
@@ -90,7 +90,7 @@ export const Footer: FC<InboundDetailFooterProps> = ({ draft, save }) => {
             />
 
             <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
-              {!isEditable && (
+              {isEditable && (
                 <>
                   <ButtonWithIcon
                     shrinkThreshold="lg"

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -29,8 +29,6 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
     'theirReference',
   ]);
 
-  if (!data) return null;
-
   const t = useTranslation(['replenishment', 'common']);
   const { success, info } = useNotification();
 
@@ -38,7 +36,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
     selectedRows: (
       Object.keys(state.rowState)
         .filter(id => state.rowState[id]?.isSelected)
-        .map(selectedId => data.find(({ id }) => selectedId === id))
+        .map(selectedId => data?.find(({ id }) => selectedId === id))
         .filter(Boolean) as InboundShipmentItem[]
     )
       .map(({ batches }) => Object.values(batches))
@@ -58,6 +56,8 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
       infoSnack();
     }
   };
+
+  if (!data) return null;
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>


### PR DESCRIPTION
Fixes #677 

- Early return caused the number of hooks rendering to vary. doh, no idea how I did this!
- Then I thought to check tests and figured I'd do a quick fix for the breadcrumbs
- Then I noticed that the stocktake page was also having an error .. so I offroaded that also.
- Then I noticed the inbound shipment footer wasn't showing when it wasn't on hold... so I offroaded that also.