### PR TITLE
persist side panel state

### DIFF
--- a/packages/common/src/hooks/useDetailPanel.tsx
+++ b/packages/common/src/hooks/useDetailPanel.tsx
@@ -2,18 +2,25 @@ import React from 'react';
 import create from 'zustand';
 import { useTranslation } from '@common/intl';
 import { SidebarIcon, ButtonWithIcon } from '../ui';
+import LocalStorage from '../localStorage/LocalStorage';
 
 type DetailPanelController = {
+  hasUserSet: boolean;
   isOpen: boolean;
   open: () => void;
   close: () => void;
 };
 
-export const useDetailPanelStore = create<DetailPanelController>(set => ({
-  isOpen: false,
-  open: () => set(state => ({ ...state, isOpen: true })),
-  close: () => set(state => ({ ...state, isOpen: false })),
-}));
+export const useDetailPanelStore = create<DetailPanelController>(set => {
+  const initialValue = LocalStorage.getItem('/detailpanel/open');
+
+  return {
+    hasUserSet: initialValue !== null,
+    isOpen: !!initialValue,
+    open: () => set(state => ({ ...state, isOpen: true, hasUserSet: true })),
+    close: () => set(state => ({ ...state, isOpen: false, hasUserSet: true })),
+  };
+});
 
 interface DetailPanel {
   OpenButton: JSX.Element | null;
@@ -33,3 +40,13 @@ export const useDetailPanel = (): DetailPanel => {
 
   return { OpenButton, open, close };
 };
+
+useDetailPanelStore.subscribe(({ hasUserSet, isOpen }) => {
+  if (hasUserSet) LocalStorage.setItem('/detailpanel/open', isOpen);
+});
+
+LocalStorage.addListener<boolean>((key, value) => {
+  if (key === '/detailpanel/open') {
+    useDetailPanelStore.setState(state => ({ ...state, isOpen: value }));
+  }
+});

--- a/packages/common/src/hooks/useDetailPanel.tsx
+++ b/packages/common/src/hooks/useDetailPanel.tsx
@@ -7,6 +7,7 @@ import LocalStorage from '../localStorage/LocalStorage';
 type DetailPanelController = {
   hasUserSet: boolean;
   isOpen: boolean;
+  shouldPersist: boolean;
   open: () => void;
   close: () => void;
 };
@@ -16,9 +17,22 @@ export const useDetailPanelStore = create<DetailPanelController>(set => {
 
   return {
     hasUserSet: initialValue !== null,
-    isOpen: !!initialValue,
-    open: () => set(state => ({ ...state, isOpen: true, hasUserSet: true })),
-    close: () => set(state => ({ ...state, isOpen: false, hasUserSet: true })),
+    isOpen: false,
+    shouldPersist: true,
+    open: () =>
+      set(state => ({
+        ...state,
+        isOpen: true,
+        hasUserSet: true,
+        shouldPersist: true,
+      })),
+    close: () =>
+      set(state => ({
+        ...state,
+        isOpen: false,
+        hasUserSet: true,
+        shouldPersist: true,
+      })),
   };
 });
 
@@ -41,8 +55,9 @@ export const useDetailPanel = (): DetailPanel => {
   return { OpenButton, open, close };
 };
 
-useDetailPanelStore.subscribe(({ hasUserSet, isOpen }) => {
-  if (hasUserSet) LocalStorage.setItem('/detailpanel/open', isOpen);
+useDetailPanelStore.subscribe(({ hasUserSet, isOpen, shouldPersist }) => {
+  if (hasUserSet && shouldPersist)
+    LocalStorage.setItem('/detailpanel/open', isOpen);
 });
 
 LocalStorage.addListener<boolean>((key, value) => {

--- a/packages/common/src/localStorage/keys.ts
+++ b/packages/common/src/localStorage/keys.ts
@@ -6,6 +6,7 @@ export type GroupByItem = {
 };
 export type LocalStorageRecord = {
   '/appdrawer/open': boolean;
+  '/detailpanel/open': boolean;
   '/localisation/locale': SupportedLocales;
   '/groupbyitem': GroupByItem;
 };

--- a/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -73,6 +73,9 @@ export function Autocomplete<T>({
       sx={{ width }}
     />
   );
+  const getOptionLabel = (option: { label?: string } & T): string => {
+    return option.label ?? '';
+  };
 
   return (
     <MuiAutocomplete
@@ -94,6 +97,7 @@ export function Autocomplete<T>({
       renderInput={renderInput || defaultRenderInput}
       renderOption={renderOption}
       onChange={onChange}
+      getOptionLabel={getOptionLabel}
     />
   );
 }

--- a/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -1,15 +1,10 @@
 import React, { FC, ReactNode, useEffect, useRef } from 'react';
+import { Box, Grid, Theme, Typography, styled, Portal } from '@mui/material';
 import {
-  Box,
-  Grid,
-  Theme,
-  Typography,
-  styled,
-  useMediaQuery,
-  useTheme,
-  Portal,
-} from '@mui/material';
-import { useDetailPanelStore, useHostContext } from '@common/hooks';
+  useDetailPanelStore,
+  useHostContext,
+  useIsLargeScreen,
+} from '@common/hooks';
 import { useTranslation } from '@common/intl';
 import { FlatButton } from '../../buttons';
 import { CloseIcon } from '@common/icons';
@@ -66,15 +61,16 @@ export const DetailPanelPortal: FC<DetailPanelPortalProps> = ({
 }) => {
   const t = useTranslation('common');
   const { detailPanelRef } = useHostContext();
-  const { close, isOpen, open } = useDetailPanelStore();
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'));
+  const { hasUserSet, isOpen, close } = useDetailPanelStore();
+  const isLargeScreen = useIsLargeScreen();
 
-  useEffect(() => {
-    if (isSmallScreen && isOpen) close();
-    if (!isSmallScreen && !isOpen) open();
-    return () => close();
-  }, [isSmallScreen]);
+  React.useEffect(() => {
+    if (hasUserSet) return;
+    if (isLargeScreen && isOpen)
+      useDetailPanelStore.setState(state => ({ ...state, isOpen: false }));
+    if (!isLargeScreen && !isOpen)
+      useDetailPanelStore.setState(state => ({ ...state, isOpen: true }));
+  }, [isLargeScreen]);
 
   if (!detailPanelRef) return null;
 


### PR DESCRIPTION
Fixes #694 

scratches an itch.. which, it turns out, shouldn't have been a problem 🙄 
The screen size detection was incorrect for the side panel, and on my little laptop screen it shouldn't have been showing anyway. Oh well, have persisted the state regardless.

Found that the panel should only show automatically at large screen sizes:

<img width="260" alt="Screen Shot 2022-01-12 at 9 44 34 AM" src="https://user-images.githubusercontent.com/9192912/149026683-78a87e1d-4236-444d-ba35-1730265e5dcf.png">

