### PR TITLE
#773 auth storage

### DIFF
--- a/packages/common/src/hooks/useHostContext.ts
+++ b/packages/common/src/hooks/useHostContext.ts
@@ -46,8 +46,8 @@ export const useHostContext = create<HostContext>(set => ({
   detailPanelRef: null,
 
   setStore: store => set(state => ({ ...state, store })),
-  store: { id: '4321dcba', code: 'Central Warehouse' },
+  store: { id: '', code: '' },
 
   setUser: user => set(state => ({ ...state, user })),
-  user: { id: 'abcd1234', name: 'Administrator' },
+  user: { id: '', name: '' },
 }));

--- a/packages/common/src/localStorage/keys.ts
+++ b/packages/common/src/localStorage/keys.ts
@@ -19,6 +19,7 @@ export type LocalStorageRecord = {
   '/theme/custom': ThemeOptions;
   '/theme/logo': string;
   '/authentication/previous': AuthenticationCredentials;
+  '/authentication/token': string;
 };
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/packages/common/src/localStorage/keys.ts
+++ b/packages/common/src/localStorage/keys.ts
@@ -18,7 +18,7 @@ export type LocalStorageRecord = {
   '/groupbyitem': GroupByItem;
   '/theme/custom': ThemeOptions;
   '/theme/logo': string;
-  '/authentication/previous': AuthenticationCredentials;
+  '/mru/credentials': AuthenticationCredentials;
   '/authentication/token': string;
 };
 

--- a/packages/common/src/localStorage/keys.ts
+++ b/packages/common/src/localStorage/keys.ts
@@ -1,10 +1,16 @@
 import { SupportedLocales } from '@common/intl';
+import { Store } from '@common/types';
 import { ThemeOptions } from '@mui/material';
 
 export type GroupByItem = {
   outboundShipment?: boolean;
   inboundShipment?: boolean;
 };
+type AuthenticationCredentials = {
+  store?: Store;
+  username: string;
+};
+
 export type LocalStorageRecord = {
   '/appdrawer/open': boolean;
   '/detailpanel/open': boolean;
@@ -12,6 +18,7 @@ export type LocalStorageRecord = {
   '/groupbyitem': GroupByItem;
   '/theme/custom': ThemeOptions;
   '/theme/logo': string;
+  '/authentication/previous': AuthenticationCredentials;
 };
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -53,6 +53,7 @@ export interface AppNavLinkProps {
   expandOnHover?: boolean;
   text?: string;
   to: string;
+  onClick?: () => void;
 }
 
 export const AppNavLink: FC<AppNavLinkProps> = props => {
@@ -62,6 +63,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
     expandOnHover,
     text,
     to,
+    onClick,
   } = props;
   const drawer = useDrawer();
 
@@ -89,7 +91,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
             role="link"
             aria-label={text}
             title={text}
-            onClick={debouncedClearHoverActive}
+            onClick={onClick || debouncedClearHoverActive}
           />
         )
       ),

--- a/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
+++ b/packages/common/src/ui/layout/tables/columns/PaginationRow/PaginationRow.tsx
@@ -77,6 +77,11 @@ export const PaginationRow: FC<PaginationRowProps> = ({
             page={displayPage}
             onChange={onChangePage}
             count={Math.ceil(total / first)}
+            sx={{
+              '& .MuiPaginationItem-root': {
+                fontSize: theme => theme.typography.body1.fontSize,
+              },
+            }}
           />
         </>
       )}

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -77,6 +77,7 @@ export const DataRow = <T extends DomainObject>({
                   color: 'inherit',
                   fontSize: dense ? '12px' : '14px',
                   backgroundColor: column.backgroundColor,
+                  fontWeight: 'normal',
                 }}
               >
                 <column.Cell

--- a/packages/host/src/Site.tsx
+++ b/packages/host/src/Site.tsx
@@ -23,6 +23,7 @@ import {
   ReplenishmentRouter,
   InventoryRouter,
 } from './routers';
