### PR TITLE
Add ConfirmationModal component

### DIFF
--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Grid } from '@mui/material';
+import { Story } from '@storybook/react';
+import { ConfirmationModal } from './ConfirmationModal';
+import { BaseButton } from '../../buttons';
+import { useToggle } from '../../../../hooks';
+
+export default {
+  title: 'Modals/ConfirmationModal',
+  component: ConfirmationModal,
+};
+
+const Template: Story = () => {
+  const modalControl = useToggle(false);
+
+  return (
+    <Grid>
+      <BaseButton onClick={modalControl.toggleOn}>Open Modal</BaseButton>
+      <ConfirmationModal
+        title={'Are you sure?'}
+        open={modalControl.isOn}
+        onConfirm={() => {
+          alert('Confirmed');
+          modalControl.toggleOff();
+        }}
+        onCancel={modalControl.toggleOff}
+        message={'This will delete all your data.'}
+      />
+    </Grid>
+  );
+};
+
+const Loading: Story = () => {
+  const modalControl = useToggle(false);
+
+  return (
+    <Grid>
+      <BaseButton onClick={modalControl.toggleOn}>Open Modal</BaseButton>
+      <ConfirmationModal
+        title={'Are you sure?'}
+        open={modalControl.isOn}
+        onConfirm={async () => {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          alert('Confirmed');
+          modalControl.toggleOff();
+        }}
+        onCancel={modalControl.toggleOff}
+        message={'This will delete all your data.'}
+      />
+    </Grid>
+  );
+};
+
+export const Primary = Template.bind({});
+export const WithAsyncConfirmation = Loading.bind({});

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { Grid, Typography } from '@mui/material';
+import { BasicModal } from '../BasicModal';
+import { AlertIcon } from '@common/icons';
+import { DialogButton, LoadingButton } from '../../buttons';
+
+interface ConfirmationModalProps {
+  open: boolean;
+  width?: number;
+  height?: number;
+  onConfirm: (() => void) | (() => Promise<void>);
+  onCancel: () => void;
+  title: string;
+  message: string;
+  Icon?: React.ReactNode;
+}
+
+export const ConfirmationModal = ({
+  open,
+  width = 400,
+  height = 200,
+  onConfirm,
+  title,
+  message,
+  onCancel,
+  Icon = <AlertIcon color="primary" />,
+}: ConfirmationModalProps) => {
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <BasicModal width={width} height={height} open={open}>
+      <Grid container gap={1} flex={1} padding={4} flexDirection="column">
+        <Grid container gap={1} flexDirection="row">
+          <Grid item>{Icon}</Grid>
+          <Grid item>
+            <Typography variant="h6">{title}</Typography>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Typography>{message}</Typography>
+        </Grid>
+        <Grid
+          container
+          gap={1}
+          flexDirection="row"
+          alignItems="flex-end"
+          justifyContent="flex-end"
+          flex={1}
+          display="flex"
+        >
+          <Grid item>
+            <DialogButton
+              variant="cancel"
+              disabled={loading}
+              onClick={onCancel}
+            />
+          </Grid>
+          <Grid item>
+            <LoadingButton
+              color="secondary"
+              isLoading={loading}
+              onClick={async () => {
+                const result = onConfirm();
+                if (result instanceof Promise) {
+                  setLoading(true);
+                  await result;
+                  setLoading(false);
+                }
+              }}
+            >
+              OK
+            </LoadingButton>
+          </Grid>
+        </Grid>
+      </Grid>
+    </BasicModal>
+  );
+};

--- a/packages/common/src/ui/components/modals/ConfirmationModal/index.ts
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmationModal } from './ConfirmationModal';

--- a/packages/common/src/ui/components/modals/index.ts
+++ b/packages/common/src/ui/components/modals/index.ts
@@ -1,3 +1,4 @@
 export * from './ListSearch';
 export * from './BasicModal';
 export * from './ModalTitle';
+export * from './ConfirmationModal';

--- a/packages/common/src/ui/notifications/AlertModal.tsx
+++ b/packages/common/src/ui/notifications/AlertModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Backdrop, Fade, Grid, Modal, Paper, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { DialogButton } from '../components/buttons';
 import { AlertIcon } from '@common/icons';
+import { BasicModal } from '@common/components';
 
 export interface AlertModalProps {
   message: string;
@@ -17,55 +18,29 @@ export const AlertModal: React.FC<AlertModalProps> = ({
   title,
 }) => {
   return (
-    <Modal
-      open={open}
-      closeAfterTransition
-      BackdropComponent={Backdrop}
-      BackdropProps={{
-        timeout: 500,
-      }}
-    >
-      <Fade in={open}>
-        <Paper
-          sx={{
-            bgcolor: 'background.paper',
-            borderRadius: '16px',
-            boxShadow: theme => theme.shadows[7],
-            left: '50%',
-            p: 4,
-            position: 'absolute',
-            top: '50%',
-            transform: 'translate(-50%, -50%)',
-            width: 400,
-            '&:focus': {
-              outline: 'none',
-            },
-          }}
-        >
-          <Grid container gap={1} flexDirection="column">
-            <Grid container gap={1}>
-              <Grid item>
-                <AlertIcon color="primary" />
-              </Grid>
-              <Grid item>
-                <Typography
-                  id="transition-modal-title"
-                  variant="h6"
-                  component="span"
-                >
-                  {title}
-                </Typography>
-              </Grid>
-            </Grid>
-            <Grid item>
-              <Typography>{message}</Typography>
-            </Grid>
-            <Grid item display="flex" justifyContent="flex-end" flex={1}>
-              <DialogButton variant="ok" onClick={onOk} />
-            </Grid>
+    <BasicModal open={open} width={400} height={150}>
+      <Grid padding={4} container gap={1} flexDirection="column">
+        <Grid container gap={1}>
+          <Grid item>
+            <AlertIcon color="primary" />
           </Grid>
-        </Paper>
-      </Fade>
-    </Modal>
+          <Grid item>
+            <Typography
+              id="transition-modal-title"
+              variant="h6"
+              component="span"
+            >
+              {title}
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Typography>{message}</Typography>
+        </Grid>
+        <Grid item display="flex" justifyContent="flex-end" flex={1}>
+          <DialogButton variant="ok" onClick={onOk} />
+        </Grid>
+      </Grid>
+    </BasicModal>
   );
 };


### PR DESCRIPTION
Starts #792 

- Adds a confirmation modal component
![image](https://user-images.githubusercontent.com/35858975/154035793-2ff80fa6-8272-4ce2-ad49-a16b826b6098.png)
- Handles the confirmation callback being an async func or returning a promise also
- Next step I think is to put this component at the root level, likely with a context provider and make a hook `useConfirmationModal` to be able to open the modal from anywhere.