### PR TITLE
Add enabling status changes for outbound shipments

### DIFF
--- a/packages/common/src/ui/components/steppers/VerticalStepper/VerticalStepper.tsx
+++ b/packages/common/src/ui/components/steppers/VerticalStepper/VerticalStepper.tsx
@@ -136,10 +136,10 @@ export const VerticalStepper: FC<StepperProps> = ({ activeStep, steps }) => (
                 justifyContent="space-between"
               >
                 <Typography
+                  color="text.primary"
                   variant="body2"
                   lineHeight={0}
                   fontSize="12px"
-                  fontWeight="bold"
                 >
                   {step.label}
                 </Typography>

--- a/packages/invoices/src/OutboundShipment/DetailView/Footer.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Footer.tsx
@@ -116,8 +116,8 @@ export const Footer: FC = () => {
                   variant="contained"
                   color="secondary"
                   onClick={async () => {
-                    success('Saved invoice! 🥳 ')();
                     await update({ status: getNextOutboundStatus(status) });
+                    success('Saved invoice! 🥳 ')();
                   }}
                 />
               )}

--- a/packages/invoices/src/OutboundShipment/api/hooks.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks.ts
@@ -53,6 +53,7 @@ export const useOutboundFields = <KeyOfInvoice extends keyof Invoice>(
 export const useIsOutboundDisabled = (): boolean => {
   const { status } = useOutboundFields('status');
   return (
+    status === InvoiceNodeStatus.Shipped ||
     status === InvoiceNodeStatus.Verified ||
     status === InvoiceNodeStatus.Delivered
   );

--- a/packages/mock-server/src/api/mutations/invoice.ts
+++ b/packages/mock-server/src/api/mutations/invoice.ts
@@ -49,7 +49,16 @@ export const InvoiceMutation = {
           input.id,
           invoiceNumber,
           otherPartyName,
-          InvoiceNodeType.OutboundShipment
+          InvoiceNodeType.OutboundShipment,
+          {
+            status: InvoiceNodeStatus.New,
+            allocatedDatetime: null,
+            pickedDatetime: null,
+            shippedDatetime: null,
+            deliveredDatetime: null,
+            verifiedDatetime: null,
+            comment: null,
+          }
         )
       );
 
@@ -60,6 +69,7 @@ export const InvoiceMutation = {
         ...invoice,
         ...getStatusTime(invoice.status),
       });
+
       const resolvedInvoice = ResolverService.invoice.byId(updated.id);
 
       return resolvedInvoice;

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -564,11 +564,11 @@ export const update = {
         (invoice?.status as unknown as InvoiceNodeStatus) ??
         existingInvoice.status,
       otherPartyId: invoice?.otherPartyId ?? existingInvoice.otherPartyId,
-      // allocatedDatetime:
-      //   invoice?.allocatedDatetime ?? existingInvoice.allocatedDatetime,
-      // shippedDatetime:
-      //   invoice?.shippedDatetime ?? existingInvoice.shippedDatetime,
-      // pickedDatetime: invoice?.pickedDatetime ?? existingInvoice.pickedDatetime,
+      allocatedDatetime:
+        invoice?.allocatedDatetime ?? existingInvoice.allocatedDatetime,
+      shippedDatetime:
+        invoice?.shippedDatetime ?? existingInvoice.shippedDatetime,
+      pickedDatetime: invoice?.pickedDatetime ?? existingInvoice.pickedDatetime,
     };
     InvoiceData[idx] = newInvoice;
     return newInvoice;


### PR DESCRIPTION
Fixes #777 

- This enables using the mock server to change statuses
- Also disables on the correct status
- Off road fix for the status text on the popover