### PR TITLE
tidy autocomplete styles

### DIFF
--- a/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.stories.tsx
@@ -18,23 +18,89 @@ const StyledPaper = styled(Paper)({
 });
 
 const options = Array.from({ length: 100 }).map((_, i) => ({
-  name: `${i}`,
+  label: `${i}`,
 }));
 
+const longOptions = [
+  {
+    label: 'SAINT JOSEPH MOSCATI (HÔPITAL CATHOLIQUE)',
+  },
+  {
+    label: 'CAFOP de YAMOUSSOUKRO (INF-LC PUBLIC)',
+  },
+  {
+    label: 'SAINT VINCENT DE PAUL DE YAMOUSSOUKRO (HÔPITAL PSY',
+  },
+  {
+    label: 'Lycée BAD de YAMOUSSOUKRO (INF-LC PUBLIC)',
+  },
+  {
+    label: 'Lycée Mami Adjoua de YAMOUSSOUKRO (INF-LC PUBLIC)',
+  },
+  {
+    label: 'Lycée Scientifique de YAMOUSSOUKRO (INF-LC PUBLIC)',
+  },
+  {
+    label: 'Garde Republicaine de YAMOUSSOUKRO (INF-M PUBLIC)',
+  },
+  {
+    label: 'GSPM de YAMOUSSOUKRO (INF-M PUBLIC)',
+  },
+  {
+    label: 'Nouvelle Clinique Saint Augustin',
+  },
+  {
+    label: 'INPHB-CENTRE PUBLIC de YAMASSOUKRO',
+  },
+  {
+    label: 'Pharmacie Centrale CHR PUBLIC DE YAMOUSSOUKRO',
+  },
+  {
+    label: 'Dispensation CHR PUBLIC DE YAMOUSSOUKRO',
+  },
+  {
+    label: 'Caisse CHR PUBLIC DE YAMOUSSOUKRO',
+  },
+  {
+    label: 'CHU COCODY central  (Main Warehouse)',
+  },
+  {
+    label: 'Pharmacie Centrale CHU COCODY - ABIDJAN (Main Phar',
+  },
+  {
+    label: 'Pediatrie CHU COCODY - ABIDJAN (Pediatrics)',
+  },
+  {
+    label: 'Maternity CHU COCODY - ABIDJAN',
+  },
+  {
+    label: 'Consultations Externes CHU COCODY',
+  },
+  {
+    label: 'PRIVE CSCT de YAMOUSSOUKRO (INF-PV)',
+  },
+];
+
 // TODO: Currently the styles are broken for this only within storybook
-const BasicTemplate: Story = () => (
+const BasicTemplate: Story = ({ options }) => (
   <Grid container>
     <Grid item>
       <StyledPaper>
         <Typography>Basic autocomplete</Typography>
-        <Autocomplete options={options.map(({ name }) => name)} width="300px" />
+        <Autocomplete options={options} width="300px" />
+      </StyledPaper>
+    </Grid>
+    <Grid item>
+      <StyledPaper>
+        <Typography>Auto Width Popper</Typography>
+        <Autocomplete options={options} width="300px" autoWidthPopper />
       </StyledPaper>
     </Grid>
     <Grid item>
       <StyledPaper>
         <Typography>Disabled</Typography>
         <Autocomplete
-          options={options.map(({ name }) => name)}
+          options={options}
           width="300px"
           disabled
           defaultValue={'95' as AutocompleteOption<string>}
@@ -49,7 +115,7 @@ const ListTemplate: Story = () => (
     <Grid item>
       <StyledPaper>
         <Typography>Autocomplete List</Typography>
-        <AutocompleteList options={options} optionKey="name" />
+        <AutocompleteList options={options} optionKey="label" />
       </StyledPaper>
     </Grid>
   </Grid>
@@ -57,3 +123,7 @@ const ListTemplate: Story = () => (
 
 export const Basic = BasicTemplate.bind({});
 export const List = ListTemplate.bind({});
+export const LongOptions = BasicTemplate.bind({});
+
+Basic.args = { options: options };
+LongOptions.args = { options: longOptions, autoWidthPopper: true };

--- a/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/packages/common/src/ui/components/inputs/Autocomplete/Autocomplete.tsx
@@ -6,6 +6,9 @@ import {
   CreateFilterOptionsConfig,
   AutocompleteInputChangeReason,
   AutocompleteProps as MuiAutocompleteProps,
+  styled,
+  Popper,
+  PopperProps,
 } from '@mui/material';
 import {
   AutocompleteOption,
@@ -40,7 +43,12 @@ export interface AutocompleteProps<T>
     reason: AutocompleteInputChangeReason
   ) => void;
   inputValue?: string;
+  autoWidthPopper?: boolean;
 }
+
+const StyledPopper = styled(Popper)(({ theme }) => ({
+  boxShadow: theme.shadows[2],
+}));
 
 export function Autocomplete<T>({
   defaultValue,
@@ -62,6 +70,7 @@ export function Autocomplete<T>({
   inputValue,
   autoFocus = false,
   getOptionLabel,
+  autoWidthPopper = false,
   ...restOfAutocompleteProps
 }: PropsWithChildren<AutocompleteProps<T>>): JSX.Element {
   const filterOptions = createFilterOptions(filterOptionConfig);
@@ -77,6 +86,14 @@ export function Autocomplete<T>({
   const defaultGetOptionLabel = (option: { label?: string } & T): string => {
     return option.label ?? '';
   };
+
+  const CustomPopper: React.FC<PopperProps> = props => (
+    <StyledPopper
+      {...props}
+      placement="bottom-start"
+      style={{ minWidth: width, width: 'auto' }}
+    />
+  );
 
   return (
     <MuiAutocomplete
@@ -99,6 +116,7 @@ export function Autocomplete<T>({
       renderOption={renderOption}
       onChange={onChange}
       getOptionLabel={getOptionLabel || defaultGetOptionLabel}
+      PopperComponent={autoWidthPopper ? CustomPopper : StyledPopper}
     />
   );
 }

--- a/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.tsx
+++ b/packages/system/src/Name/Components/NameSearchInput/NameSearchInput.tsx
@@ -52,6 +52,7 @@ export const NameSearchInput: FC<NameSearchInputProps> = ({
       renderOption={getDefaultOptionRenderer('name')}
       width={`${width}px`}
       isOptionEqualToValue={(option, value) => option?.id === value?.id}
+      autoWidthPopper
     />
   );
 };


### PR DESCRIPTION
Fixes #679 

Added the option to expand the popper width as needed, when doing so have set the `minWidth` because I think it looks silly when the popper is not as wide as the input.

Added `boxShadow` to all Autocompletes as I think it looks nice.

Updated the name search input to use auto width; added a story to demonstrate the option.