+import { RequireAuthentication } from './components/Navigation/RequireAuthentication';
 
 const Heading: FC = ({ children }) => (
   <div style={{ margin: 50 }}>
@@ -31,85 +32,89 @@ const Heading: FC = ({ children }) => (
 );
 
 export const Site: FC = () => (
-  <CommandK>
-    <SnackbarProvider maxSnack={3}>
-      <AppDrawer />
-      <Box flex={1} display="flex" flexDirection="column" overflow="hidden">
-        <AppBar />
-        <Box display="flex" flex={1} overflow="auto">
-          <Routes>
-            <Route
-              path={RouteBuilder.create(AppRoute.Dashboard)
-                .addWildCard()
-                .build()}
-              element={<DashboardRouter />}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Catalogue)
-                .addWildCard()
-                .build()}
-              element={<CatalogueRouter />}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Distribution)
-                .addWildCard()
-                .build()}
-              element={<DistributionRouter />}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Replenishment)
-                .addWildCard()
-                .build()}
-              element={<ReplenishmentRouter />}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Suppliers)
-                .addWildCard()
-                .build()}
-              element={<Heading>suppliers</Heading>}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Inventory)
-                .addWildCard()
-                .build()}
-              element={<InventoryRouter />}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Tools).addWildCard().build()}
-              element={<Heading>tools</Heading>}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Reports).addWildCard().build()}
-              element={<Heading>reports</Heading>}
-            />
-            <Route
-              path={RouteBuilder.create(AppRoute.Messages)
-                .addWildCard()
-                .build()}
-              element={<Heading>messages</Heading>}
-            />
+  <RequireAuthentication>
+    <CommandK>
+      <SnackbarProvider maxSnack={3}>
+        <AppDrawer />
+        <Box flex={1} display="flex" flexDirection="column" overflow="hidden">
+          <AppBar />
+          <Box display="flex" flex={1} overflow="auto">
+            <Routes>
+              <Route
+                path={RouteBuilder.create(AppRoute.Dashboard)
+                  .addWildCard()
+                  .build()}
+                element={<DashboardRouter />}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Catalogue)
+                  .addWildCard()
+                  .build()}
+                element={<CatalogueRouter />}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Distribution)
+                  .addWildCard()
+                  .build()}
+                element={<DistributionRouter />}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Replenishment)
+                  .addWildCard()
+                  .build()}
+                element={<ReplenishmentRouter />}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Suppliers)
+                  .addWildCard()
+                  .build()}
+                element={<Heading>suppliers</Heading>}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Inventory)
+                  .addWildCard()
+                  .build()}
+                element={<InventoryRouter />}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Tools).addWildCard().build()}
+                element={<Heading>tools</Heading>}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Reports)
+                  .addWildCard()
+                  .build()}
+                element={<Heading>reports</Heading>}
+              />
+              <Route
+                path={RouteBuilder.create(AppRoute.Messages)
+                  .addWildCard()
+                  .build()}
+                element={<Heading>messages</Heading>}
+              />
 
-            <Route
-              path={RouteBuilder.create(AppRoute.Admin).addWildCard().build()}
-              element={<Settings />}
-            />
+              <Route
+                path={RouteBuilder.create(AppRoute.Admin).addWildCard().build()}
+                element={<Settings />}
+              />
 
-            <Route
-              path="/"
-              element={
-                <Navigate
-                  replace
-                  to={RouteBuilder.create(AppRoute.Dashboard).build()}
-                />
-              }
-            />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+              <Route
+                path="/"
+                element={
+                  <Navigate
+                    replace
+                    to={RouteBuilder.create(AppRoute.Dashboard).build()}
+                  />
+                }
+              />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Box>
+          <AppFooter />
+          <AppFooterPortal SessionDetails={<Footer />} />
         </Box>
-        <AppFooter />
-        <AppFooterPortal SessionDetails={<Footer />} />
-      </Box>
-      <DetailPanel />
-    </SnackbarProvider>
-  </CommandK>
+        <DetailPanel />
+      </SnackbarProvider>
+    </CommandK>
+  </RequireAuthentication>
 );

