### PR TITLE
#733 modal perf issues

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,7 +34,7 @@
     "react-currency-input-field": "^3.6.0",
     "react-hook-form": "^7.22.0",
     "react-i18next": "^11.15.1",
-    "react-query": "^3.34.7",
+    "react-query": "^3.34.12",
     "react-router-dom": "^6.1.1",
     "react-table": "^7.7.0",
     "stylis": "^4.0.13",

--- a/packages/common/src/api/OmSupplyApiContext.tsx
+++ b/packages/common/src/api/OmSupplyApiContext.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useCallback } from 'react';
+import React, { FC, useMemo, useEffect, useState, useCallback } from 'react';
 import { createContext } from 'react';
 import { GraphQLClient } from 'graphql-request';
 import { getSdk } from '../types';
@@ -59,9 +59,17 @@ export const OmSupplyApiProvider: FC<ApiProviderProps> = ({
     setApi(createOmSupplyApi(url));
   }, [url]);
 
-  return (
-    <Provider value={{ api, client, setUrl, setHeader }}>{children}</Provider>
+  const val = useMemo(
+    () => ({
+      api,
+      client,
+      setUrl,
+      setHeader,
+    }),
+    [api, client, setUrl, setHeader]
   );
+
+  return <Provider value={val}>{children}</Provider>;
 };
 
 export const OmSupplyApiConsumer = Consumer;

