### PR TITLE
#709 dom violation

### DIFF
--- a/packages/common/src/intl/IntlProvider.tsx
+++ b/packages/common/src/intl/IntlProvider.tsx
@@ -13,8 +13,8 @@ export const IntlProvider: React.FC = ({ children }) => {
     const expirationTime =
       process.env['NODE_ENV'] === 'development'
         ? 0
-        : 7 * 24 * 60 * minuteInMilliseconds;
-
+        : // TODO: change back to a week when things are stable
+          60 * minuteInMilliseconds; // 7 * 24 * 60 * minuteInMilliseconds;
     i18next
       .use(initReactI18next) // passes i18n down to react-i18next
       .use(Backend)

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -4,14 +4,12 @@ import React, { useEffect } from 'react';
 import {
   Box,
   CircularProgress,
-  Collapse,
   TableBody,
   TableHead,
   TableContainer,
   Table as MuiTable,
   Typography,
 } from '@mui/material';
-import { TransitionGroup } from 'react-transition-group';
 
 import { TableProps } from './types';
 import { DataRow } from './components/DataRow/DataRow';
@@ -102,24 +100,19 @@ export const DataTable = <T extends DomainObject>({
           </HeaderRow>
         </TableHead>
         <TableBody sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          <TransitionGroup>
-            {data.map((row, idx) => {
-              return (
-                <Collapse sx={{ flex: 1, display: 'flex' }} key={row.id}>
-                  <DataRow
-                    rows={data}
-                    ExpandContent={ExpandContent}
-                    rowIndex={idx}
-                    columns={columns}
-                    onClick={onRowClick}
-                    rowData={row}
-                    rowKey={String(idx)}
-                    dense={dense}
-                  />
-                </Collapse>
-              );
-            })}
-          </TransitionGroup>
+          {data.map((row, idx) => (
+            <DataRow
+              key={row.id}
+              rows={data}
+              ExpandContent={ExpandContent}
+              rowIndex={idx}
+              columns={columns}
+              onClick={onRowClick}
+              rowData={row}
+              rowKey={String(idx)}
+              dense={dense}
+            />
+          ))}
         </TableBody>
       </MuiTable>
       <Box

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -93,11 +93,8 @@ export const DataRow = <T extends DomainObject>({
           <Collapse
             sx={{
               flex: 1,
-              display: 'flex',
               '& .MuiCollapse-wrapperInner': {
-                flex: 1,
                 display: 'flex',
-                flexDirection: 'column',
               },
             }}
             in={isExpanded}

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -4,7 +4,7 @@ import TableCell from '@mui/material/TableCell';
 import { Column } from '../../columns/types';
 import { DomainObject } from '@common/types';
 import { useExpanded, useDisabled } from '../../context';
-import { Collapse } from '@mui/material';
+import { Collapse, Fade } from '@mui/material';
 
 interface DataRowProps<T extends DomainObject> {
   columns: Column<T>[];
@@ -36,56 +36,58 @@ export const DataRow = <T extends DomainObject>({
 
   return (
     <>
-      <TableRow
-        sx={{
-          color: isDisabled ? 'gray.main' : 'black',
-          minWidth,
-          alignItems: 'center',
-          height: '40px',
-          maxHeight: '45px',
-          boxShadow: dense
-            ? 'none'
-            : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
-          display: 'flex',
-          flex: '1 0 auto',
-        }}
-        onClick={onRowClick}
-        hover={hasOnClick}
-      >
-        {columns.map((column, columnIndex) => {
-          return (
-            <TableCell
-              key={`${rowKey}${column.key}`}
-              align={column.align}
-              sx={{
-                borderBottom: 'none',
-                justifyContent: 'flex-end',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                paddingLeft: '16px',
-                paddingRight: '16px',
-                ...(hasOnClick && { cursor: 'pointer' }),
-                flex: `${column.width} 0 auto`,
-                minWidth: column.minWidth,
-                width: column.width,
-                color: 'inherit',
-                fontSize: dense ? '12px' : '14px',
-                padding: dense ? '12px' : undefined,
-              }}
-            >
-              <column.Cell
-                rows={rows}
-                rowData={rowData}
-                columns={columns}
-                column={column}
-                rowKey={rowKey}
-                columnIndex={columnIndex}
-                rowIndex={rowIndex}
-              />
-            </TableCell>
-          );
-        })}
-      </TableRow>
+      <Fade in={true} timeout={500}>
+        <TableRow
+          sx={{
+            color: isDisabled ? 'gray.main' : 'black',
+            minWidth,
+            alignItems: 'center',
+            height: '40px',
+            maxHeight: '45px',
+            boxShadow: dense
+              ? 'none'
+              : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
+            display: 'flex',
+            flex: '1 0 auto',
+          }}
+          onClick={onRowClick}
+          hover={hasOnClick}
+        >
+          {columns.map((column, columnIndex) => {
+            return (
+              <TableCell
+                key={`${rowKey}${column.key}`}
+                align={column.align}
+                sx={{
+                  borderBottom: 'none',
+                  justifyContent: 'flex-end',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  paddingLeft: '16px',
+                  paddingRight: '16px',
+                  ...(hasOnClick && { cursor: 'pointer' }),
+                  flex: `${column.width} 0 auto`,
+                  minWidth: column.minWidth,
+                  width: column.width,
+                  color: 'inherit',
+                  fontSize: dense ? '12px' : '14px',
+                  padding: dense ? '12px' : undefined,
+                }}
+              >
+                <column.Cell
+                  rows={rows}
+                  rowData={rowData}
+                  columns={columns}
+                  column={column}
+                  rowKey={rowKey}
+                  columnIndex={columnIndex}
+                  rowIndex={rowIndex}
+                />
+              </TableCell>
+            );
+          })}
+        </TableRow>
+      </Fade>
       <tr style={{ display: 'flex' }}>
         <td style={{ display: 'flex', flex: 1 }}>
           <Collapse

--- a/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
+++ b/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
@@ -17,7 +17,7 @@ export const MiniTable = <T extends DomainObject>({
   JSXElementConstructor<MiniTableProps<T>>
 > => {
   return (
-    <Box p={1} style={{ padding: '0 100px', width: '100%' }}>
+    <Box p={1} style={{ padding: '0 100px 5px 100px', width: '100%' }}>
       <Box
         flex={1}
         display="flex"
@@ -25,6 +25,8 @@ export const MiniTable = <T extends DomainObject>({
         borderRadius={4}
         sx={{
           backgroundColor: theme => alpha(theme.palette.gray.light, 0.2),
+          border: theme => `1px solid ${alpha(theme.palette.gray.light, 0.2)}`,
+          '& .MuiTableHead-root': { borderRadius: '16px 16px 0 0' },
         }}
       >
         <DataTable dense columns={columns} data={rows} />

--- a/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/tabs/GeneralTab.tsx
@@ -59,13 +59,13 @@ export const GeneralTabComponent: FC<
   const t = useTranslation('distribution');
   const { isGrouped, toggleIsGrouped } = useIsGrouped('outboundShipment');
 
-  const activeRows = useMemo(() => {
-    const x = data
-      .filter(({ isDeleted }) => !isDeleted)
-      .slice(pagination.offset, pagination.offset + pagination.first);
-
-    return x;
-  }, [data]);
+  const activeRows = useMemo(
+    () =>
+      data
+        .filter(({ isDeleted }) => !isDeleted)
+        .slice(pagination.offset, pagination.offset + pagination.first),
+    [data]
+  );
 
   // const toggleGrouped = () => {
   //   const outboundShipment = !isGroupedByItem?.outboundShipment;


### PR DESCRIPTION
Fixes #709

Had an issue with using `Collapse`, since it uses nested `div`s to get the animation effect.
So I've changed to use a `Fade` which affects the behaviour on first render of the table, I think it's kinda nice, so have left it. Can instead use props to only implement the fade when grouped if you prefer.

Couple of minor offroads - one was the table header change: the background was made white rather than transparent, which resulted in this:

<img width="517" alt="Screen Shot 2022-01-14 at 10 13 31 AM" src="https://user-images.githubusercontent.com/9192912/149432338-8ef9f832-4952-4976-b913-d21b49f49827.png">

I've put a border around the mini table to soften the impact of the square top of the first table row:

<img width="360" alt="Screen Shot 2022-01-14 at 1 53 33 PM" src="https://user-images.githubusercontent.com/9192912/149432528-dd34169e-8908-4fd8-8b76-196f7c96cd0b.png">

not sold on the big rounded corners.. but hopeful ok? 🤷 

