### PR TITLE
Add StocktakeDetailView row expansion

### DIFF
--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -105,7 +105,7 @@ export const DataTable = <T extends DomainObject>({
           <TransitionGroup>
             {data.map((row, idx) => {
               return (
-                <Collapse key={row.id}>
+                <Collapse sx={{ flex: 1, display: 'flex' }} key={row.id}>
                   <DataRow
                     rows={data}
                     ExpandContent={ExpandContent}

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -86,9 +86,20 @@ export const DataRow = <T extends DomainObject>({
           );
         })}
       </TableRow>
-      <tr>
-        <td style={{ display: 'flex' }}>
-          <Collapse sx={{ flex: 1 }} in={isExpanded}>
+      <tr style={{ display: 'flex' }}>
+        <td style={{ display: 'flex', flex: 1 }}>
+          <Collapse
+            sx={{
+              flex: 1,
+              display: 'flex',
+              '& .MuiCollapse-wrapperInner': {
+                flex: 1,
+                display: 'flex',
+                flexDirection: 'column',
+              },
+            }}
+            in={isExpanded}
+          >
             {ExpandContent ? <ExpandContent rowData={rowData} /> : null}
           </Collapse>
         </td>

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -1,5 +1,6 @@
 import { getCheckboxSelectionColumn } from '../columns/CheckboxSelectionColumn';
 import { ColumnAlign, ColumnFormat } from '../columns/types';
+import { formatExpiryDate } from '@common/utils';
 import { DomainObject } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
 
@@ -89,6 +90,8 @@ const getColumnLookup = <T extends DomainObject>(): Record<
     key: 'expiryDate',
     label: 'label.expiry',
     width: 200,
+    formatter: dateString =>
+      dateString ? formatExpiryDate(new Date(dateString as string)) || '' : '',
   },
 
   itemCode: {

--- a/packages/inventory/src/Stocktake/DetailView/ContentArea.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/ContentArea.tsx
@@ -5,29 +5,23 @@ import {
   Box,
   Switch,
   useIsGrouped,
+  MiniTable,
 } from '@openmsupply-client/common';
-import { useStocktakeColumns } from './columns';
+import { useStocktakeColumns, useExpansionColumns } from './columns';
 import { useStocktakeRows } from '../api';
 import { StocktakeSummaryItem, StocktakeLine } from '../../types';
 
-const Expand: FC<{ rowData: StocktakeSummaryItem | StocktakeLine }> = ({
+const Expando = ({
   rowData,
+}: {
+  rowData: StocktakeLine | StocktakeSummaryItem;
 }) => {
-  return (
-    <Box p={1} height={300} style={{ overflow: 'scroll' }}>
-      <Box
-        flex={1}
-        display="flex"
-        height="100%"
-        borderRadius={4}
-        bgcolor="#c7c9d933"
-      >
-        <span style={{ whiteSpace: 'pre-wrap' }}>
-          {JSON.stringify(rowData, null, 2)}
-        </span>
-      </Box>
-    </Box>
-  );
+  const expandoColumns = useExpansionColumns();
+  if ('lines' in rowData && rowData.lines.length > 1) {
+    return <MiniTable rows={rowData.lines} columns={expandoColumns} />;
+  } else {
+    return null;
+  }
 };
 
 export const ContentArea: FC<{
@@ -54,7 +48,7 @@ export const ContentArea: FC<{
       </Box>
       <DataTable<StocktakeSummaryItem | StocktakeLine>
         onRowClick={onRowClick}
-        ExpandContent={Expand}
+        ExpandContent={Expando}
         columns={columns}
         data={rows}
         noDataMessage={t('error.no-items')}

--- a/packages/inventory/src/Stocktake/DetailView/columns.ts
+++ b/packages/inventory/src/Stocktake/DetailView/columns.ts
@@ -110,14 +110,35 @@ export const useStocktakeColumns = ({
                 'expiryDate',
                 null
               );
-              return formatExpiryDate(expiryDate);
+              return expiryDate;
             } else {
-              return formatExpiryDate(rowData.expiryDate);
+              return rowData.expiryDate;
             }
           },
         },
       ],
-      ['packSize', { width: 125 }],
+      [
+        'packSize',
+        {
+          width: 125,
+          getSortValue: row => {
+            if ('lines' in row) {
+              const { lines } = row;
+              return ifTheSameElseDefault(lines, 'packSize', '') ?? '';
+            } else {
+              return row.packSize ?? '';
+            }
+          },
+          accessor: ({ rowData }) => {
+            if ('lines' in rowData) {
+              const { lines } = rowData;
+              return ifTheSameElseDefault(lines, 'packSize', '');
+            } else {
+              return rowData.packSize;
+            }
+          },
+        },
+      ],
       {
         key: 'snapshotNumPacks',
         width: 200,

--- a/packages/inventory/src/Stocktake/DetailView/columns.ts
+++ b/packages/inventory/src/Stocktake/DetailView/columns.ts
@@ -172,3 +172,24 @@ export const useStocktakeColumns = ({
     { sortBy, onChangeSortBy },
     [sortBy, onChangeSortBy]
   );
+
+export const useExpansionColumns = (): Column<StocktakeLine>[] =>
+  useColumns([
+    'batch',
+    'expiryDate',
+    'packSize',
+    {
+      key: 'snapshotNumPacks',
+      width: 200,
+      label: 'label.snapshot-num-of-packs',
+      align: ColumnAlign.Right,
+      accessor: ({ rowData }) => rowData.snapshotNumberOfPacks,
+    },
+    {
+      key: 'countedNumPacks',
+      label: 'label.counted-num-of-packs',
+      width: 200,
+      align: ColumnAlign.Right,
+      accessor: ({ rowData }) => rowData.countedNumberOfPacks,
+    },
+  ]);

--- a/packages/inventory/src/Stocktake/DetailView/columns.ts
+++ b/packages/inventory/src/Stocktake/DetailView/columns.ts
@@ -120,7 +120,7 @@ export const useStocktakeColumns = ({
       [
         'packSize',
         {
-          width: 125,
+          width: 50,
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
@@ -141,7 +141,7 @@ export const useStocktakeColumns = ({
       ],
       {
         key: 'snapshotNumPacks',
-        width: 200,
+        width: 180,
         label: 'label.snapshot-num-of-packs',
         align: ColumnAlign.Right,
         getSortValue: row => {
@@ -166,7 +166,7 @@ export const useStocktakeColumns = ({
       {
         key: 'countedNumPacks',
         label: 'label.counted-num-of-packs',
-        width: 200,
+        width: 180,
         align: ColumnAlign.Right,
         getSortValue: row => {
           if ('lines' in row) {

--- a/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
@@ -47,7 +47,7 @@ export const GeneralTab: FC<
   );
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" display="flex" flex={1}>
       {rows?.length !== 0 && (
         <Box style={{ padding: 5, marginInlineStart: 15 }}>
           <Switch


### PR DESCRIPTION
Fixes #730 

- Added the expiry date formatter
- Changed some styles to improve the inbound shipment table and also ensure the expando is flexed (do we want this..? Seemed weird when the expand didn't fill the whole width, especially when the screen size was smaller and you were scrolling)