### PR TITLE
remove batch & expiry table

### DIFF
--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -74,6 +74,8 @@ export interface Column<T extends DomainObject> {
 
   width: number;
   minWidth: number;
+  maxWidth?: number;
+  backgroundColor?: string;
 
   Cell: JSXElementConstructor<CellProps<T>>;
   Header: JSXElementConstructor<HeaderProps<T>>;

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -33,6 +33,8 @@ export const DataRow = <T extends DomainObject>({
 
   const onRowClick = () => onClick && onClick(rowData);
   const minWidth = columns.reduce((sum, { minWidth }) => sum + minWidth, 0);
+  const paddingX = dense ? '12px' : '16px';
+  const paddingY = dense ? '4px' : undefined;
 
   return (
     <>
@@ -63,15 +65,18 @@ export const DataRow = <T extends DomainObject>({
                   justifyContent: 'flex-end',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
-                  paddingLeft: '16px',
-                  paddingRight: '16px',
+                  paddingLeft: paddingX,
+                  paddingRight: paddingX,
+                  paddingTop: paddingY,
+                  paddingBottom: paddingY,
                   ...(hasOnClick && { cursor: 'pointer' }),
                   flex: `${column.width} 0 auto`,
                   minWidth: column.minWidth,
+                  maxWidth: column.maxWidth,
                   width: column.width,
                   color: 'inherit',
                   fontSize: dense ? '12px' : '14px',
-                  padding: dense ? '12px' : undefined,
+                  backgroundColor: column.backgroundColor,
                 }}
               >
                 <column.Cell

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -27,6 +27,7 @@ export const HeaderCell = <T extends DomainObject>({
   dense = false,
 }: HeaderCellProps<T>): JSX.Element => {
   const {
+    maxWidth,
     minWidth,
     width,
     onChangeSortBy,
@@ -60,6 +61,7 @@ export const HeaderCell = <T extends DomainObject>({
         paddingRight: '16px',
         width,
         minWidth,
+        maxWidth,
         flex: `${width} 0 auto`,
         fontWeight: 'bold',
         fontSize: dense ? '12px' : '14px',

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -31,7 +31,7 @@ const getColumnWidths = <T extends DomainObject>(
   const minWidth = column.minWidth || column.width || defaultWidth;
   const width = column.width || defaultWidth;
 
-  return { minWidth, width };
+  return { minWidth, width, maxWidth: column.maxWidth };
 };
 
 const getSortType = (column: { format?: ColumnFormat }) => {
@@ -133,7 +133,7 @@ interface ColumnOptions<T extends DomainObject> {
   sortBy?: SortBy<T>;
 }
 
-type ColumnDescription<T extends DomainObject> =
+export type ColumnDescription<T extends DomainObject> =
   | ColumnDefinition<T>
   | ColumnKey
   | [ColumnKey | ColumnDefinition<T>, Omit<ColumnDefinition<T>, 'key'>]

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
@@ -1,15 +1,6 @@
 import React, { FC } from 'react';
 
-import {
-  styled,
-  TabPanel,
-  useColumns,
-  Box,
-  DataTable,
-  alpha,
-  TextInputCell,
-  getExpiryDateInputColumn,
-} from '@openmsupply-client/common';
+import { styled, TabPanel, Box } from '@openmsupply-client/common';
 import { DraftInboundLine } from './InboundLineEdit';
 
 const StyledTabPanel = styled(TabPanel)({
@@ -22,43 +13,19 @@ const StyledTabContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
 }));
 
-const StyledStaticArea = styled(Box)(({ theme }) => ({
-  backgroundColor: alpha(theme.palette.background.menu, 0.4),
-  display: 'flex',
-  flexDirection: 'column',
-}));
-
 interface InboundLineEditPanel {
   value: string;
   lines: DraftInboundLine[];
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }
 
-const expiryInputColumn = getExpiryDateInputColumn<DraftInboundLine>();
-
 export const InboundLineEditPanel: FC<InboundLineEditPanel> = ({
-  lines,
   value,
-  updateDraftLine,
   children,
 }) => {
-  const columns = useColumns<DraftInboundLine>(
-    [
-      ['batch', { width: 150, Cell: TextInputCell, setter: updateDraftLine }],
-      [expiryInputColumn, { width: 150, setter: updateDraftLine }],
-    ],
-    {},
-    [updateDraftLine]
-  );
-
   return (
     <StyledTabPanel value={value}>
-      <StyledTabContainer>
-        <StyledStaticArea>
-          <DataTable dense columns={columns} data={lines} />
-        </StyledStaticArea>
-        {children}
-      </StyledTabContainer>
+      <StyledTabContainer>{children}</StyledTabContainer>
     </StyledTabPanel>
   );
 };

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -4,6 +4,12 @@ import {
   useColumns,
   NumberInputCell,
   CurrencyInputCell,
+  getExpiryDateInputColumn,
+  TextInputCell,
+  ColumnDescription,
+  useTheme,
+  Theme,
+  alpha,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from './InboundLineEdit';
 import { getLocationInputColumn } from '@openmsupply-client/system';
@@ -13,12 +19,42 @@ interface TableProps {
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
 }
 
+const expiryInputColumn = getExpiryDateInputColumn<DraftInboundLine>();
+const getBatchColumn = (
+  updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void,
+  theme: Theme
+): ColumnDescription<DraftInboundLine> => [
+  'batch',
+  {
+    width: 150,
+    maxWidth: 150,
+    Cell: TextInputCell,
+    setter: updateDraftLine,
+    backgroundColor: alpha(theme.palette.background.menu, 0.4),
+  },
+];
+const getExpiryColumn = (
+  updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void,
+  theme: Theme
+): ColumnDescription<DraftInboundLine> => [
+  expiryInputColumn,
+  {
+    width: 150,
+    maxWidth: 150,
+    setter: updateDraftLine,
+    backgroundColor: alpha(theme.palette.background.menu, 0.4),
+  },
+];
+
 export const QuantityTableComponent: FC<TableProps> = ({
   lines,
   updateDraftLine,
 }) => {
+  const theme = useTheme();
   const columns = useColumns<DraftInboundLine>(
     [
+      getBatchColumn(updateDraftLine, theme),
+      getExpiryColumn(updateDraftLine, theme),
       [
         'numberOfPacks',
         {
@@ -54,8 +90,11 @@ export const PricingTableComponent: FC<TableProps> = ({
   lines,
   updateDraftLine,
 }) => {
+  const theme = useTheme();
   const columns = useColumns<DraftInboundLine>(
     [
+      getBatchColumn(updateDraftLine, theme),
+      getExpiryColumn(updateDraftLine, theme),
       [
         'sellPricePerPack',
         { Cell: CurrencyInputCell, width: 100, setter: updateDraftLine },
@@ -96,8 +135,13 @@ export const LocationTableComponent: FC<TableProps> = ({
   lines,
   updateDraftLine,
 }) => {
-  const columns = useColumns(
-    [[getLocationInputColumn(), { setter: updateDraftLine }]],
+  const theme = useTheme();
+  const columns = useColumns<DraftInboundLine>(
+    [
+      getBatchColumn(updateDraftLine, theme),
+      getExpiryColumn(updateDraftLine, theme),
+      [getLocationInputColumn(), { setter: updateDraftLine }],
+    ],
     {},
     [updateDraftLine]
   );


### PR DESCRIPTION
Fixes #734 

Removed the batch and expiry table and moved those columns into each of the other tables.
To support that -
- added a `maxWidth` prop
- added a `backgroundColor` prop : went with the specific use case, rather than a more helpful implementation of `style`. when we need that, we can add it in and remove the background colour
- adjusted the row padding: as the fixed height, combined with the really big padding meant that the background overlayed and looked too dark in between the rows. As it is, I've used slightly more padding than necessary to hide the expando row