### PR TITLE
Add simple locations hook

### DIFF
--- a/packages/common/src/operations.graphql
+++ b/packages/common/src/operations.graphql
@@ -1175,3 +1175,41 @@ mutation insertInboundShipment($id: String!, $otherPartyId: String!) {
     }
   }
 }
+
+query locations {
+  locations {
+    __typename
+    ... on LocationConnector {
+      __typename
+      nodes {
+        __typename
+        id
+        name
+        onHold
+        code
+      }
+      totalCount
+    }
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/common/src/types/schema.ts
+++ b/packages/common/src/types/schema.ts
@@ -31,7 +31,7 @@ export type Scalars = {
   NaiveDate: string;
 };
 
-export type AccessDenied = LogoutErrorInterface & UserErrorInterface & {
+export type AccessDenied = LogoutErrorInterface & {
   __typename?: 'AccessDenied';
   description: Scalars['String'];
   fullError: Scalars['String'];
@@ -206,7 +206,7 @@ export enum CustomerRequisitionNodeStatus {
   New = 'NEW'
 }
 
-export type DatabaseError = AuthTokenErrorInterface & ConnectorErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UserErrorInterface & UserRegisterErrorInterface & {
+export type DatabaseError = AuthTokenErrorInterface & ConnectorErrorInterface & DeleteInboundShipmentErrorInterface & DeleteInboundShipmentLineErrorInterface & DeleteLocationErrorInterface & DeleteOutboundShipmentErrorInterface & DeleteOutboundShipmentLineErrorInterface & DeleteOutboundShipmentServiceLineErrorInterface & InsertInboundShipmentErrorInterface & InsertInboundShipmentLineErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentErrorInterface & InsertOutboundShipmentLineErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & NodeErrorInterface & RefreshTokenErrorInterface & UpdateInboundShipmentErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentErrorInterface & UpdateOutboundShipmentLineErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UserRegisterErrorInterface & {
   __typename?: 'DatabaseError';
   description: Scalars['String'];
   fullError: Scalars['String'];
@@ -370,6 +370,12 @@ export type DeleteResponse = {
   __typename?: 'DeleteResponse';
   id: Scalars['String'];
 };
+
+export type DeleteStockTakeLineInput = {
+  id: Scalars['String'];
+};
+
+export type DeleteStockTakeLineResponse = DeleteResponse;
 
 export type DeleteStocktakeInput = {
   id: Scalars['String'];
@@ -771,7 +777,7 @@ export type InsertSupplierRequisitionResponseWithId = {
   response?: Maybe<InsertSupplierRequisitionResponse>;
 };
 
-export type InternalError = AuthTokenErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & LogoutErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UserErrorInterface & UserRegisterErrorInterface & {
+export type InternalError = AuthTokenErrorInterface & InsertLocationErrorInterface & InsertOutboundShipmentServiceLineErrorInterface & LogoutErrorInterface & RefreshTokenErrorInterface & UpdateLocationErrorInterface & UpdateOutboundShipmentServiceLineErrorInterface & UserRegisterErrorInterface & {
   __typename?: 'InternalError';
   description: Scalars['String'];
   fullError: Scalars['String'];
@@ -1201,6 +1207,7 @@ export type Mutations = {
   deleteOutboundShipment: DeleteOutboundShipmentResponse;
   deleteOutboundShipmentLine: DeleteOutboundShipmentLineResponse;
   deleteOutboundShipmentServiceLine: DeleteOutboundShipmentServiceLineResponse;
+  deleteStockTakeLine: DeleteStockTakeLineResponse;
   deleteStocktake: DeleteStocktakeResponse;
   deleteSupplierRequisition: DeleteSupplierRequisitionResponse;
   deleteSupplierRequisitionLine: DeleteSupplierRequisitionLineResponse;
@@ -1320,6 +1327,12 @@ export type MutationsDeleteOutboundShipmentLineArgs = {
 
 export type MutationsDeleteOutboundShipmentServiceLineArgs = {
   input: DeleteOutboundShipmentServiceLineInput;
+};
+
+
+export type MutationsDeleteStockTakeLineArgs = {
+  input: DeleteStockTakeLineInput;
+  storeId?: Maybe<Scalars['String']>;
 };
 
 
@@ -1617,6 +1630,7 @@ export type Queries = {
   stockCounts: StockCounts;
   stocktake: StocktakeResponse;
   stocktakes: StocktakesResponse;
+  stores: StoresResponse;
 };
 
 
@@ -1694,6 +1708,12 @@ export type QueriesStocktakeArgs = {
 
 export type QueriesStocktakesArgs = {
   params?: Maybe<StocktakeListParameters>;
+};
+
+
+export type QueriesStoresArgs = {
+  filter?: Maybe<StoreFilterInput>;
+  page?: Maybe<PaginationInput>;
 };
 
 export type RangeError = InsertInboundShipmentLineErrorInterface & InsertOutboundShipmentLineErrorInterface & UpdateInboundShipmentLineErrorInterface & UpdateOutboundShipmentLineErrorInterface & {
@@ -1970,6 +1990,24 @@ export type StocktakeSortInput = {
 };
 
 export type StocktakesResponse = NodeError | StocktakeConnector;
+
+export type StoreConnector = {
+  __typename?: 'StoreConnector';
+  nodes: Array<StoreNode>;
+  totalCount: Scalars['Int'];
+};
+
+export type StoreFilterInput = {
+  id?: Maybe<SimpleStringFilterInput>;
+};
+
+export type StoreNode = {
+  __typename?: 'StoreNode';
+  code: Scalars['String'];
+  id: Scalars['String'];
+};
+
+export type StoresResponse = StoreConnector;
 
 export enum SupplierRequisitionNodeStatus {
   Draft = 'DRAFT',
@@ -2323,16 +2361,6 @@ export type User = {
   userId: Scalars['String'];
 };
 
-/** Generic Error Wrapper */
-export type UserError = {
-  __typename?: 'UserError';
-  error: UserErrorInterface;
-};
-
-export type UserErrorInterface = {
-  description: Scalars['String'];
-};
-
 export type UserNameDoesNotExist = AuthTokenErrorInterface & {
   __typename?: 'UserNameDoesNotExist';
   description: Scalars['String'];
@@ -2356,7 +2384,7 @@ export type UserRegisterInput = {
 
 export type UserRegisterResponse = RegisteredUser | UserRegisterError;
 
-export type UserResponse = User | UserError;
+export type UserResponse = User;
 
 export type InvoiceQueryVariables = Exact<{
   id: Scalars['String'];
@@ -2615,6 +2643,11 @@ export type InsertInboundShipmentMutationVariables = Exact<{
 
 
 export type InsertInboundShipmentMutation = { __typename?: 'Mutations', insertInboundShipment: { __typename: 'InsertInboundShipmentError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'ForeignKeyError', description: string, key: ForeignKey } | { __typename: 'OtherPartyNotASupplier', description: string, otherParty: { __typename?: 'NameNode', code: string, id: string, isCustomer: boolean, isSupplier: boolean, name: string } } | { __typename: 'RecordAlreadyExist', description: string } } | { __typename: 'InvoiceNode', id: string } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+
+export type LocationsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LocationsQuery = { __typename?: 'Queries', locations: { __typename: 'ConnectorError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'PaginationError', description: string, rangeError: { __typename?: 'RangeError', description: string, field: RangeField, max?: number | null | undefined, min?: number | null | undefined } } } | { __typename: 'LocationConnector', totalCount: number, nodes: Array<{ __typename: 'LocationNode', id: string, name: string, onHold: boolean, code: string }> } };
 
 
 export const InvoiceDocument = gql`
@@ -3714,6 +3747,45 @@ export const InsertInboundShipmentDocument = gql`
   }
 }
     `;
+export const LocationsDocument = gql`
+    query locations {
+  locations {
+    __typename
+    ... on LocationConnector {
+      __typename
+      nodes {
+        __typename
+        id
+        name
+        onHold
+        code
+      }
+      totalCount
+    }
+    ... on ConnectorError {
+      __typename
+      error {
+        description
+        ... on DatabaseError {
+          __typename
+          description
+          fullError
+        }
+        ... on PaginationError {
+          __typename
+          description
+          rangeError {
+            description
+            field
+            max
+            min
+          }
+        }
+      }
+    }
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
@@ -3817,6 +3889,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     insertInboundShipment(variables: InsertInboundShipmentMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<InsertInboundShipmentMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<InsertInboundShipmentMutation>(InsertInboundShipmentDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'insertInboundShipment');
+    },
+    locations(variables?: LocationsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<LocationsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<LocationsQuery>(LocationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'locations');
     }
   };
 }
@@ -4363,5 +4438,21 @@ export const mockDeleteInboundShipmentsMutation = (resolver: ResponseResolver<Gr
 export const mockInsertInboundShipmentMutation = (resolver: ResponseResolver<GraphQLRequest<InsertInboundShipmentMutationVariables>, GraphQLContext<InsertInboundShipmentMutation>, any>) =>
   graphql.mutation<InsertInboundShipmentMutation, InsertInboundShipmentMutationVariables>(
     'insertInboundShipment',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockLocationsQuery((req, res, ctx) => {
+ *   return res(
+ *     ctx.data({ locations })
+ *   )
+ * })
+ */
+export const mockLocationsQuery = (resolver: ResponseResolver<GraphQLRequest<LocationsQueryVariables>, GraphQLContext<LocationsQuery>, any>) =>
+  graphql.query<LocationsQuery, LocationsQueryVariables>(
+    'locations',
     resolver
   )

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -14,7 +14,7 @@ import {
   useTranslation,
 } from '@openmsupply-client/common';
 import { getInboundShipmentListViewApi } from './api';
-import { NameSearchModal } from '@openmsupply-client/system/src/Name';
+import { NameSearchModal } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { InvoiceRow } from '../../types';
@@ -24,7 +24,6 @@ export const InboundListView: FC = () => {
   const navigate = useNavigate();
   const { error } = useNotification();
   const { api } = useOmSupplyApi();
-
   const {
     totalCount,
     data,

--- a/packages/mock-server/src/api/resolvers/index.ts
+++ b/packages/mock-server/src/api/resolvers/index.ts
@@ -8,6 +8,7 @@ import { requisitionLineResolver } from './requisitionLine';
 import { invoiceLineResolver } from './invoiceLine';
 import { statisticsResolver } from './statistics';
 import { StocktakeResolver } from './stocktake';
+import { locationResolver } from './location';
 
 export const ResolverService = {
   invoice: invoiceResolver,
@@ -20,4 +21,5 @@ export const ResolverService = {
   statistics: statisticsResolver,
   stocktake: StocktakeResolver,
   stocktakeLine: StocktakeLineResolver,
+  location: locationResolver,
 };

--- a/packages/mock-server/src/api/resolvers/invoiceLine.ts
+++ b/packages/mock-server/src/api/resolvers/invoiceLine.ts
@@ -1,3 +1,4 @@
+import { locationResolver } from './location';
 import { itemResolver } from './item';
 import { createListResponse } from './utils';
 import { ResolvedInvoiceLine, ListResponse } from './../../data/types';
@@ -8,11 +9,15 @@ export const invoiceLineResolver = {
   byId: (id: string): ResolvedInvoiceLine => {
     const invoiceLine = db.get.byId.invoiceLine(id);
     const item = itemResolver.byId(invoiceLine.itemId);
+    const location = invoiceLine.locationId
+      ? locationResolver.byId(invoiceLine.locationId)
+      : null;
 
     return {
       __typename: 'InvoiceLineNode',
       ...invoiceLine,
       item,
+      location,
       stockLine: invoiceLine.stockLineId
         ? stockLineResolver.byId(invoiceLine.stockLineId)
         : undefined,

--- a/packages/mock-server/src/api/resolvers/location.ts
+++ b/packages/mock-server/src/api/resolvers/location.ts
@@ -1,0 +1,27 @@
+import { createListResponse } from './utils';
+import { StockLineConnector } from '@openmsupply-client/common/src/types';
+import { ListResponse, ResolvedLocation } from './../../data/types';
+import { db } from './../../data/database';
+
+export const locationResolver = {
+  byId: (id: string): ResolvedLocation => {
+    const location = db.location.get.byId(id);
+    const stock: StockLineConnector = {
+      __typename: 'StockLineConnector',
+      nodes: [],
+      totalCount: 0,
+    };
+
+    return { ...location, stock, __typename: 'LocationNode' };
+  },
+  list: (): ListResponse<ResolvedLocation, 'LocationConnector'> => {
+    const locations = db.location.get.all();
+    const resolved = locations.map(location =>
+      locationResolver.byId(location.id)
+    );
+
+    const nodes = resolved.map(location => locationResolver.byId(location.id));
+
+    return createListResponse(nodes.length, nodes, 'LocationConnector');
+  },
+};

--- a/packages/mock-server/src/api/resolvers/stockLine.ts
+++ b/packages/mock-server/src/api/resolvers/stockLine.ts
@@ -1,3 +1,4 @@
+import { locationResolver } from './location';
 import { createListResponse } from './utils';
 import { ResolvedStockLine, ListResponse } from './../../data/types';
 import { db } from '../../data/database';
@@ -6,7 +7,11 @@ export const stockLineResolver = {
   byId: (id: string): ResolvedStockLine => {
     const stockLine = db.stockLine.get.byId(id);
     const item = db.item.get.byId(stockLine.itemId);
-    return { ...stockLine, item, __typename: 'StockLineNode' };
+    const location = stockLine.locationId
+      ? locationResolver.byId(stockLine.locationId)
+      : null;
+
+    return { ...stockLine, item, __typename: 'StockLineNode', location };
   },
   list: (
     lines = db.stockLine.get.all()

--- a/packages/mock-server/src/data/data.ts
+++ b/packages/mock-server/src/data/data.ts
@@ -11,6 +11,7 @@ import {
   RequisitionLine,
   Stocktake,
   StocktakeLine,
+  Location,
 } from './types';
 import {
   randomName,
@@ -117,13 +118,14 @@ export const adjustStockLineAvailableNumberOfPacks = (
   return newStockLine;
 };
 
-const locations = Array.from({ length: 50 }).map(() => ({
-  id: faker.datatype.uuid(),
-  name: `${alphaString(1)}${faker.datatype.number(9)}`,
-  code: `${alphaString(3)}${faker.datatype.number({ min: 100, max: 999 })}`,
-  onHold: false,
-  stock: { nodes: [], totalCount: 0 },
-}));
+const createLocations = () => {
+  return Array.from({ length: 50 }).map(() => ({
+    id: faker.datatype.uuid(),
+    name: `${alphaString(1)}${faker.datatype.number(9)}`,
+    code: `${alphaString(3)}${faker.datatype.number({ min: 100, max: 999 })}`,
+    onHold: false,
+  }));
+};
 
 export const getStockLinesForItem = (
   item: Item,
@@ -417,7 +419,7 @@ export const createSuppliers = (
   });
 };
 
-const createStockLines = (items: Item[]) => {
+const createStockLines = (items: Item[], locations: Location[]) => {
   return items
     .map(item => {
       // Update this to change the number of stock lines per item, per store.
@@ -443,7 +445,7 @@ const createStockLines = (items: Item[]) => {
             expiryDate: faker.date.future(1.5).toISOString(),
             batch: `${alphaString(4)}${faker.datatype.number(1000)}`,
             locationName: `${alphaString(1)}${faker.datatype.number(9)}`,
-            location: takeRandomElementFrom(locations),
+            locationId: takeRandomElementFrom(locations).id,
 
             availableNumberOfPacks: 0,
             totalNumberOfPacks: 0,
@@ -486,7 +488,7 @@ const createInvoiceLine = (
 
     stockLineId: stockLine.id,
     locationName: stockLine.locationName,
-    location: stockLine.location,
+    locationId: stockLine.locationId,
     type:
       invoice.type === InvoiceNodeType.InboundShipment
         ? InvoiceLineNodeType.StockIn
@@ -764,7 +766,8 @@ export const removeElement = (source: any[], idx: number): void => {
 export let NameData = [...createCustomers(), ...createSuppliers()];
 export let ItemData = createItems();
 export let InvoiceData = createInvoices(NameData);
-export let StockLineData = createStockLines(ItemData);
+export let LocationData = createLocations();
+export let StockLineData = createStockLines(ItemData, LocationData);
 export let InvoiceLineData = createInvoicesLines(InvoiceData, StockLineData);
 export let RequisitionData = [
   ...createSupplierRequisitions(),

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -41,8 +41,10 @@ import {
   RequisitionLine,
   Stocktake,
   StocktakeLine,
+  Location,
 } from './types';
 import {
+  LocationData,
   InvoiceData,
   InvoiceLineData,
   ItemData,
@@ -76,6 +78,23 @@ export const invoice = {
       ({
         ...InvoiceData.find(getFilter(invoiceNumber, 'invoiceNumber')),
       } as Invoice),
+  },
+};
+
+export const location = {
+  get: {
+    byId: (id: string): Location => {
+      const location = LocationData.find(getFilter(id, 'id'));
+
+      if (!location) {
+        throw new Error(`Location with id ${id} not found`);
+      }
+
+      return location;
+    },
+    all: (): Location[] => {
+      return LocationData;
+    },
   },
 };
 
@@ -546,6 +565,7 @@ export const insert = {
       expiryDate: invoiceLine?.expiryDate ?? '',
       type: InvoiceLineNodeType.StockIn,
       batch: '',
+      locationId: '',
       stockLineId: '',
       packSize: invoiceLine.packSize ?? 1,
       costPricePerPack: invoiceLine?.costPricePerPack ?? 0,
@@ -571,6 +591,7 @@ export const insert = {
       itemId: item.id,
       expiryDate: stockLine?.expiryDate ?? '',
       batch: '',
+      locationId: '',
       stockLineId: stockLine?.id ?? '',
       packSize: stockLine?.packSize ?? 1,
       costPricePerPack: stockLine?.costPricePerPack ?? 0,
@@ -622,4 +643,5 @@ export const db = {
   remove,
   stocktake,
   stocktakeLine,
+  location,
 };

--- a/packages/mock-server/src/data/types.ts
+++ b/packages/mock-server/src/data/types.ts
@@ -33,9 +33,13 @@ export interface Store {
   nameId: string;
 }
 
-export type Item = Omit<ItemNode, 'availableBatches' | 'availableQuantity'>;
+export type Location = Omit<LocationNode, 'stock'>;
 
-export type Location = LocationNode;
+export type ResolvedLocation = LocationNode & {
+  __typename: 'LocationNode';
+};
+
+export type Item = Omit<ItemNode, 'availableBatches' | 'availableQuantity'>;
 
 export interface ResolvedItem extends Item {
   __typename: 'ItemNode';
@@ -56,19 +60,20 @@ export interface ResolvedName extends Name {
 }
 
 export interface StockLine extends Omit<StockLineNode, 'location'> {
-  location: Location;
+  locationId: string;
 }
 
 export interface ResolvedStockLine extends StockLine {
   __typename: 'StockLineNode';
   item: Item;
+  location?: ResolvedLocation | null;
 }
 
 export interface InvoiceLine
   extends Omit<InvoiceLineNode, 'location' | 'item'> {
   id: string;
+  locationId: string;
   itemName: string;
-  location?: Location;
   itemCode: string;
   itemUnit: string;
   batch?: string;
@@ -86,6 +91,7 @@ export interface InvoiceLine
 export interface ResolvedInvoiceLine extends InvoiceLine {
   __typename: 'InvoiceLineNode';
   stockLine?: ResolvedStockLine;
+  location?: ResolvedLocation | null;
   item: ResolvedItem;
 }
 

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -25,6 +25,7 @@ const resolvers = {
     ...Schema.Statistics.QueryResolvers,
     ...Schema.Requisition.QueryResolvers,
     ...Schema.Stocktake.QueryResolvers,
+    ...Schema.Location.QueryResolvers,
   },
   Mutations: {
     ...Schema.Invoice.MutationResolvers,

--- a/packages/mock-server/src/schema/Location.ts
+++ b/packages/mock-server/src/schema/Location.ts
@@ -1,0 +1,15 @@
+import { Api } from './../api/index';
+import { LocationsResponse } from '@openmsupply-client/common/src/types';
+
+const QueryResolvers = {
+  locations: (): LocationsResponse => {
+    return Api.ResolverService.location.list();
+  },
+};
+
+const MutationResolvers = {};
+
+export const Location = {
+  QueryResolvers,
+  MutationResolvers,
+};

--- a/packages/mock-server/src/schema/index.ts
+++ b/packages/mock-server/src/schema/index.ts
@@ -1,5 +1,4 @@
 import { Name } from './Name';
-// import { InvoiceLine } from './InvoiceLine';
 import { StockLine } from './StockLine';
 import { Item } from './Item';
 import { Invoice } from './Invoice';

--- a/packages/mock-server/src/schema/index.ts
+++ b/packages/mock-server/src/schema/index.ts
@@ -5,6 +5,7 @@ import { Invoice } from './Invoice';
 import { Statistics } from './Statistics';
 import { Requisition } from './Requisition';
 import { Stocktake } from './Stocktake';
+import { Location } from './Location';
 
 export const Schema = {
   Invoice,
@@ -14,4 +15,5 @@ export const Schema = {
   Statistics,
   Requisition,
   Stocktake,
+  Location,
 };

--- a/packages/mock-server/src/worker/handlers/index.ts
+++ b/packages/mock-server/src/worker/handlers/index.ts
@@ -4,6 +4,7 @@ import { NameHandlers } from './name';
 import { ItemHandlers } from './item';
 import { StocktakeHandlers } from './stocktake';
 import { ExperimentalHandlers } from './experimental';
+import { LocationHandlers } from './location';
 
 // Checking for not equal to production instead of
 // checking for development, as jest sets this to
@@ -17,7 +18,13 @@ const unsupported = [
   ...RequisitionHandlers,
   ...ExperimentalHandlers,
 ];
-const supported = [...InvoiceHandlers, ...NameHandlers, ...ItemHandlers];
+
+const supported = [
+  ...InvoiceHandlers,
+  ...NameHandlers,
+  ...ItemHandlers,
+  ...LocationHandlers,
+];
 
 const DevHandlers = [...unsupported, ...supported];
 const ProdHandlers = [...unsupported];

--- a/packages/mock-server/src/worker/handlers/location/index.ts
+++ b/packages/mock-server/src/worker/handlers/location/index.ts
@@ -1,0 +1,10 @@
+import { ResolverService } from './../../../api/resolvers';
+import { mockLocationsQuery } from '@openmsupply-client/common/src/types/schema';
+
+const locationsQuery = mockLocationsQuery((_, res, ctx) => {
+  const locationsResponse = ResolverService.location.list();
+
+  return res(ctx.data({ locations: locationsResponse }));
+});
+
+export const LocationHandlers = [locationsQuery];

--- a/packages/system/src/Location/hooks/index.ts
+++ b/packages/system/src/Location/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useLocations';

--- a/packages/system/src/Location/hooks/useLocations.ts
+++ b/packages/system/src/Location/hooks/useLocations.ts
@@ -1,0 +1,27 @@
+import {
+  useQuery,
+  useOmSupplyApi,
+  UseQueryResult,
+  LocationsQuery,
+  LocationNode,
+} from '@openmsupply-client/common';
+
+const locationsGuard = (locationsQuery: LocationsQuery) => {
+  if (locationsQuery.locations.__typename === 'LocationConnector') {
+    return locationsQuery.locations;
+  }
+
+  throw new Error(locationsQuery.locations.error.description);
+};
+
+export const useLocations = (): UseQueryResult<
+  { nodes: LocationNode; totalCount: number },
+  unknown
+> => {
+  const { api } = useOmSupplyApi();
+  return useQuery(['locations', 'list'], async () => {
+    const result = await api.locations();
+    const locations = locationsGuard(result);
+    return locations;
+  });
+};

--- a/packages/system/src/Location/index.ts
+++ b/packages/system/src/Location/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/packages/system/src/index.ts
+++ b/packages/system/src/index.ts
@@ -1,3 +1,4 @@
 export * from './Item';
 export * from './Stock';
 export * from './Name';
+export * from './Location';


### PR DESCRIPTION
Fixes #510 

- I want to start correcting/completing the inbound cells in the edit modal, so wanted locations.
- Just the first query to get it on the board with all the boilerplate.. the hook I used in just the list view of the inbound shipment page and it's returning from the mock server and against the demo server