### PR TITLE
update RTL styles

### DIFF
--- a/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -3,6 +3,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import { Slide } from '../../ui/animations';
 import { BasicModal, ModalTitle } from '@common/components';
+import { useRtl } from '@common/intl';
 
 export interface ButtonProps {
   icon?: React.ReactElement;
@@ -42,16 +43,22 @@ enum Direction {
   Down = 'down',
 }
 
-const useSlideAnimation = () => {
+const useSlideAnimation = (isRtl: boolean) => {
   const [slideConfig, setSlide] = useState({
     in: true,
-    direction: Direction.Right,
+    direction: isRtl ? Direction.Left : Direction.Right,
   });
 
   const onTriggerSlide = () => {
-    setSlide({ in: false, direction: Direction.Left });
+    setSlide({
+      in: false,
+      direction: isRtl ? Direction.Right : Direction.Left,
+    });
     setTimeout(() => {
-      setSlide({ in: true, direction: Direction.Right });
+      setSlide({
+        in: true,
+        direction: isRtl ? Direction.Left : Direction.Right,
+      });
     }, 500);
   };
 
@@ -63,6 +70,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
   const [open, setOpen] = React.useState(false);
   const showDialog = () => setOpen(true);
   const hideDialog = () => setOpen(false);
+  const isRtl = useRtl();
 
   useEffect(() => {
     if (isOpen != null) setOpen(isOpen);
@@ -84,7 +92,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
   }) => {
     // The slide animation is triggered by cloning the next button and wrapping the passed
     // on click with a trigger to slide.
-    const { slideConfig, onTriggerSlide } = useSlideAnimation();
+    const { slideConfig, onTriggerSlide } = useSlideAnimation(isRtl);
 
     // TODO: If you want to disable the slide, add a prop `slidesOnNext` or something,
     // with a default of true and check before doing all this.

--- a/packages/common/src/ui/components/buttons/FlatButton.tsx
+++ b/packages/common/src/ui/components/buttons/FlatButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button as MuiButton, styled } from '@mui/material';
 import { Property } from 'csstype';
-
+import { useRtl } from '@common/intl';
 interface ButtonProps {
   color?: 'inherit' | 'primary' | 'secondary';
   icon: React.ReactNode;
@@ -10,12 +10,20 @@ interface ButtonProps {
   disabled?: boolean;
 }
 
-const StyledButton = styled(MuiButton)({
+const StyledButton = styled(MuiButton, {
+  shouldForwardProp: prop => prop !== 'isRtl',
+})<{ isRtl: boolean }>(({ isRtl }) => ({
   fontWeight: 700,
   marginLeft: 5,
   marginRight: 5,
   textTransform: 'none' as Property.TextTransform,
-});
+  '& .MuiButton-startIcon': isRtl
+    ? {
+        marginRight: -4,
+        marginLeft: 8,
+      }
+    : {},
+}));
 
 export const FlatButton: React.FC<ButtonProps> = ({
   color,
@@ -23,14 +31,18 @@ export const FlatButton: React.FC<ButtonProps> = ({
   icon,
   onClick,
   disabled = false,
-}) => (
-  <StyledButton
-    disabled={disabled}
-    onClick={onClick}
-    startIcon={icon}
-    variant="text"
-    color={color}
-  >
-    {label}
-  </StyledButton>
-);
+}) => {
+  const isRtl = useRtl();
+  return (
+    <StyledButton
+      disabled={disabled}
+      onClick={onClick}
+      startIcon={icon}
+      variant="text"
+      color={color}
+      isRtl={isRtl}
+    >
+      {label}
+    </StyledButton>
+  );
+};

--- a/packages/common/src/ui/components/buttons/standard/ShrinkableBaseButton.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ShrinkableBaseButton.tsx
@@ -2,10 +2,11 @@ import React, { FC } from 'react';
 import { ButtonProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { StyledBaseButton } from './BaseButton';
+import { useRtl } from '@common/intl';
 
 export const StyledShrinkableBaseButton = styled(StyledBaseButton, {
-  shouldForwardProp: prop => prop !== 'shrink',
-})<{ shrink: boolean }>(({ shrink, theme }) => ({
+  shouldForwardProp: prop => prop !== 'shrink' && prop !== 'isRtl',
+})<{ isRtl: boolean; shrink: boolean }>(({ isRtl, shrink, theme }) => ({
   // These magic padding numbers give a little bit of space to the left and right when
   // the button content is extra large, such as in the "Save & Confirm Allocation" button
   // on an outbound shipment.
@@ -17,6 +18,12 @@ export const StyledShrinkableBaseButton = styled(StyledBaseButton, {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
   }),
+  '& .MuiButton-startIcon': isRtl
+    ? {
+        marginRight: -2,
+        marginLeft: 8,
+      }
+    : {},
 }));
 
 interface ShrinkableBaseButtonProps extends ButtonProps {
@@ -24,11 +31,15 @@ interface ShrinkableBaseButtonProps extends ButtonProps {
 }
 
 export const ShrinkableBaseButton: FC<ShrinkableBaseButtonProps> =
-  React.forwardRef(({ shrink = false, ...props }, ref) => (
-    <StyledShrinkableBaseButton
-      ref={ref}
-      shrink={shrink}
-      size="small"
-      {...props}
-    />
-  ));
+  React.forwardRef(({ shrink = false, ...props }, ref) => {
+    const isRtl = useRtl();
+    return (
+      <StyledShrinkableBaseButton
+        ref={ref}
+        shrink={shrink}
+        size="small"
+        isRtl={isRtl}
+        {...props}
+      />
+    );
+  });

--- a/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
+++ b/packages/common/src/ui/components/domain/Dashboard/StatsPanel.tsx
@@ -30,7 +30,7 @@ export const StatsPanel: FC<StatsPanelProps> = ({
           color: 'gray.main',
           fontSize: '12px',
           fontWeight: 500,
-          marginLeft: '8px',
+          marginInlineStart: '8px',
         }}
       >
         {label}
@@ -51,7 +51,7 @@ export const StatsPanel: FC<StatsPanelProps> = ({
     >
       <Grid container>
         <Grid alignItems="center" display="flex">
-          <Grid item style={{ marginRight: 8 }}>
+          <Grid item style={{ marginInlineEnd: 8 }}>
             <StockIcon
               color="secondary"
               style={{

--- a/packages/common/src/ui/components/inputs/Switch/Switch.tsx
+++ b/packages/common/src/ui/components/inputs/Switch/Switch.tsx
@@ -32,9 +32,9 @@ const getLabelStyle = (
   const margin = size === 'medium' ? '0' : '3px';
   switch (labelPlacement) {
     case 'end':
-      return { marginLeft: margin };
+      return { marginInlineStart: margin };
     case 'start':
-      return { marginRight: margin };
+      return { marginInlineEnd: margin };
     default:
       return {};
   }

--- a/packages/common/src/ui/components/modals/BasicModal/BasicModal.tsx
+++ b/packages/common/src/ui/components/modals/BasicModal/BasicModal.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import Dialog, { DialogProps as MuiDialogProps } from '@mui/material/Dialog';
+import { useRtl } from '@common/intl';
 
 interface DialogProps extends MuiDialogProps {
   height?: number;
@@ -12,6 +13,7 @@ export const BasicModal: FC<DialogProps> = ({
   height = 400,
   ...dialogProps
 }) => {
+  const isRtl = useRtl();
   return (
     <Dialog
       PaperProps={{
@@ -19,6 +21,7 @@ export const BasicModal: FC<DialogProps> = ({
           borderRadius: '20px',
           minHeight: `${height}px`,
           minWidth: `${width}px`,
+          direction: isRtl ? 'rtl' : 'ltr',
         },
         ...PaperProps,
       }}

--- a/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { styled } from '@mui/material/styles';
-import { Typography } from '@mui/material';
+import { Breadcrumbs as MuiBreadcrumbs } from '@mui/material';
 import { useLocation, Link } from 'react-router-dom';
 
 import { LocaleKey, useTranslation } from '@common/intl';
@@ -51,16 +51,21 @@ export const Breadcrumbs: React.FC = () => {
     }
 
     return (
-      <span key={part.key}>
-        <Breadcrumb to={part.path}>{t(part.key)}</Breadcrumb>
-        {' / '}
-      </span>
+      <Breadcrumb to={part.path} key={part.key}>
+        {t(part.key)}
+      </Breadcrumb>
     );
   });
 
   return (
-    <Typography variant="h6" color="inherit" noWrap>
+    <MuiBreadcrumbs
+      sx={{
+        fontSize: '16px',
+        color: theme => theme.typography.body1.color,
+        fontWeight: 500,
+      }}
+    >
       {crumbs}
-    </Typography>
+    </MuiBreadcrumbs>
   );
 };

--- a/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -112,7 +112,9 @@ export const DetailPanelPortal: FC<DetailPanelPortalProps> = ({
                   sx={{
                     fontSize: 12,
                     fontWeight: 600,
-                    margin: '15px 0 10px 21px',
+                    marginTop: '15px',
+                    marginBottom: '10px',
+                    marginInlineStart: '15px',
                   }}
                 >
                   {t('heading.actions')}

--- a/packages/common/src/ui/forms/Modal/ModalLabel.tsx
+++ b/packages/common/src/ui/forms/Modal/ModalLabel.tsx
@@ -9,7 +9,7 @@ export interface ModalLabelProps {
 
 const labelStyle = {
   fontSize: '12px',
-  paddingRight: '19px',
+  marginInlineEnd: '19px',
 };
 
 export const ModalLabel: React.FC<ModalLabelProps> = ({

--- a/packages/host/src/components/AppBar/AppBar.tsx
+++ b/packages/host/src/components/AppBar/AppBar.tsx
@@ -35,7 +35,7 @@ export const AppBar: React.FC = () => {
   ) : (
     <StyledContainer ref={ref} sx={{ boxShadow: theme => theme.shadows[2] }}>
       <Toolbar disableGutters>
-        <Box style={{ paddingRight: 5 }}>
+        <Box style={{ marginInlineEnd: 5 }}>
           <SectionIcon />
         </Box>
 

--- a/packages/host/src/components/Footer/Footer.tsx
+++ b/packages/host/src/components/Footer/Footer.tsx
@@ -15,7 +15,7 @@ export const Footer: React.FC = () => {
   const textStyles = {
     color: 'gray.main',
     fontSize: '12px',
-    paddingLeft: '8px',
+    marginInlineStart: '8px',
   };
 
   return (

--- a/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
@@ -49,7 +49,7 @@ export const GeneralTab: FC<
   return (
     <Box flexDirection="column">
       {rows?.length !== 0 && (
-        <Box style={{ padding: 5, paddingLeft: 15 }}>
+        <Box style={{ padding: 5, marginInlineStart: 15 }}>
           <Switch
             label={t('label.group-by-item', { ns: 'replenishment' })}
             onChange={toggleIsGrouped}

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -86,7 +86,7 @@ export const GeneralTabComponent: FC<
   return (
     <Box flexDirection="column">
       {activeRows?.length !== 0 && (
-        <Box style={{ padding: 5, paddingLeft: 15 }}>
+        <Box style={{ padding: 5, marginInlineStart: 15 }}>
           <Switch
             label={t('label.group-by-item')}
             onChange={toggleIsGrouped}


### PR DESCRIPTION
Fixes #465 

Found more items, and I expect that there are others I've missed. This is enough for now though!

- [ ] Dashboard: spacing in StatusPanel
- [ ]  SidePanel: spacing around Actions and the action button + icons
- [ ]  IconWithButton: spacing between text and icon
- [ ]  Breadcrumb: spacing between text and icon
- [ ] Modal was not showing RTL at all
- [ ] Dialog buttons
- [ ] App footer: icon alignment
- [ ] padding in body of GeneralTab, most noticeable with the 'group by item' checkbox
- [ ] modal form label alignment

Dashboard
<img width="243" alt="Screen Shot 2021-12-29 at 9 37 18 AM" src="https://user-images.githubusercontent.com/9192912/147612660-a1885022-a367-46ce-9315-75955bb4ef31.png">

Buttons
<img width="455" alt="Screen Shot 2021-12-29 at 11 06 01 AM" src="https://user-images.githubusercontent.com/9192912/147612705-14cdddf7-159b-4543-9728-9a836f91c929.png">

General Tab
<img width="503" alt="Screen Shot 2021-12-29 at 11 05 13 AM" src="https://user-images.githubusercontent.com/9192912/147612732-a1b1c341-1713-462a-9536-597505ece71d.png">

Footer
<img width="282" alt="Screen Shot 2021-12-29 at 11 04 53 AM" src="https://user-images.githubusercontent.com/9192912/147612744-fbf039a9-9b2f-4d57-8340-13820c3e11a9.png">

Detail Panel
<img width="258" alt="Screen Shot 2021-12-29 at 9 36 31 AM" src="https://user-images.githubusercontent.com/9192912/147612768-637bf72b-0a29-4c16-a0f2-3f22a20c2de5.png">

