### PR TITLE
Add defensive code protecting against invalid value access

### DIFF
--- a/packages/invoices/src/OutboundShipment/DetailView/modals/OutboundLineEditForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/OutboundLineEditForm.tsx
@@ -108,7 +108,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
               style={{ minWidth: 125 }}
             >
               <InputLabel sx={{ fontSize: '12px' }}>
-                {packSizeController.selected.value === -1
+                {packSizeController.selected?.value === -1
                   ? t('label.packs-of', { count: quantity })
                   : t('label.units-in-pack-size-of', { count: quantity })}
               </InputLabel>


### PR DESCRIPTION
Just a minor mistake slipped through causing a crash when opening the outbound line edit