### PR TITLE
make kbar pretty again

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,7 @@
     "i18next-http-backend": "^1.3.1",
     "i18next-localstorage-backend": "^3.1.3",
     "immer": "^9.0.7",
-    "kbar": "^0.1.0-beta.24",
+    "kbar": "^0.1.0-beta.27",
     "lodash": "^4.17.21",
     "notistack": "^2.0.3",
     "react-currency-input-field": "^3.6.0",

--- a/packages/common/src/intl/locales/en/app.json
+++ b/packages/common/src/intl/locales/en/app.json
@@ -30,5 +30,22 @@
   "sync": "Sync",
   "tools": "Tools",
   "stocktake": "Stocktake",
-  "locations": "Locations"
+  "locations": "Locations",
+  "cmdk.navigation-actions": "Navigation actions",
+  "cmdk.go-back": "Go Back",
+  "cmdk.drawer-toggle": "Toggle Menu",
+  "cmdk.goto-outbound": "Go to: Outbound Shipments",
+  "cmdk.create-outbound": "Create: New Outbound Shipment",
+  "cmdk.goto-inbound": "Go to: Inbound Shipments",
+  "cmdk.create-inbound": "Create: New Inbound Shipment",
+  "cmdk.goto-dashboard": "Go to: Dashboard",
+  "cmdk.goto-customer-requisition": "Go to: Customer Requisition",
+  "cmdk.goto-supplier-requisition": "Go to: Supplier Requisition",
+  "cmdk.goto-stocktakes": "Go to: Stocktakes",
+  "cmdk.goto-stock": "Go to: Stock",
+  "cmdk.goto-locations": "Go to: Locations",
+  "cmdk.goto-items": "Go to: Items",
+  "cmdk.goto-customers": "Go to: Customers",
+  "cmdk.goto-suppliers": "Go to: Suppliers",
+  "cmdk.goto-reports": "Go to: Reports"
 }

--- a/packages/common/src/intl/locales/en/app.json
+++ b/packages/common/src/intl/locales/en/app.json
@@ -47,5 +47,6 @@
   "cmdk.goto-items": "Go to: Items",
   "cmdk.goto-customers": "Go to: Customers",
   "cmdk.goto-suppliers": "Go to: Suppliers",
-  "cmdk.goto-reports": "Go to: Reports"
+  "cmdk.goto-reports": "Go to: Reports",
+  "cmdk.placeholder": "Type a command or search"
 }