--- a/packages/common/src/hooks/usePagination/usePagination.ts
+++ b/packages/common/src/hooks/usePagination/usePagination.ts
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { useSearchParameters } from '../useSearchParameters';
+
 export interface Pagination {
   page: number;
   offset: number;
@@ -17,32 +17,16 @@ export interface PaginationState extends PaginationController {
 }
 
 export const usePagination = (initialFirst = 20): PaginationState => {
-  const searchParams = useSearchParameters();
-  const getPageFromSearchParams = () =>
-    Math.max(0, searchParams.getNumber('page') - 1);
   const [first, onChangeFirst] = useState(initialFirst);
   const [offset, onChangeOffset] = useState(0);
-  const [page, onChangePage] = useState(getPageFromSearchParams());
+  const [page, onChangePage] = useState(0);
 
   const pageRef = useRef(page);
 
   useEffect(() => {
     onChangeOffset(page * first);
     pageRef.current = page;
-    searchParams.set({ page: String(page + 1) });
   }, [first, page]);
-
-  useEffect(() => {
-    const newPage = getPageFromSearchParams();
-    onChangeOffset(newPage * first);
-    pageRef.current = newPage;
-  }, [location]);
-
-  useEffect(() => {
-    if (!searchParams.getNumber('page')) {
-      searchParams.set({ page: String(page + 1) });
-    }
-  }, []);
 
   const nextPage = () => {
     onChangePage(pageRef.current + 1);

--- a/packages/common/src/hooks/useSortBy/useSortBy.ts
+++ b/packages/common/src/hooks/useSortBy/useSortBy.ts
@@ -1,5 +1,4 @@
-import { useCallback, useState, useEffect } from 'react';
-import { useSearchParameters } from '../useSearchParameters';
+import { useCallback, useState } from 'react';
 import { Column } from '../../ui/layout/tables';
 import { DomainObject } from '../../types';
 export interface SortRule<T> {
@@ -27,11 +26,9 @@ export const useSortBy = <T extends DomainObject>({
   key: initialSortKey,
   isDesc: initialIsDesc = false,
 }: SortRule<T>): SortState<T> => {
-  const searchParams = useSearchParameters();
-  const descParam = searchParams.get('desc');
   const [sortBy, setSortBy] = useState<SortBy<T>>({
-    key: searchParams.get('sort') ?? initialSortKey,
-    isDesc: descParam ? descParam === 'true' : initialIsDesc,
+    key: initialSortKey,
+    isDesc: initialIsDesc ?? false,
     direction: getDirection(initialIsDesc),
   });
 
@@ -54,22 +51,6 @@ export const useSortBy = <T extends DomainObject>({
 
     return { ...newSortBy, direction: getDirection(!!newSortBy?.isDesc) };
   }, []);
-
-  useEffect(() => {
-    searchParams.set({
-      sort: String(sortBy.key),
-      desc: String(!!sortBy.isDesc),
-    });
-  }, [sortBy]);
-
-  useEffect(() => {
-    if (!searchParams.get('sort')) {
-      searchParams.set({
-        sort: String(initialSortKey),
-        desc: String(!!initialIsDesc),
-      });
-    }
-  }, [initialSortKey, initialIsDesc]);
 
   return { sortBy, onChangeSortBy, sort: { sortBy, onChangeSortBy } };
 };

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -19,7 +19,7 @@ import { DomainObject } from '@common/types';
 import { useTranslation } from '@common/intl';
 import { useTableStore } from './context';
 
-export const DataTable = <T extends DomainObject>({
+export const DataTableComponent = <T extends DomainObject>({
   columns,
   data = [],
   isLoading = false,
@@ -139,3 +139,12 @@ export const DataTable = <T extends DomainObject>({
     </TableContainer>
   );
 };
+
+// This is a hack!
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37087
+// Using generic types while using `react.memo` doesn't work well.
+// There are a few alternatives for some situations. However they didn't
+// work for this one!
+export const DataTable = React.memo(
+  DataTableComponent
+) as typeof DataTableComponent;

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -104,9 +104,7 @@ export const DataRow = <T extends DomainObject>({
             }}
             in={isExpanded}
           >
-            {ExpandContent && isExpanded ? (
-              <ExpandContent rowData={rowData} />
-            ) : null}
+            {ExpandContent ? <ExpandContent rowData={rowData} /> : null}
           </Collapse>
         </td>
       </tr>

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -104,7 +104,9 @@ export const DataRow = <T extends DomainObject>({
             }}
             in={isExpanded}
           >
-            {ExpandContent ? <ExpandContent rowData={rowData} /> : null}
+            {ExpandContent && isExpanded ? (
+              <ExpandContent rowData={rowData} />
+            ) : null}
           </Collapse>
         </td>
       </tr>

--- a/packages/common/src/ui/layout/tables/context/TableContext.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.ts
@@ -268,7 +268,10 @@ interface IsGroupedControl {
 }
 
 export const useIsGrouped = (key: keyof GroupByItem): IsGroupedControl => {
-  const { setIsGrouped } = useTableStore();
+  const selector = useCallback(({ setIsGrouped }: TableStore) => {
+    return { setIsGrouped };
+  }, []);
+  const { setIsGrouped } = useTableStore(selector);
   const [groupByItem, setGroupByItem] = useLocalStorage('/groupbyitem', {
     outboundShipment: false,
     inboundShipment: false,

--- a/packages/common/src/utils/formatters.ts
+++ b/packages/common/src/utils/formatters.ts
@@ -14,6 +14,14 @@ export const formatExpiryDate = (date?: Date | null): string | null => {
   else return null;
 };
 
+// Date needs to be in the format yyyy-MM-dd
+export const formatExpiryDateString = (
+  date?: string | null | undefined
+): string => {
+  const expiryDate = date ? formatExpiryDate(new Date(date)) : null;
+  return expiryDate ?? '';
+};
+
 export class RouteBuilder {
   parts: string[];
 

--- a/packages/invoices/src/InboundShipment/DetailView/api.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/api.ts
@@ -188,17 +188,12 @@ export const getInboundShipmentDetailViewApi = (
       const stockLine = line.stockLine
         ? stockLineGuard(line.stockLine)
         : undefined;
-
-      const expiryDate = line.expiryDate
-        ? new Date(line.expiryDate)
-        : undefined;
       const location = line.location ? locationGuard(line.location) : undefined;
 
       return {
         ...line,
         stockLine,
         location,
-        expiryDate,
         stockLineId: stockLine?.id ?? '',
         invoiceId: invoice.id,
       };

--- a/packages/invoices/src/InboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/columns.ts
@@ -87,9 +87,17 @@ export const useInboundShipmentColumns = (): Column<
                 'expiryDate',
                 null
               );
-              return formatExpiryDate(expiryDate);
+              const formatted =
+                expiryDate == null
+                  ? ''
+                  : formatExpiryDate(new Date(expiryDate));
+              return formatted;
             } else {
-              return formatExpiryDate(rowData.expiryDate);
+              const formatted =
+                rowData.expiryDate == null
+                  ? ''
+                  : formatExpiryDate(new Date(rowData.expiryDate));
+              return formatted;
             }
           },
         },

--- a/packages/invoices/src/InboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/columns.ts
@@ -1,5 +1,5 @@
 import {
-  formatExpiryDate,
+  formatExpiryDateString,
   getRowExpandColumn,
   GenericColumnKey,
   getSumOfKeyReducer,
@@ -87,17 +87,10 @@ export const useInboundShipmentColumns = (): Column<
                 'expiryDate',
                 null
               );
-              const formatted =
-                expiryDate == null
-                  ? ''
-                  : formatExpiryDate(new Date(expiryDate));
-              return formatted;
+
+              return formatExpiryDateString(expiryDate);
             } else {
-              const formatted =
-                rowData.expiryDate == null
-                  ? ''
-                  : formatExpiryDate(new Date(rowData.expiryDate));
-              return formatted;
+              return formatExpiryDateString(rowData.expiryDate);
             }
           },
         },

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import {
   TableProvider,
   createTableStore,
@@ -20,9 +20,12 @@ export const DetailView: FC = () => {
   const { entity, mode, onOpen, onClose, isOpen } = useEditModal<Item>();
   const { data } = useOutbound();
 
-  const onRowClick = (item: InvoiceLine | InvoiceItem) => {
-    onOpen(toItem(item));
-  };
+  const onRowClick = useCallback(
+    (item: InvoiceLine | InvoiceItem) => {
+      onOpen(toItem(item));
+    },
+    [toItem, onOpen]
+  );
 
   return (
     <React.Suspense
@@ -31,7 +34,6 @@ export const DetailView: FC = () => {
       {data && data.id ? (
         <TableProvider createStore={createTableStore}>
           <AppBarButtons onAddItem={() => onOpen()} />
-
           {isOpen && (
             <OutboundLineEdit
               item={entity}

--- a/packages/invoices/src/OutboundShipment/DetailView/api.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/api.ts
@@ -102,14 +102,12 @@ export const onRead =
         ? stockLineGuard(line.stockLine)
         : undefined;
       const location = line.location ? locationGuard(line.location) : undefined;
-      const expiryDate = line.expiryDate ? new Date(line.expiryDate) : null;
       const item = line.item ? itemGuard(line.item) : undefined;
 
       return {
         ...line,
         stockLine,
         location,
-        expiryDate,
         stockLineId: stockLine?.id ?? '',
         invoiceId: invoice.id,
         unitName: item?.unitName ?? '',

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -1,4 +1,5 @@
 import {
+  formatExpiryDateString,
   useColumns,
   getRowExpandColumn,
   getNotePopoverColumn,
@@ -7,7 +8,6 @@ import {
   GenericColumnKey,
   SortBy,
   Column,
-  formatExpiryDate,
   ifTheSameElseDefault,
 } from '@openmsupply-client/common';
 import { InvoiceLine, InvoiceItem } from '../../types';
@@ -120,15 +120,9 @@ export const useOutboundColumns = ({
               const { lines } = row;
               const expiryDate =
                 ifTheSameElseDefault(lines, 'expiryDate', null) ?? '';
-              return (
-                (expiryDate && formatExpiryDate(new Date(expiryDate))) || ''
-              );
+              return formatExpiryDateString(expiryDate);
             } else {
-              return (
-                formatExpiryDate(
-                  row.expiryDate == null ? null : new Date(row.expiryDate)
-                ) ?? ''
-              );
+              return formatExpiryDateString(row.expiryDate);
             }
           },
           accessor: ({ rowData }) => {
@@ -139,9 +133,9 @@ export const useOutboundColumns = ({
                 'expiryDate',
                 null
               );
-              return expiryDate;
+              return formatExpiryDateString(expiryDate);
             } else {
-              return rowData.expiryDate;
+              return formatExpiryDateString(rowData.expiryDate);
             }
           },
         },

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -120,9 +120,15 @@ export const useOutboundColumns = ({
               const { lines } = row;
               const expiryDate =
                 ifTheSameElseDefault(lines, 'expiryDate', null) ?? '';
-              return (expiryDate && formatExpiryDate(expiryDate)) || '';
+              return (
+                (expiryDate && formatExpiryDate(new Date(expiryDate))) || ''
+              );
             } else {
-              return formatExpiryDate(row.expiryDate) ?? '';
+              return (
+                formatExpiryDate(
+                  row.expiryDate == null ? null : new Date(row.expiryDate)
+                ) ?? ''
+              );
             }
           },
           accessor: ({ rowData }) => {

--- a/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/packages/invoices/src/OutboundShipment/api/api.ts
@@ -153,14 +153,12 @@ export const OutboundApi = {
           const location = line.location
             ? locationGuard(line.location)
             : undefined;
-          const expiryDate = line.expiryDate ? new Date(line.expiryDate) : null;
           const item = line.item ? itemGuard(line.item) : undefined;
 
           return {
             ...line,
             stockLine,
             location,
-            expiryDate,
             stockLineId: stockLine?.id ?? '',
             invoiceId: invoice.id,
             unitName: item?.unitName ?? '',

--- a/packages/invoices/src/types.ts
+++ b/packages/invoices/src/types.ts
@@ -21,14 +21,13 @@ import { Location } from '@openmsupply-client/system';
  */
 
 export interface InvoiceLine
-  extends Omit<InvoiceLineNode, 'item' | 'type' | 'location' | 'expiryDate'>,
+  extends Omit<InvoiceLineNode, 'item' | 'type' | 'location'>,
     DomainObject {
   stockLine?: StockLine;
   stockLineId: string;
   unitName?: string;
   invoiceId: string;
   location?: Location;
-  expiryDate?: Date | null;
 }
 
 export interface InvoiceRow

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -571,7 +571,7 @@ export const update = {
     if (idx < 0) throw new Error('Invalid invoice line id');
 
     const expiryDate = invoiceLine?.expiryDate
-      ? parse(invoiceLine.expiryDate, 'dd-MM-yyyy', new Date()).toISOString()
+      ? parse(invoiceLine.expiryDate, 'yyyy-MM-dd', new Date()).toISOString()
       : '';
 
     const newLine = {
@@ -608,7 +608,7 @@ export const insert = {
       itemUnit: item.unitName ?? '',
       itemId: item.id,
       expiryDate: invoiceLine?.expiryDate
-        ? parse(invoiceLine.expiryDate, 'dd-MM-yyyy', new Date()).toISOString()
+        ? parse(invoiceLine.expiryDate, 'yyyy-MM-dd', new Date()).toISOString()
         : '',
       type: InvoiceLineNodeType.StockIn,
       batch: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13800,10 +13800,10 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-query@^3.34.7:
-  version "3.34.7"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.7.tgz#e3d71318f510ea354794cd188b351bb57f577cb9"
-  integrity sha512-Q8+H2DgpoZdGUpwW2Z9WAbSrIE+yOdZiCUokHjlniOOmlcsfqNLgvHF5i7rtuCmlw3hv5OAhtpS7e97/DvgpWw==
+react-query@^3.34.12:
+  version "3.34.12"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.12.tgz#dcaaf7b629f0868aae8afef9fb7692f6ea7643bf"
+  integrity sha512-flDdudQVH4CqE+kNYYYyo4g2Yjek3H/36G3b9bK5oe26jD5gFnx+PPwnq0gayq5z2dcSfr2z4+drvuyeZ3A5QQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"


### PR DESCRIPTION
Fixes #733 

![image](https://user-images.githubusercontent.com/35858975/152891615-dd39082d-47e4-48fb-9a1d-4eeff280b353.png)

- The main thing I concentrated on here was the heavy rendering. There were previously quite a few renders 200ms+. Now the heaviest is 40ms. It feels snappy!
- Memo'd the `DataTable` with a hacky solution (because of generic types)
- Removed the `useSearchParams` usage. Not sure if the right thing to do 😢 
- Made the data row expansions only render when expanded
- more memoising in various key places
- main one: removed the parsing of expiry dates into real dates in the query fn. This was making react-query think the data had changed, so was causing reference instability and re-rendering all of the things