### PR TITLE
Add split button component

### DIFF
--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -127,5 +127,7 @@
   "label.counted-num-of-packs": "Counted # of Packs",
   "label.snapshot-num-of-packs": "Snapshot # of Packs",
   "label.count-this-line": "Count this line",
-  "label.unit-price": "Unit Price"
+  "label.unit-price": "Unit Price",
+  "aria.split-button": "Split button",
+  "aria.split-button-controls": "Split button menu"
 }

--- a/packages/common/src/ui/components/buttons/ButtonShowcase.stories.tsx
+++ b/packages/common/src/ui/components/buttons/ButtonShowcase.stories.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from 'react';
 import { Grid, Paper, Typography } from '@mui/material';
 import { Story } from '@storybook/react';
 import { FlatButton } from './FlatButton';
+import { SplitButton } from './SplitButton';
 import { BookIcon, TruckIcon } from '@common/icons';
 import { BaseButton, ButtonWithIcon } from '.';
 import { DialogButton, IconButton } from '../buttons';
@@ -170,6 +171,17 @@ const Template: Story = () => {
           <ColorSelectButton
             color={color.hex}
             onChange={newColor => setColor(newColor)}
+          />
+        </Wrapper>
+
+        <Wrapper text="Split button">
+          <SplitButton
+            options={[
+              { label: 'Create a merge commit' },
+              { label: 'Squash and merge' },
+              { label: 'Rebase and merge' },
+            ]}
+            onClick={option => alert(JSON.stringify(option))}
           />
         </Wrapper>
       </Grid>

--- a/packages/common/src/ui/components/buttons/SplitButton.stories.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { ComponentMeta } from '@storybook/react';
+import { SplitButton } from './SplitButton';
+
+const ops = [
+  { label: 'Create a merge commit' },
+  { label: 'Squash and merge' },
+  { label: 'Rebase and merge' },
+];
+
+const Template = () => {
+  return (
+    <Box>
+      <SplitButton
+        ariaLabel="Split button"
+        ariaControlLabel="open split button menu"
+        options={ops}
+        onClick={option => alert(JSON.stringify(option))}
+      />
+    </Box>
+  );
+};
+
+export const Primary = Template.bind({});
+
+export default {
+  title: 'Buttons/SplitButton',
+  component: SplitButton,
+} as ComponentMeta<typeof SplitButton>;

--- a/packages/common/src/ui/components/buttons/SplitButton.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Button from '@mui/material/Button';
-import ButtonGroup, { ButtonGroupProps } from '@mui/material/ButtonGroup';
+
+import ButtonGroup from '@mui/material/ButtonGroup';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Grow from '@mui/material/Grow';
 import Paper from '@mui/material/Paper';
@@ -8,6 +8,8 @@ import Popper from '@mui/material/Popper';
 import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
 import { ChevronDownIcon } from '../../icons';
+import { ButtonWithIcon, ButtonWithIconProps } from './standard/ButtonWithIcon';
+import { ShrinkableBaseButton } from '@common/components';
 
 interface SplitButtonOption {
   label: string;
@@ -16,19 +18,21 @@ interface SplitButtonOption {
 }
 
 interface SplitButtonProps {
-  color?: ButtonGroupProps['color'];
+  color?: ButtonWithIconProps['color'];
   ariaLabel?: string;
   ariaControlLabel?: string;
   options: SplitButtonOption[];
   onClick: (option: SplitButtonOption) => void;
+  Icon?: ButtonWithIconProps['Icon'];
 }
 
 export const SplitButton = ({
-  color = 'primary',
+  color = 'secondary',
   ariaLabel,
   ariaControlLabel,
   options,
   onClick,
+  Icon = null,
 }: SplitButtonProps) => {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLDivElement>(null);
@@ -38,15 +42,13 @@ export const SplitButton = ({
     <>
       <ButtonGroup
         color={color}
-        variant="contained"
+        variant="outlined"
         ref={anchorRef}
         aria-label={ariaLabel}
       >
-        <Button
-          sx={{
-            borderTopLeftRadius: '24px',
-            borderBottomLeftRadius: '24px',
-          }}
+        <ButtonWithIcon
+          color={color}
+          sx={{ borderTopRightRadius: '0px', borderBottomRightRadius: '0px' }}
           onClick={() => {
             const selectedOption = options[selectedIndex];
             if (!selectedOption) {
@@ -55,10 +57,13 @@ export const SplitButton = ({
 
             onClick(selectedOption);
           }}
-        >
-          {options[selectedIndex]?.label}
-        </Button>
-        <Button
+          label={options[selectedIndex]?.label ?? ''}
+          Icon={Icon}
+        />
+
+        <ShrinkableBaseButton
+          shrink
+          color={color}
           size="small"
           aria-controls={open ? ariaControlLabel : undefined}
           aria-expanded={open ? 'true' : undefined}
@@ -67,10 +72,10 @@ export const SplitButton = ({
           onClick={() => {
             setOpen(prevOpen => !prevOpen);
           }}
-          sx={{ borderTopRightRadius: '24px', borderBottomRightRadius: '24px' }}
+          sx={{ borderTopLeftRadius: '0px', borderBottomLeftRadius: '0px' }}
         >
           <ChevronDownIcon />
-        </Button>
+        </ShrinkableBaseButton>
       </ButtonGroup>
 
       <Popper

--- a/packages/common/src/ui/components/buttons/SplitButton.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import ButtonGroup from '@mui/material/ButtonGroup';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Grow from '@mui/material/Grow';
@@ -24,6 +23,7 @@ interface SplitButtonProps {
   options: SplitButtonOption[];
   onClick: (option: SplitButtonOption) => void;
   Icon?: ButtonWithIconProps['Icon'];
+  isDisabled?: boolean;
 }
 
 export const SplitButton = ({
@@ -33,10 +33,13 @@ export const SplitButton = ({
   options,
   onClick,
   Icon = null,
+  isDisabled = false,
 }: SplitButtonProps) => {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLDivElement>(null);
-  const [selectedIndex, setSelectedIndex] = React.useState(1);
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  const buttonLabel = options[selectedIndex]?.label ?? '';
 
   return (
     <>
@@ -48,7 +51,12 @@ export const SplitButton = ({
       >
         <ButtonWithIcon
           color={color}
-          sx={{ borderTopRightRadius: '0px', borderBottomRightRadius: '0px' }}
+          disabled={isDisabled}
+          sx={{
+            borderRadius: 0,
+            borderStartStartRadius: '24px',
+            borderEndStartRadius: '24px',
+          }}
           onClick={() => {
             const selectedOption = options[selectedIndex];
             if (!selectedOption) {
@@ -57,12 +65,13 @@ export const SplitButton = ({
 
             onClick(selectedOption);
           }}
-          label={options[selectedIndex]?.label ?? ''}
+          label={buttonLabel}
           Icon={Icon}
         />
 
         <ShrinkableBaseButton
           shrink
+          disabled={isDisabled}
           color={color}
           size="small"
           aria-controls={open ? ariaControlLabel : undefined}
@@ -72,7 +81,11 @@ export const SplitButton = ({
           onClick={() => {
             setOpen(prevOpen => !prevOpen);
           }}
-          sx={{ borderTopLeftRadius: '0px', borderBottomLeftRadius: '0px' }}
+          sx={{
+            borderRadius: 0,
+            borderStartEndRadius: '24px',
+            borderEndEndRadius: '24px',
+          }}
         >
           <ChevronDownIcon />
         </ShrinkableBaseButton>

--- a/packages/common/src/ui/components/buttons/SplitButton.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import ButtonGroup, { ButtonGroupProps } from '@mui/material/ButtonGroup';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
+import Grow from '@mui/material/Grow';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import { ChevronDownIcon } from '../../icons';
+
+const ops = [
+  { label: 'Create a merge commit' },
+  { label: 'Squash and merge' },
+  { label: 'Rebase and merge' },
+];
+
+interface SplitButtonOption {
+  label: string;
+  value?: string;
+  isDisabled?: boolean;
+}
+
+interface SplitButtonProps {
+  color?: ButtonGroupProps['color'];
+  ariaLabel?: string;
+  ariaControlLabel?: string;
+  options: SplitButtonOption[];
+  onClick: (option: SplitButtonOption) => void;
+}
+
+export const SplitButton = ({
+  color = 'primary',
+  ariaLabel,
+  ariaControlLabel,
+  options = ops,
+  onClick,
+}: SplitButtonProps) => {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+  const [selectedIndex, setSelectedIndex] = React.useState(1);
+
+  return (
+    <>
+      <ButtonGroup
+        color={color}
+        variant="contained"
+        ref={anchorRef}
+        aria-label={ariaLabel}
+      >
+        <Button
+          sx={{
+            borderTopLeftRadius: '24px',
+            borderBottomLeftRadius: '24px',
+          }}
+          onClick={() => {
+            const selectedOption = options[selectedIndex];
+            if (!selectedOption) {
+              throw new Error('The selected index for an option is invalid');
+            }
+
+            onClick(selectedOption);
+          }}
+        >
+          {options[selectedIndex]?.label}
+        </Button>
+        <Button
+          size="small"
+          aria-controls={open ? ariaControlLabel : undefined}
+          aria-expanded={open ? 'true' : undefined}
+          aria-label={ariaLabel}
+          aria-haspopup="menu"
+          onClick={() => {
+            setOpen(prevOpen => !prevOpen);
+          }}
+          sx={{ borderTopRightRadius: '24px', borderBottomRightRadius: '24px' }}
+        >
+          <ChevronDownIcon />
+        </Button>
+      </ButtonGroup>
+
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={'menu'}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <Paper elevation={5}>
+              <ClickAwayListener
+                onClickAway={event => {
+                  if (
+                    anchorRef.current &&
+                    anchorRef.current.contains(event.target as HTMLElement)
+                  ) {
+                    return;
+                  }
+
+                  setOpen(false);
+                }}
+              >
+                <MenuList>
+                  {options.map((option, index) => (
+                    <MenuItem
+                      key={option.label}
+                      disabled={option?.isDisabled}
+                      selected={index === selectedIndex}
+                      onClick={() => {
+                        setSelectedIndex(index);
+                        setOpen(false);
+                      }}
+                    >
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+};

--- a/packages/common/src/ui/components/buttons/SplitButton.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import ButtonGroup from '@mui/material/ButtonGroup';
-import ClickAwayListener from '@mui/material/ClickAwayListener';
-import Grow from '@mui/material/Grow';
-import Paper from '@mui/material/Paper';
-import Popper from '@mui/material/Popper';
+import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import MenuList from '@mui/material/MenuList';
 import { ChevronDownIcon } from '../../icons';
 import { ButtonWithIcon, ButtonWithIconProps } from './standard/ButtonWithIcon';
 import { ShrinkableBaseButton } from '@common/components';
@@ -35,20 +31,15 @@ export const SplitButton = ({
   Icon = null,
   isDisabled = false,
 }: SplitButtonProps) => {
-  const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
 
   const buttonLabel = options[selectedIndex]?.label ?? '';
+  const open = !!anchorEl;
 
   return (
     <>
-      <ButtonGroup
-        color={color}
-        variant="outlined"
-        ref={anchorRef}
-        aria-label={ariaLabel}
-      >
+      <ButtonGroup color={color} variant="outlined" aria-label={ariaLabel}>
         <ButtonWithIcon
           color={color}
           disabled={isDisabled}
@@ -78,8 +69,8 @@ export const SplitButton = ({
           aria-expanded={open ? 'true' : undefined}
           aria-label={ariaLabel}
           aria-haspopup="menu"
-          onClick={() => {
-            setOpen(prevOpen => !prevOpen);
+          onClick={e => {
+            setAnchorEl(e.currentTarget);
           }}
           sx={{
             borderRadius: 0,
@@ -89,56 +80,36 @@ export const SplitButton = ({
         >
           <ChevronDownIcon />
         </ShrinkableBaseButton>
+        <Menu
+          anchorEl={anchorEl}
+          open={open}
+          onClose={() => setAnchorEl(null)}
+          elevation={5}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+        >
+          {options.map((option, index) => (
+            <MenuItem
+              sx={{ zIndex: 1000000000 }}
+              key={option.label}
+              disabled={option?.isDisabled}
+              selected={index === selectedIndex}
+              onClick={() => {
+                setSelectedIndex(index);
+                setAnchorEl(null);
+              }}
+            >
+              {option.label}
+            </MenuItem>
+          ))}
+        </Menu>
       </ButtonGroup>
-
-      <Popper
-        open={open}
-        anchorEl={anchorRef.current}
-        role={'menu'}
-        transition
-        disablePortal
-      >
-        {({ TransitionProps, placement }) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin:
-                placement === 'bottom' ? 'center top' : 'center bottom',
-            }}
-          >
-            <Paper elevation={5}>
-              <ClickAwayListener
-                onClickAway={event => {
-                  if (
-                    anchorRef.current &&
-                    anchorRef.current.contains(event.target as HTMLElement)
-                  ) {
-                    return;
-                  }
-
-                  setOpen(false);
-                }}
-              >
-                <MenuList>
-                  {options.map((option, index) => (
-                    <MenuItem
-                      key={option.label}
-                      disabled={option?.isDisabled}
-                      selected={index === selectedIndex}
-                      onClick={() => {
-                        setSelectedIndex(index);
-                        setOpen(false);
-                      }}
-                    >
-                      {option.label}
-                    </MenuItem>
-                  ))}
-                </MenuList>
-              </ClickAwayListener>
-            </Paper>
-          </Grow>
-        )}
-      </Popper>
     </>
   );
 };

--- a/packages/common/src/ui/components/buttons/SplitButton.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.tsx
@@ -9,12 +9,6 @@ import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
 import { ChevronDownIcon } from '../../icons';
 
-const ops = [
-  { label: 'Create a merge commit' },
-  { label: 'Squash and merge' },
-  { label: 'Rebase and merge' },
-];
-
 interface SplitButtonOption {
   label: string;
   value?: string;
@@ -33,7 +27,7 @@ export const SplitButton = ({
   color = 'primary',
   ariaLabel,
   ariaControlLabel,
-  options = ops,
+  options,
   onClick,
 }: SplitButtonProps) => {
   const [open, setOpen] = React.useState(false);

--- a/packages/common/src/ui/components/buttons/SplitButton.tsx
+++ b/packages/common/src/ui/components/buttons/SplitButton.tsx
@@ -96,7 +96,6 @@ export const SplitButton = ({
         >
           {options.map((option, index) => (
             <MenuItem
-              sx={{ zIndex: 1000000000 }}
               key={option.label}
               disabled={option?.isDisabled}
               selected={index === selectedIndex}

--- a/packages/common/src/ui/components/buttons/index.ts
+++ b/packages/common/src/ui/components/buttons/index.ts
@@ -5,3 +5,4 @@ export * from './IconButton';
 export * from './ToggleButton';
 export * from './ColorSelectButton';
 export * from './LoadingButton';
+export * from './SplitButton';

--- a/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
+++ b/packages/common/src/ui/components/buttons/standard/ButtonWithIcon.tsx
@@ -3,7 +3,7 @@ import { ButtonProps, Tooltip } from '@mui/material';
 import { ShrinkableBaseButton } from './ShrinkableBaseButton';
 import { useIsScreen } from '@common/hooks';
 
-interface ButtonWithIconProps extends ButtonProps {
+export interface ButtonWithIconProps extends ButtonProps {
   Icon: React.ReactNode;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   label: string;


### PR DESCRIPTION
Fixes #813 

- Adds a split button component
- Not sure about the design of it, but the functionality is there! Specifically, the shrinking to just an icon. It has a tooltip, but might still be confusing?

<img width="692" alt="image" src="https://user-images.githubusercontent.com/35858975/153723397-b0b61e09-223a-4539-9076-c172b9db1ff1.png">


- Idea is to have a list of different statuses to choose and 'skip'