--- a/packages/host/src/CommandK.tsx
+++ b/packages/host/src/CommandK.tsx
@@ -1,0 +1,255 @@
+import React, { FC } from 'react';
+import {
+  useNavigate,
+  RouteBuilder,
+  useDrawer,
+  styled,
+  useMatches,
+  alpha,
+  useTranslation,
+  KBarAnimator,
+  KBarResults,
+  KBarSearch,
+  KBarProvider,
+  KBarPositioner,
+  KBarPortal,
+} from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
+import { Action } from 'kbar/lib/types';
+
+const CustomKBarSearch = styled(KBarSearch)(({ theme }) => ({
+  width: 500,
+  height: 50,
+  fontSize: 20,
+  backgroundColor: alpha(theme.palette.primary.main, 0.2),
+  borderColor: theme.palette.primary.main,
+  borderRadius: 5,
+  ':focus-visible': {
+    outline: 'none',
+  },
+}));
+
+const StyledKBarAnimator = styled(KBarAnimator)(({ theme }) => ({
+  boxShadow: '0px 6px 20px rgb(0 0 0 / 20%)',
+  backgroundColor: alpha(theme.palette.background.toolbar, 0.9),
+  borderRadius: 7,
+  '& #kbar-listbox>div': {
+    padding: '0 8px',
+  },
+}));
+
+const StyledKBarResults = styled(KBarResults)({
+  width: 500,
+  fontSize: 16,
+  borderRadius: '5px',
+  boxShadow: '0px 6px 20px rgb(0 0 0 / 20%)',
+  ':focus-visible': {
+    outline: 'none',
+  },
+});
+
+const CustomKBarResults = () => {
+  const { results } = useMatches();
+  return (
+    <StyledKBarResults
+      items={results}
+      onRender={({ item, active }) =>
+        typeof item === 'string' ? (
+          <div>{item}</div>
+        ) : (
+          <div
+            style={{
+              background: active ? '#eee' : 'transparent',
+            }}
+          >
+            {item.name}
+          </div>
+        )
+      }
+    />
+  );
+};
+
+const actionSorter = (a: Action, b: Action) => {
+  if (a.name < b.name) return -1;
+  if (a.name > b.name) return 1;
+  return 0;
+};
+
+export const CommandK: FC = ({ children }) => {
+  const navigate = useNavigate();
+  const drawer = useDrawer();
+  const t = useTranslation('app');
+  const actions = [
+    // {
+    //   id: 'Navigate',
+    //   name: t('cmdk.navigation-actions'),
+    //   shortcut: ['c'],
+    //   keywords: 'navigation, back',
+    //   children: [
+    //     {
+    //       id: 'navigation:go-back',
+    //       name: t('cmdk.go-back'),
+    //       shortcut: ['c'],
+    //       keywords: 'navigation, back',
+    //       perform: () => navigate(-1),
+    //       parent: 'Navigate',
+    //     },
+    //   ],
+    // },
+    {
+      id: 'navigation-drawer:toggle',
+      name: `${t('cmdk.drawer-toggle')} (m)`,
+      shortcut: ['m'],
+      keywords: 'drawer, close',
+      perform: () => drawer.toggle(),
+    },
+    {
+      id: 'navigation:outbound-shipment',
+      name: `${t('cmdk.goto-outbound')} (o)`,
+      shortcut: ['o'],
+      keywords: 'shipment',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Distribution)
+            .addPart(AppRoute.OutboundShipment)
+            .build()
+        ),
+    },
+    // {
+    //   id: 'navigation:outbound-shipment/new',
+    //   name: t('cmdk.create-outbound'),
+    //   keywords: 'distribution',
+    //   perform: () => navigate('/distribution/outbound-shipment/new'),
+    // },
+    {
+      id: 'navigation:inbound-shipment',
+      name: `${t('cmdk.goto-inbound')} (i)`,
+      shortcut: ['i'],
+      keywords: 'shipment',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Replenishment)
+            .addPart(AppRoute.InboundShipment)
+            .build()
+        ),
+    },
+    // {
+    //   id: 'navigation:inbound-shipment/new',
+    //   name: t('cmdk.create-inbound'),
+    //   keywords: 'distribution',
+    //   perform: () => navigate('/replenishment/inbound-shipment/new'),
+    // },
+    {
+      id: 'navigation:customers',
+      name: `${t('cmdk.goto-customers')} (g+c)`,
+      keywords: 'customers',
+      shortcut: ['g', 'c'],
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Distribution)
+            .addPart(AppRoute.Customer)
+            .build()
+        ),
+    },
+    {
+      id: 'navigation:dashboard',
+      name: `${t('cmdk.goto-dashboard')} (d)`,
+      shortcut: ['d'],
+      keywords: 'dashboard',
+      perform: () => navigate(RouteBuilder.create(AppRoute.Dashboard).build()),
+    },
+    {
+      id: 'navigation:items',
+      name: `${t('cmdk.goto-items')} (g+i)`,
+      shortcut: ['g', 'i'],
+      keywords: 'items',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Catalogue)
+            .addPart(AppRoute.Items)
+            .build()
+        ),
+    },
+    {
+      id: 'navigation:customer-requisition',
+      name: `${t('cmdk.goto-customer-requisition')} (c+r)`,
+      shortcut: ['c', 'r'],
+      keywords: 'distribution',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Distribution)
+            .addPart(AppRoute.CustomerRequisition)
+            .build()
+        ),
+    },
+    {
+      id: 'navigation:reports',
+      name: `${t('cmdk.goto-reports')} (r)`,
+      shortcut: ['r'],
+      keywords: 'reports',
+      perform: () => navigate(RouteBuilder.create(AppRoute.Reports).build()),
+    },
+    {
+      id: 'navigation:suppliers',
+      name: `${t('cmdk.goto-suppliers')} (g+s)`,
+      keywords: 'suppliers',
+      shortcut: ['g', 's'],
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Replenishment)
+            .addPart(AppRoute.Suppliers)
+            .build()
+        ),
+    },
+    {
+      id: 'navigation:stock',
+      name: t('cmdk.goto-stock'),
+      keywords: 'stock',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Inventory)
+            .addPart(AppRoute.Stock)
+            .build()
+        ),
+    },
+    {
+      id: 'navigation:stocktakes',
+      name: t('cmdk.goto-stocktakes'),
+      keywords: 'stocktakes',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Inventory)
+            .addPart(AppRoute.Stocktake)
+            .build()
+        ),
+    },
+    {
+      id: 'navigation:locations',
+      name: `${t('cmdk.goto-locations')} (g+l)`,
+      shortcut: ['g', 'l'],
+      keywords: 'locations',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Inventory)
+            .addPart(AppRoute.Locations)
+            .build()
+        ),
+    },
+  ];
+
+  const sortedActions = actions.sort(actionSorter);
+  return (
+    <KBarProvider actions={sortedActions}>
+      <KBarPortal>
+        <KBarPositioner style={{ zIndex: 1001 }}>
+          <StyledKBarAnimator>
+            <CustomKBarSearch placeholder="Type a command or search" />
+            <CustomKBarResults />
+          </StyledKBarAnimator>
+        </KBarPositioner>
+      </KBarPortal>
+      {children}
+    </KBarProvider>
+  );
+};

