### PR TITLE
default pack size

### DIFF
--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsForm.tsx
@@ -112,8 +112,8 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
                   onChangeQuantity(
                     Number(event.target.value),
                     packSizeController.selected.value === -1
-                      ? Number(packSizeController.selected.value)
-                      : null
+                      ? null
+                      : Number(packSizeController.selected.value)
                   );
                 },
               })}
@@ -145,6 +145,7 @@ export const ItemDetailsForm: React.FC<ItemDetailsFormProps> = ({
               onChange={e => {
                 const { value } = e.target;
                 const packSize = Number(value);
+
                 packSizeController.setPackSize(packSize);
                 onChangeQuantity(quantity, packSize === -1 ? null : packSize);
               }}

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/ItemDetailsModal.tsx
@@ -147,18 +147,7 @@ const usePackSizeController = (
     }))
   );
 
-  const selectedPackSize = ifTheSameElseDefault(
-    batches.filter(batch => batch.numberOfPacks > 0),
-    'packSize',
-    0
-  );
-  const defaultPackSize = (selectedPackSize === 0
-    ? options[0]
-    : options.find(option => option.value === selectedPackSize)) ?? {
-    label: '',
-    value: '',
-  };
-  const [selected, setSelected] = useState(defaultPackSize);
+  const [selected, setSelected] = useState({ label: '', value: 0 });
 
   const setPackSize = (newValue: number) => {
     const packSizeOption = options.find(({ value }) => value === newValue);
@@ -167,15 +156,32 @@ const usePackSizeController = (
   };
 
   useEffect(() => {
+    if (selected.value !== 0) return;
+
+    const selectedPackSize = ifTheSameElseDefault(
+      batches.filter(batch => batch.numberOfPacks > 0),
+      'packSize',
+      0
+    );
+
+    const defaultPackSize = (selectedPackSize === 0
+      ? options[0]
+      : options.find(option => option.value === selectedPackSize)) ?? {
+      label: '',
+      value: '',
+    };
+
     if (defaultPackSize.value && typeof defaultPackSize.value == 'number') {
       setPackSize(defaultPackSize.value);
     }
     if (packSizes.length === 0) {
-      setSelected({ label: '', value: '' });
+      setSelected({ label: '', value: 0 });
     }
-  }, [defaultPackSize.value]);
+  }, [batches]);
 
-  return { selected, setPackSize, options };
+  const reset = () => setSelected({ label: '', value: 0 });
+
+  return { selected, setPackSize, options, reset };
 };
 
 const sumAvailableQuantity = (batchRows: BatchRow[]) => {
@@ -236,6 +242,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
   });
 
   const onReset = () => {
+    packSizeController.reset();
     reset();
   };
   const onCancel = () => {
@@ -264,6 +271,10 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
     onClose();
     onReset();
     onChangeItem(null);
+  };
+  const next = () => {
+    packSizeController.reset();
+    onNext();
   };
 
   const allocateQuantities = (
@@ -384,7 +395,7 @@ export const ItemDetailsModal: React.FC<ItemDetailsModalProps> = ({
         <DialogButton
           disabled={isEditMode && isOnlyItem}
           variant="next"
-          onClick={onNext}
+          onClick={next}
         />
       }
       okButton={<DialogButton variant="ok" onClick={upsertAndClose} />}


### PR DESCRIPTION
Fixes #752 

couple of daft bugs 🐛  🙄 

As in the issue: changing the quantity would reset any changes to the selected pack size. The hook was happily resetting on every change. stopping that meant that the value was retained when editing a different line, which is a different problem. I've worked around by resetting the packSizeController state when you change the modal.