--- a/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -18,6 +18,7 @@ import {
   useTranslation,
   AppNavLink,
   useIsMediumScreen,
+  useLocalStorage,
 } from '@openmsupply-client/common';
 import { AppRoute, ExternalURL } from '@openmsupply-client/config';
 import {
@@ -147,8 +148,10 @@ const StyledDrawer = styled(Box, {
 export const AppDrawer: React.FC = () => {
   const t = useTranslation('app');
   const isMediumScreen = useIsMediumScreen();
-
   const drawer = useDrawer();
+  const [, setAuthToken] = useLocalStorage('/authentication/token');
+
+  const onLogout = () => setAuthToken('');
 
   React.useEffect(() => {
     if (drawer.hasUserSet) return;
@@ -229,6 +232,7 @@ export const AppDrawer: React.FC = () => {
             to={AppRoute.Login}
             icon={<PowerIcon fontSize="small" color="primary" />}
             text={t('logout')}
+            onClick={onLogout}
           />
         </List>
       </LowerListContainer>

--- a/packages/host/src/components/Footer/Footer.tsx
+++ b/packages/host/src/components/Footer/Footer.tsx
@@ -20,14 +20,18 @@ export const Footer: React.FC = () => {
 
   return (
     <Box gap={2} display="flex" flex={1} alignItems="center">
-      <PaddedCell>
-        <HomeIcon sx={iconStyles} />
-        <Typography sx={textStyles}>{store.code}</Typography>
-      </PaddedCell>
-      <PaddedCell>
-        <UserIcon sx={iconStyles} />
-        <Typography sx={textStyles}>{user.name}</Typography>
-      </PaddedCell>
+      {store.code && (
+        <PaddedCell>
+          <HomeIcon sx={iconStyles} />
+          <Typography sx={textStyles}>{store.code}</Typography>
+        </PaddedCell>
+      )}
+      {user.name && (
+        <PaddedCell>
+          <UserIcon sx={iconStyles} />
+          <Typography sx={textStyles}>{user.name}</Typography>
+        </PaddedCell>
+      )}
     </Box>
   );
 };

--- a/packages/host/src/components/Login/hooks.ts
+++ b/packages/host/src/components/Login/hooks.ts
@@ -1,0 +1,85 @@
+import React from 'react';
+import create from 'zustand';
+
+import { AppRoute } from '@openmsupply-client/config';
+import {
+  Store,
+  useHostContext,
+  useLocalStorage,
+  useNavigate,
+} from '@openmsupply-client/common';
+import { useAuthToken } from './api';
+
+interface LoginForm {
+  isLoggingIn: boolean;
+  password: string;
+  store?: Store;
+  username: string;
+  setIsLoggingIn: (isLoggingIn: boolean) => void;
+  setPassword: (password: string) => void;
+  setStore: (store?: Store) => void;
+  setUsername: (username: string) => void;
+}
+export const useLoginFormState = create<LoginForm>(set => ({
+  isLoggingIn: false,
+  password: '',
+  store: undefined,
+  username: '',
+  setIsLoggingIn: (isLoggingIn: boolean) =>
+    set(state => ({ ...state, isLoggingIn })),
+  setPassword: (password: string) => set(state => ({ ...state, password })),
+  setStore: (store?: Store) => set(state => ({ ...state, store })),
+  setUsername: (username: string) => set(state => ({ ...state, username })),
+}));
+
+export const useLoginForm = (
+  passwordRef: React.RefObject<HTMLInputElement>
+) => {
+  const state = useLoginFormState();
+  const navigate = useNavigate();
+  const { setStore: setHostStore, setUser } = useHostContext();
+  const [previousAuth, setPreviousAuth] = useLocalStorage(
+    '/authentication/previous'
+  );
+  const {
+    isLoggingIn,
+    password,
+    setIsLoggingIn,
+    setPassword,
+    setStore,
+    setUsername,
+    store,
+    username,
+  } = state;
+  const { data: authenticationResponse, isLoading: isAuthenticating } =
+    useAuthToken({ username, password }, isLoggingIn);
+
+  const onLogin = () => {
+    setIsLoggingIn(true);
+  };
+
+  const isValid = !!username && !!password && !!store?.id;
+
+  React.useEffect(() => {
+    if (previousAuth?.store && !store) {
+      setStore(previousAuth.store);
+    }
+    if (previousAuth?.username && !username) {
+      setUsername(previousAuth.username);
+      setTimeout(() => passwordRef.current?.focus(), 100);
+    }
+  }, [previousAuth]);
+
+  React.useEffect(() => {
+    setIsLoggingIn(isAuthenticating);
+    if (authenticationResponse?.token) {
+      setPassword('');
+      setPreviousAuth({ username: username, store: store });
+      setUser({ id: '', name: username });
+      if (store) setHostStore(store);
+      navigate(`/${AppRoute.Dashboard}`);
+    }
+  }, [authenticationResponse, isAuthenticating]);
+
+  return { authenticationResponse, isValid, onLogin, ...state };
+};

--- a/packages/host/src/components/Login/hooks.ts
+++ b/packages/host/src/components/Login/hooks.ts
@@ -40,9 +40,8 @@ export const useLoginForm = (
   const navigate = useNavigate();
   const location = useLocation();
   const { setStore: setHostStore, setUser } = useHostContext();
-  const [previousAuth, setPreviousAuth] = useLocalStorage(
-    '/authentication/previous'
-  );
+  const [mostRecentlyUsedCredentials, setMRUCredentials] =
+    useLocalStorage('/mru/credentials');
   const [, setAuthToken] = useLocalStorage('/authentication/token');
   const {
     isLoggingIn,
@@ -65,7 +64,7 @@ export const useLoginForm = (
   const onAuthenticated = (token: string) => {
     setPassword('');
     setAuthToken(token);
-    setPreviousAuth({ username: username, store: store });
+    setMRUCredentials({ username: username, store: store });
     setUser({ id: '', name: username });
     if (store) setHostStore(store);
     // navigate back, if redirected by the <RequireAuthentication /> component
@@ -75,14 +74,14 @@ export const useLoginForm = (
   };
 
   React.useEffect(() => {
-    if (previousAuth?.store && !store) {
-      setStore(previousAuth.store);
+    if (mostRecentlyUsedCredentials?.store && !store) {
+      setStore(mostRecentlyUsedCredentials.store);
     }
-    if (previousAuth?.username && !username) {
-      setUsername(previousAuth.username);
+    if (mostRecentlyUsedCredentials?.username && !username) {
+      setUsername(mostRecentlyUsedCredentials.username);
       setTimeout(() => passwordRef.current?.focus(), 100);
     }
-  }, [previousAuth]);
+  }, [mostRecentlyUsedCredentials]);
 
   React.useEffect(() => {
     setIsLoggingIn(isAuthenticating);

--- a/packages/host/src/components/Navigation/RequireAuthentication.tsx
+++ b/packages/host/src/components/Navigation/RequireAuthentication.tsx
@@ -1,0 +1,21 @@
+import {
+  Navigate,
+  useLocalStorage,
+  useLocation,
+} from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
+import React from 'react';
+
+export const RequireAuthentication = ({ children }) => {
+  const [authToken] = useLocalStorage('/authentication/token');
+  const location = useLocation();
+  const isProduction = process.env['NODE_ENV'] === 'production';
+
+  if (!authToken && isProduction) {
+    return (
+      <Navigate to={`/${AppRoute.Login}`} state={{ from: location }} replace />
+    );
+  }
+
+  return children;
+};

--- a/packages/mock-server/src/api/resolvers/index.ts
+++ b/packages/mock-server/src/api/resolvers/index.ts
@@ -9,6 +9,7 @@ import { invoiceLineResolver } from './invoiceLine';
 import { statisticsResolver } from './statistics';
 import { StocktakeResolver } from './stocktake';
 import { locationResolver } from './location';
+import { storeResolver } from './store';
 
 export const ResolverService = {
   invoice: invoiceResolver,
@@ -22,4 +23,5 @@ export const ResolverService = {
   stocktake: StocktakeResolver,
   stocktakeLine: StocktakeLineResolver,
   location: locationResolver,
+  store: storeResolver,
 };

--- a/packages/mock-server/src/api/resolvers/store.ts
+++ b/packages/mock-server/src/api/resolvers/store.ts
@@ -1,0 +1,19 @@
+import { db } from './../../data/database';
+import { ListResponse, ResolvedStore } from './../../data/types';
+import { createListResponse } from './utils';
+
+export const storeResolver = {
+  list: (): ListResponse<ResolvedStore, 'StoreConnector'> => {
+    const stores = db.get.all.store();
+    const resolvedStores = stores.map(store => storeResolver.byId(store.id));
+
+    return createListResponse(
+      resolvedStores.length,
+      resolvedStores,
+      'StoreConnector'
+    );
+  },
+  byId: (id: string): ResolvedStore => {
+    return { __typename: 'StoreNode', ...db.get.byId.store(id) };
+  },
+};

--- a/packages/mock-server/src/data/data.ts
+++ b/packages/mock-server/src/data/data.ts
@@ -12,6 +12,7 @@ import {
   Stocktake,
   StocktakeLine,
   Location,
+  Store,
 } from './types';
 import {
   randomName,
@@ -760,10 +761,20 @@ const createStocktakeLines = (): StocktakeLine[] => {
     .flat();
 };
 
+export const createStores = (
+  numberToCreate = randomInteger({ min: 10, max: 100 })
+): Store[] =>
+  Array.from({ length: numberToCreate }).map(() => ({
+    id: `${faker.datatype.uuid()}`,
+    code: faker.company.companyName(),
+    nameId: '',
+  }));
+
 export const removeElement = (source: any[], idx: number): void => {
   source = source.splice(idx, 1);
 };
 
+export let StoreData = createStores();
 export let NameData = [...createCustomers(), ...createSuppliers()];
 export let ItemData = createItems();
 export let InvoiceData = createInvoices(NameData);

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -45,6 +45,7 @@ import {
   Stocktake,
   StocktakeLine,
   Location,
+  Store,
 } from './types';
 import {
   LocationData,
@@ -60,6 +61,7 @@ import {
   StocktakeData,
   StocktakeLineData,
   createStocktakeLine,
+  StoreData,
 } from './data';
 
 import {
@@ -472,6 +474,10 @@ export const get = {
       ({
         ...NameData.find(getFilter(id, 'id')),
       } as Name),
+    store: (id: string): Store =>
+      ({
+        ...StoreData.find(getFilter(id, 'id')),
+      } as Store),
   },
 
   all: {
@@ -480,6 +486,7 @@ export const get = {
     invoice: (): Invoice[] => InvoiceData.slice(),
     invoiceLine: (): InvoiceLine[] => InvoiceLineData.slice(),
     name: (): Name[] => NameData.slice(),
+    store: (): Store[] => StoreData.slice(),
   },
 
   stockLines: {

--- a/packages/mock-server/src/data/types.ts
+++ b/packages/mock-server/src/data/types.ts
@@ -2,6 +2,7 @@ import {
   StockLineConnector,
   InvoiceSortInput,
   InvoiceFilterInput,
+  StoreNode,
 } from '@openmsupply-client/common/src/types/schema';
 import {
   InvoiceLineNode,
@@ -27,10 +28,13 @@ import {
 
 export { ItemSortFieldInput, RequisitionListParameters, ItemsResponse };
 
-export interface Store {
+export interface Store extends Omit<StoreNode, '__typename'> {
   id: string;
   code: string;
   nameId: string;
+}
+export interface ResolvedStore extends Store {
+  __typename: 'StoreNode';
 }
 
 export type Location = Omit<LocationNode, 'stock'>;

--- a/packages/mock-server/src/worker/handlers/authentication/index.ts
+++ b/packages/mock-server/src/worker/handlers/authentication/index.ts
@@ -1,0 +1,25 @@
+import { mockAuthTokenQuery } from '@openmsupply-client/common/src/types/schema';
+
+const mockAuthToken = mockAuthTokenQuery((req, res, ctx) => {
+  const isValid = req.variables.password.startsWith('pass');
+
+  return isValid
+    ? res(
+        ctx.data({
+          authToken: { __typename: 'AuthToken', token: 'token-token-token' },
+        })
+      )
+    : res(
+        ctx.data({
+          authToken: {
+            __typename: 'AuthTokenError',
+            error: {
+              __typename: 'InvalidCredentials',
+              description: 'Guess again!',
+            },
+          },
+        })
+      );
+});
+
+export const AuthHandlers = [mockAuthToken];

--- a/packages/mock-server/src/worker/handlers/index.ts
+++ b/packages/mock-server/src/worker/handlers/index.ts
@@ -5,6 +5,8 @@ import { ItemHandlers } from './item';
 import { StocktakeHandlers } from './stocktake';
 import { ExperimentalHandlers } from './experimental';
 import { LocationHandlers } from './location';
+import { StoreHandlers } from './store';
+import { AuthHandlers } from './authentication';
 
 // Checking for not equal to production instead of
 // checking for development, as jest sets this to
@@ -24,6 +26,8 @@ const supported = [
   ...NameHandlers,
   ...ItemHandlers,
   ...LocationHandlers,
+  ...StoreHandlers,
+  ...AuthHandlers,
 ];
 
 const DevHandlers = [...unsupported, ...supported];

--- a/packages/mock-server/src/worker/handlers/store/index.ts
+++ b/packages/mock-server/src/worker/handlers/store/index.ts
@@ -1,0 +1,10 @@
+import { mockStoresQuery } from '@openmsupply-client/common/src/types/schema';
+import { ResolverService } from '../../../api/resolvers';
+
+const mockStoresList = mockStoresQuery((_, res, ctx) => {
+  const result = ResolverService.store.list();
+
+  return res(ctx.data({ stores: result }));
+});
+
+export const StoreHandlers = [mockStoresList];


### PR DESCRIPTION
Fixes #773 

Adds the mock queries - not certain it is helpful, but it's fun to do.
The login allows a password starting with `pass` and rejects otherwise

Added the requirement for authentication too, only enforced in production though.. don't want to be annoying the devs.
Will probably need to timeout the session, and will need to add the token and store id to queries.. can do that later I think.