--- a/packages/host/src/CommandK.tsx
+++ b/packages/host/src/CommandK.tsx
@@ -244,7 +244,7 @@ export const CommandK: FC = ({ children }) => {
       <KBarPortal>
         <KBarPositioner style={{ zIndex: 1001 }}>
           <StyledKBarAnimator>
-            <CustomKBarSearch placeholder="Type a command or search" />
+            <CustomKBarSearch placeholder={t('cmdk.placeholder')} />
             <CustomKBarResults />
           </StyledKBarAnimator>
         </KBarPositioner>

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -4,7 +4,6 @@ import {
   BrowserRouter,
   Routes,
   Route,
-  useNavigate,
   Navigate,
   AppFooterPortal,
   Box,
@@ -17,20 +16,11 @@ import {
   RouteBuilder,
   ErrorBoundary,
   GenericErrorFallback,
-  KBarProvider,
-  KBarPortal,
-  KBarPositioner,
-  KBarAnimator,
-  KBarSearch,
-  KBarResults,
-  useDrawer,
-  styled,
   DetailPanel,
   AppFooter,
   OmSupplyApiProvider,
   IntlProvider,
   RandomLoader,
-  useMatches,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { AppDrawer, AppBar, Viewport, NotFound, Footer } from './components';
@@ -42,6 +32,7 @@ import {
   ReplenishmentRouter,
 } from './routers';
 import { Settings } from './Admin/Settings';
+import { CommandK } from './CommandK';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -57,146 +48,6 @@ const Heading: FC = ({ children }) => (
     <Typography>[ Placeholder page: {children} ]</Typography>
   </div>
 );
-
-const CustomKBarSearch = styled(KBarSearch)(({ theme }) => ({
-  width: 500,
-  height: 50,
-  fontSize: 20,
-  backgroundColor: theme.palette.primary.main,
-  borderRadius: '5px',
-  ':focus-visible': {
-    outline: 'none',
-  },
-}));
-
-const StyledKBarResults = styled(KBarResults)({
-  width: 500,
-  fontSize: 16,
-  borderRadius: '5px',
-  boxShadow: '0px 6px 20px rgb(0 0 0 / 20%)',
-  ':focus-visible': {
-    outline: 'none',
-  },
-});
-
-const CustomKBarResults = () => {
-  const { results } = useMatches();
-
-  return (
-    <StyledKBarResults
-      items={results}
-      onRender={({ item, active }) =>
-        typeof item === 'string' ? (
-          <div>{item}</div>
-        ) : (
-          <div
-            style={{
-              background: active ? '#eee' : 'transparent',
-            }}
-          >
-            {item.name}
-          </div>
-        )
-      }
-    />
-  );
-};
-
-const CommandK: FC = ({ children }) => {
-  const navigate = useNavigate();
-  const drawer = useDrawer();
-
-  const actions = [
-    {
-      id: 'Navigate',
-      section: 'This is a subtitle hehe',
-      name: 'Navigation actions',
-      shortcut: ['c'],
-      keywords: 'navigation, back',
-      children: ['navigation:go-back', 'navigation:outbound-shipment'],
-    },
-
-    {
-      id: 'navigation:go-back',
-      name: 'Go back',
-      shortcut: ['c'],
-      keywords: 'navigation, back',
-      perform: () => navigate(-1),
-    },
-    {
-      id: 'navigation-drawer:close-drawer',
-      name: 'Navigation Drawer: Close',
-      shortcut: ['c'],
-      keywords: 'drawer, close',
-      perform: () => drawer.close(),
-    },
-    {
-      id: 'navigation-drawer:open-drawer',
-      name: 'Navigation Drawer: Open',
-      shortcut: ['o'],
-      keywords: 'drawer, open',
-      perform: () => drawer.open(),
-    },
-    {
-      id: 'navigation:outbound-shipment',
-      name: 'Go to: Outbound Shipments',
-      shortcut: ['c'],
-      keywords: 'shipment',
-      perform: () =>
-        navigate(
-          RouteBuilder.create(AppRoute.Distribution)
-            .addPart(AppRoute.OutboundShipment)
-            .build()
-        ),
-    },
-    {
-      id: 'navigation:outbound-shipment/new',
-      name: 'Create: New Outbound Shipment',
-      shortcut: ['o'],
-      keywords: 'distribution',
-      perform: () => navigate('/distribution/outbound-shipment/new'),
-    },
-    {
-      id: 'navigation:dashboard',
-      name: 'Go to: Dashboard',
-      shortcut: ['d'],
-      keywords: 'dashboard',
-      perform: () => navigate('/dashboard'),
-    },
-    {
-      id: 'navigation:customer-requisition',
-      name: 'Go to: Customer Requisition',
-      shortcut: ['r'],
-      keywords: 'distribution',
-      perform: () => navigate('/distribution/customer-requisition'),
-    },
-    {
-      id: 'navigation:reports',
-      name: 'Go to: Reports',
-      shortcut: ['r'],
-      keywords: 'reports',
-      perform: () => navigate('/reports'),
-    },
-  ];
-
-  return (
-    <KBarProvider actions={actions}>
-      <KBarPortal>
-        <KBarPositioner>
-          <KBarAnimator
-            style={{
-              boxShadow: '0px 6px 20px rgb(0 0 0 / 20%)',
-            }}
-          >
-            <CustomKBarSearch placeholder="Type a command or search" />
-            <CustomKBarResults />
-          </KBarAnimator>
-        </KBarPositioner>
-      </KBarPortal>
-      {children}
-    </KBarProvider>
-  );
-};
 
 const Host: FC = () => (
   <React.Suspense fallback={<RandomLoader />}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11133,10 +11133,10 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-kbar@^0.1.0-beta.24:
-  version "0.1.0-beta.24"
-  resolved "https://registry.yarnpkg.com/kbar/-/kbar-0.1.0-beta.24.tgz#5404c9817a0b7419b60b8378e45cffd7197970ee"
-  integrity sha512-frawEcCuWhI82DFxtv368vlApUkW11DfcpGt4WFxHT6t7uA1Gcz9Uqj8Pclt52iWJHRAcodqDKFZWrIg9mk8/Q==
+kbar@^0.1.0-beta.27:
+  version "0.1.0-beta.27"
+  resolved "https://registry.yarnpkg.com/kbar/-/kbar-0.1.0-beta.27.tgz#6fec637054599dc4c6aa5a0cfc4042a50b3e32d1"
+  integrity sha512-4knRJxDQqx3LUduhjuJh9EDGxnFpaQKjXt11UOsjKQ4ByXTTQpPjfAaKagVcTp9uVwEXGDhvGrsGbMfrI+6/Kg==
   dependencies:
     "@reach/portal" "^0.16.0"
     fast-equals "^2.0.3"


### PR DESCRIPTION
Fixes #761 

- Updated kbar ( for no good reason really, there was an error, but it was due to our config )
- Changed the styles of a few parts
  - Search bar is now less orange ( opacity reduced to 0.2 so that the text is visible ), added a border
  - Opacity of background + background colour
  - Added z-index, though only required when shown over the data table due to the newly added zIndex of the header
  - Some padding around list results
  - border radius on results
- Modified the action list, added a bunch of routes, removed ones that were not working ( new outbound and navigation back )
- lifted kbar out to a sep file
- changed routes to use route builder
- added translation support for items

<img width="637" alt="Screen Shot 2022-01-28 at 11 55 36 AM" src="https://user-images.githubusercontent.com/9192912/151457467-856d98a3-7f86-4ff2-8a0d-d3b77ac8edf1.png">

