### PR TITLE
#692 inbound optimistic onhold

### DIFF
--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -11,7 +11,7 @@ import { AppBarButtons } from './AppBarButtons';
 import { SidePanel } from './SidePanel';
 import { GeneralTab } from './GeneralTab';
 import { InboundLineEdit } from './modals/InboundLineEdit/InboundLineEdit';
-import { getNextInboundStatus, isInboundEditable } from '../../utils';
+import { isInboundEditable } from '../../utils';
 import { InvoiceLine, InboundShipmentItem } from '../../types';
 
 export enum ModalMode {
@@ -30,7 +30,7 @@ export const toItem = (line: InboundShipmentItem | InvoiceLine): Item => ({
 });
 
 export const DetailView: FC = () => {
-  const { draft, updateInvoice } = useDraftInbound();
+  const { draft } = useDraftInbound();
 
   const [modalState, setModalState] = React.useState<{
     item: Item | null;
@@ -67,12 +67,7 @@ export const DetailView: FC = () => {
 
       <GeneralTab onRowClick={onRowClick} />
 
-      <Footer
-        draft={draft}
-        save={async () => {
-          updateInvoice({ status: getNextInboundStatus(draft?.status) });
-        }}
-      />
+      <Footer />
       <SidePanel />
 
       <InboundLineEdit

--- a/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
@@ -23,13 +23,8 @@ import {
   useIsInboundEditable,
 } from './api';
 
-interface InboundDetailFooterProps {
-  draft: Invoice;
-  save: () => Promise<void>;
-}
-
-const createStatusLog = (draft: Invoice) => {
-  const statusIdx = inboundStatuses.findIndex(s => draft.status === s);
+const createStatusLog = (invoice: Invoice) => {
+  const statusIdx = inboundStatuses.findIndex(s => invoice.status === s);
   const statusLog: Record<InvoiceNodeStatus, null | string | undefined> = {
     [InvoiceNodeStatus.New]: null,
     [InvoiceNodeStatus.Picked]: null,
@@ -43,25 +38,25 @@ const createStatusLog = (draft: Invoice) => {
   statusLog;
 
   if (statusIdx >= 0) {
-    statusLog[InvoiceNodeStatus.New] = draft.createdDatetime;
+    statusLog[InvoiceNodeStatus.New] = invoice.createdDatetime;
   }
   if (statusIdx >= 1) {
-    statusLog[InvoiceNodeStatus.Picked] = draft.pickedDatetime;
+    statusLog[InvoiceNodeStatus.Picked] = invoice.pickedDatetime;
   }
   if (statusIdx >= 2) {
-    statusLog[InvoiceNodeStatus.Shipped] = draft.shippedDatetime;
+    statusLog[InvoiceNodeStatus.Shipped] = invoice.shippedDatetime;
   }
   if (statusIdx >= 3) {
-    statusLog[InvoiceNodeStatus.Picked] = draft.deliveredDatetime;
+    statusLog[InvoiceNodeStatus.Picked] = invoice.deliveredDatetime;
   }
   if (statusIdx >= 4) {
-    statusLog[InvoiceNodeStatus.Picked] = draft.verifiedDatetime;
+    statusLog[InvoiceNodeStatus.Picked] = invoice.verifiedDatetime;
   }
 
   return statusLog;
 };
 
-export const Footer: FC<InboundDetailFooterProps> = ({ save }) => {
+export const Footer: FC = () => {
   const t = useTranslation('common');
   const { success } = useNotification();
   const { onHold, status, update } = useInboundFields(['onHold', 'status']);
@@ -121,8 +116,6 @@ export const Footer: FC<InboundDetailFooterProps> = ({ save }) => {
                           onSuccess: success('Saved invoice! 🥳'),
                         }
                       );
-
-                      save();
                     }}
                   />
                 </>

--- a/packages/invoices/src/InboundShipment/DetailView/api.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/api.ts
@@ -218,7 +218,6 @@ export const getInboundShipmentDetailViewApi = (
 
 export const useInboundShipment = (): UseQueryResult<Invoice, unknown> => {
   const { id = '' } = useParams();
-
   const { api } = useOmSupplyApi();
   const queries = getInboundShipmentDetailViewApi(api);
   return useQuery(['invoice', id], () => {
@@ -322,10 +321,6 @@ export const useInboundFields = <KeyOfInvoice extends keyof Invoice>(
         await queryClient.cancelQueries(['invoice', id]);
 
         const previous = queryClient.getQueryData<Invoice>(['invoice', id]);
-
-        console.log('-------------------------------------------');
-        console.log('patch', patch);
-        console.log('-------------------------------------------');
 
         if (previous) {
           queryClient.setQueryData<Invoice>(['invoice', id], {


### PR DESCRIPTION
Fixes #692 

- Turns out the problem was actually because the mutation was being debounced.. which gets into a bit more of a tricky problem: The mutation is debounced, so the optimistic update doesn't trigger. You could maybe do some other tricky dicky things like debounce the actual query rather than the 'update' function, which might be better? But I think you might get into more complicated situations where the cache has been updated, then a timer for a debounce query starts, and then something else updates the cache but doesn't update and doesn't cancel the query being sent and then other overrides happen.. or something? I'm not sure if it's really a problem, but I thought this would work for now.. though, also need to use that buffer state for the status button.. lucky they're right next to each other, I guess!
- Could also do a manual cache update for this special case using `useQueryClient().setQueryData` 🤔  - though need to manage a rollback and things after that also..

Also getting closer to finding a pattern with the api stuff, I think ... 🙄 

something like...
- `useInbound` - a query for the inbound
- `useInboundUpdate` - a query for updating the inbound
- `useInboundFields` (uses `useInbound` and `useInboundUpdate`
- `useInboundLines`/`useInboundItems`/ `useInboundLineUpsert`/`Delete`/

It's a lot of hooks and doesn't organise the queries for them very nicely..