### PR TITLE
#686 Inbound shipment statuses

### DIFF
--- a/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -7,16 +7,16 @@ import {
   useDetailPanel,
   useTranslation,
 } from '@openmsupply-client/common';
+import { useIsInboundEditable } from './api';
 
 interface AppBarButtonProps {
-  isDisabled: boolean;
   onAddItem: (newState: boolean) => void;
 }
 
 export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
-  isDisabled,
   onAddItem,
 }) => {
+  const isEditable = useIsInboundEditable();
   const { OpenButton } = useDetailPanel();
   const t = useTranslation('common');
 
@@ -24,7 +24,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
     <AppBarButtonsPortal>
       <Grid container gap={1}>
         <ButtonWithIcon
-          disabled={isDisabled}
+          disabled={!isEditable}
           label={t('button.add-item')}
           Icon={<PlusCircleIcon />}
           onClick={() => onAddItem(true)}

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -18,7 +18,6 @@ import { AppBarButtons } from './AppBarButtons';
 import { SidePanel } from './SidePanel';
 import { GeneralTab } from './GeneralTab';
 import { InboundLineEdit } from './modals/InboundLineEdit/InboundLineEdit';
-import { isInboundEditable } from '../../utils';
 import { InvoiceLine, InboundShipmentItem } from '../../types';
 import { AppRoute } from '@openmsupply-client/config';
 
@@ -44,12 +43,9 @@ export const DetailView: FC = () => {
     >
       {draft ? (
         <TableProvider createStore={createTableStore}>
-          <AppBarButtons
-            isDisabled={!isInboundEditable(draft)}
-            onAddItem={() => onOpen()}
-          />
+          <AppBarButtons onAddItem={() => onOpen()} />
 
-          <Toolbar draft={draft} />
+          <Toolbar />
 
           <GeneralTab onRowClick={onRowClick} />
 

--- a/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer.tsx
@@ -15,6 +15,7 @@ import {
   getNextInboundStatusButtonTranslation,
   getStatusTranslator,
   inboundStatuses,
+  getNextInboundStatus,
 } from '../../utils';
 import { Invoice } from '../../types';
 import {
@@ -47,10 +48,10 @@ const createStatusLog = (invoice: Invoice) => {
     statusLog[InvoiceNodeStatus.Shipped] = invoice.shippedDatetime;
   }
   if (statusIdx >= 3) {
-    statusLog[InvoiceNodeStatus.Picked] = invoice.deliveredDatetime;
+    statusLog[InvoiceNodeStatus.Delivered] = invoice.deliveredDatetime;
   }
   if (statusIdx >= 4) {
-    statusLog[InvoiceNodeStatus.Picked] = invoice.verifiedDatetime;
+    statusLog[InvoiceNodeStatus.Verified] = invoice.verifiedDatetime;
   }
 
   return statusLog;
@@ -95,30 +96,28 @@ export const Footer: FC = () => {
 
             <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
               {isEditable && (
-                <>
-                  <ButtonWithIcon
-                    shrinkThreshold="lg"
-                    disabled={onHoldBuffer}
-                    Icon={<ArrowRightIcon />}
-                    label={t('button.save-and-confirm-status', {
-                      status: t(getNextInboundStatusButtonTranslation(status)),
-                    })}
-                    sx={{ fontSize: '12px' }}
-                    variant="contained"
-                    color="secondary"
-                    onClick={async () => {
-                      update(
-                        {
-                          onHold: onHoldBuffer,
-                          status: InvoiceNodeStatus.Verified,
-                        },
-                        {
-                          onSuccess: success('Saved invoice! 🥳'),
-                        }
-                      );
-                    }}
-                  />
-                </>
+                <ButtonWithIcon
+                  shrinkThreshold="lg"
+                  disabled={onHoldBuffer}
+                  Icon={<ArrowRightIcon />}
+                  label={t('button.save-and-confirm-status', {
+                    status: t(getNextInboundStatusButtonTranslation(status)),
+                  })}
+                  sx={{ fontSize: '12px' }}
+                  variant="contained"
+                  color="secondary"
+                  onClick={async () => {
+                    update(
+                      {
+                        onHold: onHoldBuffer,
+                        status: getNextInboundStatus(status),
+                      },
+                      {
+                        onSuccess: success('Saved invoice! 🥳'),
+                      }
+                    );
+                  }}
+                />
               )}
             </Box>
           </Box>

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -18,15 +18,12 @@ import {
   useInboundFields,
   useInboundItems,
   useInboundLines,
+  useIsInboundEditable,
 } from './api';
-import { InboundShipmentItem, Invoice, InvoiceLine } from '../../types';
-import { isInboundEditable } from '../../utils';
+import { InboundShipmentItem, InvoiceLine } from '../../types';
 
-interface ToolbarProps {
-  draft: Invoice;
-}
-
-export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
+export const Toolbar: FC = () => {
+  const isEditable = useIsInboundEditable();
   const { data } = useInboundItems();
   const lines = useInboundLines();
 
@@ -97,7 +94,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
                 Input={
                   <NameSearchInput
                     type="supplier"
-                    disabled={!isInboundEditable(draft)}
+                    disabled={!isEditable}
                     value={otherParty}
                     onChange={name => {
                       update({ otherParty: name });
@@ -110,7 +107,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
               label={t('label.supplier-ref')}
               Input={
                 <BufferedTextInput
-                  disabled={!isInboundEditable(draft)}
+                  disabled={!isEditable}
                   size="small"
                   sx={{ width: 250 }}
                   value={theirReference ?? ''}
@@ -122,10 +119,7 @@ export const Toolbar: FC<ToolbarProps> = ({ draft }) => {
             />
           </Box>
         </Grid>
-        <DropdownMenu
-          disabled={!isInboundEditable(draft)}
-          label={t('label.select')}
-        >
+        <DropdownMenu disabled={!isEditable} label={t('label.select')}>
           <DropdownMenuItem IconComponent={DeleteIcon} onClick={deleteAction}>
             {t('button.delete-lines', { ns: 'distribution' })}
           </DropdownMenuItem>

--- a/packages/invoices/src/InboundShipment/DetailView/api.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/api.ts
@@ -93,7 +93,9 @@ const locationGuard = (location: LocationResponse): Location => {
   throw new Error('Unknown');
 };
 
-const getPatchStatus = (patch: Partial<Invoice>) => {
+const getPatchStatus = (
+  patch: Partial<Invoice>
+): UpdateInboundShipmentStatusInput | undefined => {
   switch (patch.status) {
     case InvoiceNodeStatus.Verified:
       return UpdateInboundShipmentStatusInput.Verified;
@@ -361,7 +363,7 @@ export const useInboundFields = <KeyOfInvoice extends keyof Invoice>(
 
 export const useIsInboundEditable = (): boolean => {
   const { status } = useInboundFields('status');
-  return status === 'NEW' || status === 'ALLOCATED';
+  return status === 'NEW' || status === 'SHIPPED' || status === 'DELIVERED';
 };
 
 export const useInboundLines = (itemId?: string): InvoiceLine[] => {

--- a/packages/invoices/src/utils.ts
+++ b/packages/invoices/src/utils.ts
@@ -2,7 +2,6 @@ import {
   LocaleKey,
   InvoiceNodeStatus,
   useTranslation,
-  InvoiceNodeType,
   groupBy,
 } from '@openmsupply-client/common';
 import {
@@ -14,64 +13,6 @@ import {
   InvoiceLine,
   InvoiceRow,
 } from './types';
-
-export const placeholderInvoice: Invoice = {
-  id: '',
-  otherPartyName: '',
-  comment: '',
-  theirReference: '',
-  status: InvoiceNodeStatus.New,
-  type: InvoiceNodeType.OutboundShipment,
-  createdDatetime: '',
-  allocatedDatetime: '',
-  shippedDatetime: '',
-  pickedDatetime: '',
-  deliveredDatetime: '',
-  invoiceNumber: 0,
-  onHold: false,
-  otherParty: undefined,
-  otherPartyId: '',
-  lines: [],
-  pricing: {
-    totalAfterTax: 0,
-    //  subtotal: 0,
-    //   taxPercentage: 0
-  },
-};
-
-export const placeholderOutboundShipment: OutboundShipment = {
-  id: '',
-  otherPartyName: '',
-  comment: '',
-  theirReference: '',
-  status: InvoiceNodeStatus.New,
-  type: InvoiceNodeType.OutboundShipment,
-  createdDatetime: '',
-  allocatedDatetime: '',
-  shippedDatetime: '',
-  pickedDatetime: '',
-  deliveredDatetime: '',
-  invoiceNumber: 0,
-  onHold: false,
-  otherParty: undefined,
-  otherPartyId: '',
-  items: [],
-  pricing: {
-    totalAfterTax: 0,
-    //  subtotal: 0,
-    //   taxPercentage: 0
-  },
-
-  // color: 'grey',
-  // purchaseOrderNumber: undefined,
-  // goodsReceiptNumber: undefined,
-  // requisitionNumber: undefined,
-  // inboundShipmentNumber: undefined,
-  // transportReference: undefined,
-  // shippingMethod: undefined,
-  // enteredByName: '',
-  // donorName: '',
-};
 
 export const outboundStatuses: InvoiceNodeStatus[] = [
   InvoiceNodeStatus.New,
@@ -89,6 +30,12 @@ export const inboundStatuses: InvoiceNodeStatus[] = [
   InvoiceNodeStatus.Delivered,
   InvoiceNodeStatus.Verified,
 ];
+
+export const nextStatusMap: { [k in InvoiceNodeStatus]?: InvoiceNodeStatus } = {
+  [InvoiceNodeStatus.New]: InvoiceNodeStatus.Delivered,
+  [InvoiceNodeStatus.Shipped]: InvoiceNodeStatus.Delivered,
+  [InvoiceNodeStatus.Delivered]: InvoiceNodeStatus.Verified,
+};
 
 const statusTranslation: Record<InvoiceNodeStatus, LocaleKey> = {
   ALLOCATED: 'label.allocated',
@@ -116,14 +63,8 @@ export const getNextOutboundStatus = (
 export const getNextInboundStatus = (
   currentStatus: InvoiceNodeStatus
 ): InvoiceNodeStatus => {
-  const currentStatusIdx = inboundStatuses.findIndex(
-    status => currentStatus === status
-  );
-
-  const nextStatus = inboundStatuses[currentStatusIdx + 1];
-
+  const nextStatus = nextStatusMap[currentStatus];
   if (!nextStatus) throw new Error('Could not find the next status');
-
   return nextStatus;
 };
 

--- a/packages/mock-server/src/api/mutations/invoice.ts
+++ b/packages/mock-server/src/api/mutations/invoice.ts
@@ -20,8 +20,14 @@ const getStatusTime = (status: string | undefined | null) => {
     case 'SHIPPED': {
       return { shippedDatetime: new Date().toISOString() };
     }
+    case 'DELIVERED': {
+      return { deliveredDatetime: new Date().toISOString() };
+    }
     case 'PICKED': {
       return { pickedDatetime: new Date().toISOString() };
+    }
+    case 'VERIFIED': {
+      return { verifiedDatetime: new Date().toISOString() };
     }
   }
 

--- a/packages/mock-server/src/data/database.ts
+++ b/packages/mock-server/src/data/database.ts
@@ -547,8 +547,10 @@ export const update = {
   invoice: (
     invoice: (UpdateOutboundShipmentInput | UpdateInboundShipmentInput) & {
       allocatedDatetime?: string;
+      deliveredDatetime?: string;
       shippedDatetime?: string;
       pickedDatetime?: string;
+      verifiedDatetime?: string;
     }
   ): Invoice => {
     const idx = InvoiceData.findIndex(getFilter(invoice.id, 'id'));
@@ -566,8 +568,12 @@ export const update = {
       otherPartyId: invoice?.otherPartyId ?? existingInvoice.otherPartyId,
       allocatedDatetime:
         invoice?.allocatedDatetime ?? existingInvoice.allocatedDatetime,
+      deliveredDatetime:
+        invoice?.deliveredDatetime ?? existingInvoice.deliveredDatetime,
       shippedDatetime:
         invoice?.shippedDatetime ?? existingInvoice.shippedDatetime,
+      verifiedDatetime:
+        invoice?.verifiedDatetime ?? existingInvoice.verifiedDatetime,
       pickedDatetime: invoice?.pickedDatetime ?? existingInvoice.pickedDatetime,
     };
     InvoiceData[idx] = newInvoice;


### PR DESCRIPTION
Fixes #686 

- This adds some changes to inbound shipment statuses to hopefully get them working somewhat close to the desired behaviour
- You'll notice that when creating an ad hoc inbound shipment the status is `new`. Then, when changing the status, we skipped to delivered. This is because 'picked' and 'shipped' should be set when the corresponding customer invoice status is set. Maybe it would be better if the original status was `shipped`. However, you can't change any statuses @ `shipped`, nor change the status to `shipped`, so if we want to change this behaviour we will need API changes.
- Also you'll notice the statuses are grey'd out. This is because the component is actually checking the dates corresponding to the status to determine completeness. Unsure if this is good or not, but it was easier to code like that originally.