### PR TITLE
#703 locations to inbound

### DIFF
--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -58,13 +58,16 @@ export const CurrencyInput: FC<CurrencyInputProps> = ({
   // loses focus when the buffer is in this invalid state, the currency input will
   // append two zeros so will always result in a valid number.
   useEffect(() => {
+    // circuit break when the value is equal to the buffer - we don't need to do anything.
+    if (Number(buffer) === value) return;
+
     if (buffer == null) {
       return onChangeNumber(0);
     }
     if (!Number.isNaN(buffer)) {
       return onChangeNumber(Number(buffer));
     }
-  }, [buffer]);
+  }, [buffer, value]);
 
   return (
     <StyledCurrencyInput

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -20,7 +20,7 @@ export enum ModalMode {
 }
 
 export const toItem = (line: InboundShipmentItem | InvoiceLine): Item => ({
-  id: 'lines' in line ? line.lines[0].id : line.itemId,
+  id: 'lines' in line ? line.lines[0].itemId : line.itemId,
   name: 'lines' in line ? line.lines[0].itemName : line.itemName,
   code: 'lines' in line ? line.lines[0].itemCode : line.itemCode,
   isVisible: true,

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -100,17 +100,18 @@ const useDraftInboundLines = (itemId: string) => {
     setDraftLines([...draftLines, newLine]);
   };
 
-  const updateDraftLine = (
-    patch: Partial<DraftInboundLine> & { id: string }
-  ) => {
-    const batch = draftLines.find(line => line.id === patch.id);
-    if (batch) {
-      const newBatch = { ...batch, ...patch, isUpdated: true };
-      const index = draftLines.indexOf(batch);
-      draftLines[index] = newBatch;
-      setDraftLines([...draftLines]);
-    }
-  };
+  const updateDraftLine = React.useCallback(
+    (patch: Partial<DraftInboundLine> & { id: string }) => {
+      const batch = draftLines.find(line => line.id === patch.id);
+      if (batch) {
+        const newBatch = { ...batch, ...patch, isUpdated: true };
+        const index = draftLines.indexOf(batch);
+        draftLines[index] = newBatch;
+        setDraftLines([...draftLines]);
+      }
+    },
+    [draftLines, setDraftLines]
+  );
 
   const saveLines = async () => {
     await mutateAsync(draftLines);

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -5,9 +5,6 @@ import {
   TabContext,
   TabList,
   Tab,
-  alpha,
-  TabPanel,
-  styled,
   useTranslation,
   useIsMediumScreen,
   ButtonWithIcon,
@@ -22,7 +19,7 @@ import {
 } from '@openmsupply-client/common';
 import { InvoiceLine } from '../../../../types';
 import { ModalMode } from '../../DetailView';
-import { BatchTable, PricingTable } from './TabTables';
+import { QuantityTable, PricingTable } from './TabTables';
 import { InboundLineEditForm } from './InboundLineEditForm';
 import {
   useInboundLines,
@@ -30,10 +27,7 @@ import {
   useSaveInboundLines,
   useNextItem,
 } from '../../api';
-
-const StyledTabPanel = styled(TabPanel)({
-  height: '100%',
-});
+import { InboundLineEditPanel } from './InboundLineEditPanel';
 
 interface InboundLineEditProps {
   item: Item | null;
@@ -235,29 +229,19 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
                   borderRadius: '20px',
                 }}
               >
-                <Box
-                  sx={{
-                    width: 400,
-                    height: isMediumScreen ? 300 : 400,
-                    backgroundColor: theme =>
-                      alpha(theme.palette['background']['menu'], 0.4),
-                    position: 'absolute',
-                    borderRadius: '20px',
-                  }}
-                />
-                <StyledTabPanel value={Tabs.Batch}>
-                  <BatchTable
+                <InboundLineEditPanel value={Tabs.Batch} lines={draftLines}>
+                  <QuantityTable
                     batches={draftLines}
                     updateDraftLine={updateDraftLine}
                   />
-                </StyledTabPanel>
+                </InboundLineEditPanel>
 
-                <StyledTabPanel value={Tabs.Pricing}>
+                <InboundLineEditPanel value={Tabs.Pricing} lines={draftLines}>
                   <PricingTable
                     batches={draftLines}
                     updateDraftLine={updateDraftLine}
                   />
-                </StyledTabPanel>
+                </InboundLineEditPanel>
               </TableContainer>
             </TabContext>
           ) : (

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -230,14 +230,22 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
                   borderRadius: '20px',
                 }}
               >
-                <InboundLineEditPanel value={Tabs.Batch} lines={draftLines}>
+                <InboundLineEditPanel
+                  value={Tabs.Batch}
+                  lines={draftLines}
+                  updateDraftLine={updateDraftLine}
+                >
                   <QuantityTable
                     batches={draftLines}
                     updateDraftLine={updateDraftLine}
                   />
                 </InboundLineEditPanel>
 
-                <InboundLineEditPanel value={Tabs.Pricing} lines={draftLines}>
+                <InboundLineEditPanel
+                  value={Tabs.Pricing}
+                  lines={draftLines}
+                  updateDraftLine={updateDraftLine}
+                >
                   <PricingTable
                     batches={draftLines}
                     updateDraftLine={updateDraftLine}

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
@@ -7,7 +7,7 @@ import {
   Box,
   DataTable,
   alpha,
-  Column,
+  TextInputCell,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from './InboundLineEdit';
 
@@ -34,17 +34,19 @@ const StyledStaticArea = styled(Box)(({ theme }) => ({
 interface InboundLineEditPanel {
   value: string;
   lines: DraftInboundLine[];
+  updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }
 
 export const InboundLineEditPanel: FC<InboundLineEditPanel> = ({
   lines,
   value,
+  updateDraftLine,
   children,
 }) => {
-  const columns = useColumns([
-    ['batch', { width: 100 }],
-    ['expiryDate', { width: 100 }],
-  ]) as [Column<DraftInboundLine>, Column<DraftInboundLine>];
+  const columns = useColumns<DraftInboundLine>([
+    ['batch', { width: 150, Cell: TextInputCell, setter: updateDraftLine }],
+    ['expiryDate', { width: 150 }],
+  ]);
 
   return (
     <StyledTabPanel value={value}>

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
@@ -1,0 +1,59 @@
+import React, { FC } from 'react';
+
+import {
+  styled,
+  TabPanel,
+  useColumns,
+  Box,
+  DataTable,
+  alpha,
+  Column,
+} from '@openmsupply-client/common';
+import { DraftInboundLine } from './InboundLineEdit';
+
+const StyledTabPanel = styled(TabPanel)({
+  height: '100%',
+});
+
+const StyledTabContainer = styled(Box)(({ theme }) => ({
+  height: 300,
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: theme.palette.divider,
+  borderRadius: '20px',
+  flexDirection: 'row',
+  display: 'flex',
+}));
+
+const StyledStaticArea = styled(Box)(({ theme }) => ({
+  backgroundColor: alpha(theme.palette.background.menu, 0.4),
+  display: 'flex',
+  flexDirection: 'column',
+}));
+
+interface InboundLineEditPanel {
+  value: string;
+  lines: DraftInboundLine[];
+}
+
+export const InboundLineEditPanel: FC<InboundLineEditPanel> = ({
+  lines,
+  value,
+  children,
+}) => {
+  const columns = useColumns([
+    ['batch', { width: 100 }],
+    ['expiryDate', { width: 100 }],
+  ]) as [Column<DraftInboundLine>, Column<DraftInboundLine>];
+
+  return (
+    <StyledTabPanel value={value}>
+      <StyledTabContainer>
+        <StyledStaticArea>
+          <DataTable dense columns={columns} data={lines} />
+        </StyledStaticArea>
+        {children}
+      </StyledTabContainer>
+    </StyledTabPanel>
+  );
+};

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -7,7 +7,7 @@ import {
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from './InboundLineEdit';
 
-export const QuantityTable: FC<{
+export const QuantityTableComponent: FC<{
   batches: DraftInboundLine[];
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }> = ({ batches, updateDraftLine }) => {
@@ -38,10 +38,13 @@ export const QuantityTable: FC<{
   );
 };
 
-export const PricingTable: FC<{
+export const QuantityTable = React.memo(QuantityTableComponent);
+
+export const PricingTableComponent: FC<{
   batches: DraftInboundLine[];
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }> = ({ batches, updateDraftLine }) => {
+  console.log('render');
   const columns = useColumns<DraftInboundLine>([
     [
       'sellPricePerPack',
@@ -73,3 +76,5 @@ export const PricingTable: FC<{
     />
   );
 };
+
+export const PricingTable = React.memo(PricingTableComponent);

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -2,20 +2,16 @@ import React, { FC } from 'react';
 import {
   DataTable,
   useColumns,
-  TextInputCell,
-  getLineLabelColumn,
   NumberInputCell,
   CurrencyInputCell,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from './InboundLineEdit';
 
-export const BatchTable: FC<{
+export const QuantityTable: FC<{
   batches: DraftInboundLine[];
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }> = ({ batches, updateDraftLine }) => {
   const columns = useColumns<DraftInboundLine>([
-    getLineLabelColumn(),
-    ['batch', { Cell: TextInputCell, width: 200, setter: updateDraftLine }],
     [
       'numberOfPacks',
       {
@@ -30,7 +26,6 @@ export const BatchTable: FC<{
       'unitQuantity',
       { accessor: ({ rowData }) => rowData.numberOfPacks * rowData.packSize },
     ],
-    'expiryDate',
   ]);
 
   return (
@@ -48,8 +43,6 @@ export const PricingTable: FC<{
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }> = ({ batches, updateDraftLine }) => {
   const columns = useColumns<DraftInboundLine>([
-    getLineLabelColumn(),
-    ['batch', { Cell: TextInputCell, width: 200, setter: updateDraftLine }],
     [
       'sellPricePerPack',
       { Cell: CurrencyInputCell, width: 100, setter: updateDraftLine },

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -44,7 +44,6 @@ export const PricingTableComponent: FC<{
   batches: DraftInboundLine[];
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }> = ({ batches, updateDraftLine }) => {
-  console.log('render');
   const columns = useColumns<DraftInboundLine>([
     [
       'sellPricePerPack',


### PR DESCRIPTION
Doesn't fix #703 🙃 

Some misc. fixes and setup for the real PR....! Also just getting my feet wet again after taking basically a year off!

- Fixed a bug which was making now batches show up for an edit
- Moved the 'static' columns into their own 'panel' component similar to how the stocktake modal is done - but I simplified it further by just using a second `DataTable`
- Fixed some big re-rendering issues where the currency input was always triggering 2 re-renders when first rendered. The table always still rerenders when switched to (i.e. the pricing table) but is only doing it once now 🎉 