### PR TITLE
Add style updates

### DIFF
--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -56,6 +56,12 @@ declare module '@mui/material/Switch' {
   }
 }
 
+declare module '@mui/material/styles/zIndex' {
+  interface ZIndex {
+    tableHeader: number;
+  }
+}
+
 declare module '@mui/material/styles/createPalette' {
   interface Palette {
     border: string;
@@ -140,6 +146,18 @@ const themeOptions = {
       field: '#555770',
       label: '#28293d',
     },
+  },
+  zIndex: {
+    tableHeader: 1000,
+
+    // Defaults below. Pasted here for convenience!
+    mobileStepper: 1000,
+    speedDial: 1050,
+    appBar: 1100,
+    drawer: 1200,
+    modal: 1300,
+    snackbar: 1400,
+    tooltip: 1500,
   },
   typography: {
     body1: {

--- a/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -42,6 +42,7 @@ const StyledDrawer = styled(Box, {
   borderRadius: 8,
   height: '100vh',
   overflow: 'hidden',
+  zIndex: theme.zIndex.drawer,
   boxShadow: theme.shadows[7],
   ...(isOpen && openedMixin(theme)),
   ...(!isOpen && closedMixin(theme)),

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -78,7 +78,7 @@ export const DataTable = <T extends DomainObject>({
         overflowX: 'unset',
       }}
     >
-      <MuiTable sx={{ display: 'block', flex: 1 }}>
+      <MuiTable>
         <TableHead
           sx={{
             backgroundColor: dense ? 'transparent' : 'background.white',

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -6,6 +6,8 @@ import {
   CircularProgress,
   TableBody,
   TableHead,
+  TableFooter,
+  TableRow,
   TableContainer,
   Table as MuiTable,
   Typography,
@@ -85,7 +87,7 @@ export const DataTable = <T extends DomainObject>({
             flexDirection: 'column',
             position: 'sticky',
             top: 0,
-            zIndex: 10,
+            zIndex: 'tableHeader',
             boxShadow: dense ? null : theme => theme.shadows[2],
           }}
         >
@@ -116,16 +118,29 @@ export const DataTable = <T extends DomainObject>({
             );
           })}
         </TableBody>
+        <TableFooter
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'sticky',
+            insetBlockEnd: 0,
+            backgroundColor: 'white',
+          }}
+        >
+          <TableRow>
+            {pagination && onChangePage && (
+              <PaginationRow
+                page={pagination.page}
+                offset={pagination.offset}
+                first={pagination.first}
+                total={pagination.total ?? 0}
+                onChange={onChangePage}
+              />
+            )}
+          </TableRow>
+        </TableFooter>
       </MuiTable>
-      {pagination && onChangePage && (
-        <PaginationRow
-          page={pagination.page}
-          offset={pagination.offset}
-          first={pagination.first}
-          total={pagination.total ?? 0}
-          onChange={onChangePage}
-        />
-      )}
     </TableContainer>
   );
 };

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -223,7 +223,7 @@ const Host: FC = () => (
                           overflow="hidden"
                         >
                           <AppBar />
-                          <Box display="flex" flex={1} overflow="scroll">
+                          <Box display="flex" flex={1} overflow="auto">
                             <Routes>
                               <Route
                                 path={RouteBuilder.create(AppRoute.Dashboard)

--- a/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
@@ -47,23 +47,24 @@ export const GeneralTab: FC<
   );
 
   return (
-    <Grid container flexDirection="column" flexWrap="nowrap" width="auto">
-      <Grid
-        item
-        justifyContent="flex-start"
-        display="flex"
-        flex={0}
-        sx={{ padding: '5px', paddingLeft: '15px' }}
-      >
-        <Switch
-          label={t('label.group-by-item', { ns: 'replenishment' })}
-          onChange={toggleIsGrouped}
-          checked={isGrouped}
-          size="small"
-          disabled={rows?.length === 0}
-          color="secondary"
-        />
-      </Grid>
+    <Grid container display="block">
+      {rows?.length !== 0 && (
+        <Grid
+          item
+          justifyContent="flex-start"
+          display="flex"
+          sx={{ padding: '5px', paddingLeft: '15px' }}
+        >
+          <Switch
+            label={t('label.group-by-item', { ns: 'replenishment' })}
+            onChange={toggleIsGrouped}
+            checked={isGrouped}
+            size="small"
+            disabled={rows?.length === 0}
+            color="secondary"
+          />
+        </Grid>
+      )}
       <Grid item>
         <DataTable
           onRowClick={onRowClick}

--- a/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
@@ -5,7 +5,7 @@ import {
   DomainObject,
   useTranslation,
   useIsGrouped,
-  Grid,
+  Box,
   Switch,
   MiniTable,
 } from '@openmsupply-client/common';
@@ -47,14 +47,9 @@ export const GeneralTab: FC<
   );
 
   return (
-    <Grid container display="block">
+    <Box flexDirection="column">
       {rows?.length !== 0 && (
-        <Grid
-          item
-          justifyContent="flex-start"
-          display="flex"
-          sx={{ padding: '5px', paddingLeft: '15px' }}
-        >
+        <Box style={{ padding: 5, paddingLeft: 15 }}>
           <Switch
             label={t('label.group-by-item', { ns: 'replenishment' })}
             onChange={toggleIsGrouped}
@@ -63,19 +58,17 @@ export const GeneralTab: FC<
             disabled={rows?.length === 0}
             color="secondary"
           />
-        </Grid>
+        </Box>
       )}
-      <Grid item>
-        <DataTable
-          onRowClick={onRowClick}
-          ExpandContent={Expando}
-          pagination={{ ...pagination, total: rows?.length }}
-          columns={columns}
-          data={paged}
-          onChangePage={pagination.onChangePage}
-          noDataMessage={t('error.no-items')}
-        />
-      </Grid>
-    </Grid>
+      <DataTable
+        onRowClick={onRowClick}
+        ExpandContent={Expando}
+        pagination={{ ...pagination, total: rows?.length }}
+        columns={columns}
+        data={paged}
+        onChangePage={pagination.onChangePage}
+        noDataMessage={t('error.no-items')}
+      />
+    </Box>
   );
 });

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -54,7 +54,7 @@ export const InboundListView: FC = () => {
       // getNameAndColorColumn((row: InvoiceRow, color: Color) => {
       //   onUpdate({ ...row, color: color.hex });
       // }),
-      'otherPartyName',
+      ['otherPartyName', { width: 50 }],
       [
         'status',
         {

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -54,7 +54,7 @@ export const InboundListView: FC = () => {
       // getNameAndColorColumn((row: InvoiceRow, color: Color) => {
       //   onUpdate({ ...row, color: color.hex });
       // }),
-      ['otherPartyName', { width: 50 }],
+      'otherPartyName',
       [
         'status',
         {

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -6,7 +6,7 @@ import {
   Column,
   DomainObject,
   useTranslation,
-  Grid,
+  Box,
   Switch,
   useColumns,
   MiniTable,
@@ -98,14 +98,9 @@ export const GeneralTabComponent: FC<
   }, [isGrouped, data]);
 
   return (
-    <Grid container display="block">
+    <Box flexDirection="column">
       {activeRows?.length !== 0 && (
-        <Grid
-          item
-          justifyContent="flex-start"
-          display="flex"
-          sx={{ padding: '5px', paddingLeft: '15px' }}
-        >
+        <Box style={{ padding: 5, paddingLeft: 15 }}>
           <Switch
             label={t('label.group-by-item')}
             onChange={toggleIsGrouped}
@@ -114,20 +109,18 @@ export const GeneralTabComponent: FC<
             disabled={activeRows.length === 0}
             color="secondary"
           />
-        </Grid>
+        </Box>
       )}
-      <Grid item>
-        <DataTable
-          onRowClick={onRowClick}
-          ExpandContent={Expand}
-          pagination={{ ...pagination, total: activeRows.length }}
-          columns={columns}
-          data={activeRows}
-          onChangePage={pagination.onChangePage}
-          noDataMessage={t('error.no-items')}
-        />
-      </Grid>
-    </Grid>
+      <DataTable
+        onRowClick={onRowClick}
+        ExpandContent={Expand}
+        pagination={{ ...pagination, total: activeRows.length }}
+        columns={columns}
+        data={activeRows}
+        onChangePage={pagination.onChangePage}
+        noDataMessage={t('error.no-items')}
+      />
+    </Box>
   );
 };
 

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -98,23 +98,24 @@ export const GeneralTabComponent: FC<
   }, [isGrouped, data]);
 
   return (
-    <Grid container flexDirection="column" flexWrap="nowrap" width="auto">
-      <Grid
-        item
-        justifyContent="flex-start"
-        display="flex"
-        flex={0}
-        sx={{ padding: '5px', paddingLeft: '15px' }}
-      >
-        <Switch
-          label={t('label.group-by-item')}
-          onChange={toggleIsGrouped}
-          checked={isGrouped}
-          size="small"
-          disabled={activeRows.length === 0}
-          color="secondary"
-        />
-      </Grid>
+    <Grid container display="block">
+      {activeRows?.length !== 0 && (
+        <Grid
+          item
+          justifyContent="flex-start"
+          display="flex"
+          sx={{ padding: '5px', paddingLeft: '15px' }}
+        >
+          <Switch
+            label={t('label.group-by-item')}
+            onChange={toggleIsGrouped}
+            checked={isGrouped}
+            size="small"
+            disabled={activeRows.length === 0}
+            color="secondary"
+          />
+        </Grid>
+      )}
       <Grid item>
         <DataTable
           onRowClick={onRowClick}


### PR DESCRIPTION
Fixes #689 

- Ended up being a few different style updates
- Turned out the columns just weren't flexing because of the Grid added around the DataTable in the `GeneralTab`.. I think
- Then I made the scroll bar on the right 'auto' .. which when it wasn't showing when there were just a few items made the header row overlap the side panel .. so changed some zIndicies..