### PR TITLE
#792 status confirmation

### DIFF
--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -55,6 +55,7 @@
   "heading.expiring-stock": "Expiring Stock",
   "heading.shipments-to-be-picked": "Shipments to be picked",
   "heading.settings": "Settings",
+  "heading.are-you-sure": "Are you sure?",
   "label.average-monthly-consumption": "Av Monthly Consumption",
   "label.stock-on-hand": "Stock on Hand (Est. remaining)",
   "label.forecast-quantity": "Forecast Quantity to Reach Target",

--- a/packages/common/src/intl/locales/en/distribution.json
+++ b/packages/common/src/intl/locales/en/distribution.json
@@ -32,5 +32,8 @@
   "message.deleted-requisitions": "Deleted {{number}} requisitions",
   "message.select-rows-to-delete": "Select rows to delete",
   "messages.click-to-return-to-requisitions": "Unable to find a requisition with that ID. Click OK to return to the requisition list",
-  "message.deleted-lines": "Deleted {{number}} lines"
+  "message.deleted-lines": "Deleted {{number}} lines",
+  "message.confirm-status-as": "Confirm status as $t({{status}})?",
+  "message.shipment-saved": "Shipment saved 🥳",
+  "message.error-saving-shipment": "Error saving shipment 🥺"
 }

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -4,6 +4,7 @@ import { Story } from '@storybook/react';
 import { ConfirmationModal } from './ConfirmationModal';
 import { BaseButton } from '../../buttons';
 import { useToggle } from '../../../../hooks';
+import { useConfirmationModal } from '@common/components';
 
 export default {
   title: 'Modals/ConfirmationModal',
@@ -51,5 +52,16 @@ const Loading: Story = () => {
   );
 };
 
+const UseConfirmationModalHook: Story = () => {
+  const getConfirmation = useConfirmationModal({
+    title: 'Are you sure?',
+    message: 'This will delete all your data.',
+    onConfirm: () => alert('confirmed!'),
+  });
+
+  return <BaseButton onClick={getConfirmation}>Open Modal</BaseButton>;
+};
+
 export const Primary = Template.bind({});
 export const WithAsyncConfirmation = Loading.bind({});
+export const WithContextAndHook = UseConfirmationModalHook.bind({});

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -4,7 +4,7 @@ import { Story } from '@storybook/react';
 import { ConfirmationModal } from './ConfirmationModal';
 import { BaseButton } from '../../buttons';
 import { useToggle } from '../../../../hooks';
-import { useConfirmationModal } from '@common/components';
+import { useConfirmationModal } from './ConfirmationModalProvider';
 
 export default {
   title: 'Modals/ConfirmationModal',

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -38,7 +38,7 @@ export const ConfirmationModal = ({
       <Grid container gap={1} flex={1} padding={4} flexDirection="column">
         <Grid container gap={1} flexDirection="row">
           <Grid item>
-            <Icon color="primary" />
+            <Icon color={iconType === 'info' ? 'secondary' : 'primary'} />
           </Grid>
           <Grid item>
             <Typography variant="h6">{title}</Typography>

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -74,6 +74,7 @@ export const ConfirmationModal = ({
                   await result;
                   setLoading(false);
                 }
+                onCancel();
               }}
             >
               OK

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.stories.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Story } from '@storybook/react';
+import { BaseButton } from '../../buttons';
+import { useConfirmationModal } from './ConfirmationModalProvider';
+
+export default {
+  title: 'Hooks/useConfirmationModal',
+  component: useConfirmationModal,
+};
+
+const UseConfirmationModalStory: Story = () => {
+  const getConfirmation = useConfirmationModal({
+    title: 'Are you sure?',
+    message: 'This will delete all your data.',
+    onConfirm: () => alert('confirmed!'),
+  });
+
+  return <BaseButton onClick={getConfirmation}>Open Modal</BaseButton>;
+};
+
+export const UseConfirmationModalHook = UseConfirmationModalStory.bind({});

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
@@ -1,0 +1,104 @@
+import React, {
+  FC,
+  useCallback,
+  useMemo,
+  useContext,
+  useState,
+  createContext,
+} from 'react';
+import { ConfirmationModal } from './ConfirmationModal';
+
+interface ConfirmationModalState {
+  open: boolean;
+  message: string;
+  title: string;
+  iconType?: 'alert' | 'info';
+  onConfirm: (() => void) | (() => Promise<void>);
+}
+
+interface ConfirmationModalControllerState extends ConfirmationModalState {
+  setState: (state: ConfirmationModalState) => void;
+  setMessage: (message: string) => void;
+  setTitle: (title: string) => void;
+  setOnConfirm: (onConfirm: (() => Promise<void>) | (() => void)) => void;
+  setOpen: (open: boolean) => void;
+}
+
+const Context = createContext<ConfirmationModalControllerState>({
+  open: false,
+  message: '',
+  title: '',
+  iconType: 'info',
+  onConfirm: () => {},
+  setState: () => {},
+  setMessage: () => {},
+  setTitle: () => {},
+  setOnConfirm: () => {},
+  setOpen: () => {},
+});
+
+export const ConfirmationModalProvider: FC = ({ children }) => {
+  const [confirmationModalState, setState] = useState<ConfirmationModalState>({
+    open: false,
+    message: '',
+    title: '',
+    iconType: 'info',
+    onConfirm: async () => {},
+  });
+  const { open, message, title, iconType, onConfirm } = confirmationModalState;
+
+  const confirmationModalController: ConfirmationModalControllerState = useMemo(
+    () => ({
+      setMessage: (message: string) =>
+        setState(state => ({ ...state, message })),
+      setTitle: (title: string) => setState(state => ({ ...state, title })),
+      setOnConfirm: (onConfirm: (() => Promise<void>) | (() => void)) =>
+        setState(state => ({ ...state, onConfirm })),
+      setOpen: (open: boolean) => setState(state => ({ ...state, open })),
+      setState,
+      ...confirmationModalState,
+    }),
+    [setState, confirmationModalState]
+  );
+
+  return (
+    <Context.Provider value={confirmationModalController}>
+      {children}
+      <ConfirmationModal
+        open={open}
+        message={message}
+        title={title}
+        onConfirm={onConfirm}
+        onCancel={() => setState(state => ({ ...state, open: false }))}
+        iconType={iconType}
+      />
+    </Context.Provider>
+  );
+};
+
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export const useConfirmationModal = ({
+  onConfirm,
+  message,
+  title,
+}: PartialBy<ConfirmationModalState, 'open'>) => {
+  const { setOpen, setMessage, setOnConfirm, setTitle } = useContext(Context);
+
+  const trigger = () => {
+    setMessage(message);
+    setOnConfirm(onConfirm);
+    setTitle(title);
+    setOpen(true);
+  };
+
+  return useCallback(trigger, [
+    message,
+    onConfirm,
+    title,
+    setMessage,
+    setOnConfirm,
+    setTitle,
+    setOpen,
+  ]);
+};

--- a/packages/common/src/ui/components/modals/ConfirmationModal/index.ts
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/index.ts
@@ -1,1 +1,2 @@
 export { ConfirmationModal } from './ConfirmationModal';
+export * from './ConfirmationModalProvider';

--- a/packages/common/src/utils/testing.tsx
+++ b/packages/common/src/utils/testing.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { TableProvider, createTableStore } from '../ui/layout/tables';
 import { IntlTestProvider, OmSupplyApiProvider } from '..';
 import { Environment } from '@openmsupply-client/config';
+import { ConfirmationModalProvider } from '../ui/components/modals';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -59,7 +60,9 @@ export const StoryProvider: FC<StoryProviderProps> = ({ children }) => (
       <SnackbarProvider maxSnack={3}>
         <IntlTestProvider locale="en">
           <TableProvider createStore={createTableStore}>
-            <AppThemeProvider>{children}</AppThemeProvider>
+            <AppThemeProvider>
+              <ConfirmationModalProvider>{children}</ConfirmationModalProvider>
+            </AppThemeProvider>
           </TableProvider>
         </IntlTestProvider>
       </SnackbarProvider>

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -15,6 +15,7 @@ import {
   OmSupplyApiProvider,
   IntlProvider,
   RandomLoader,
+  ConfirmationModalProvider,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Login, Viewport } from './components';
@@ -37,19 +38,21 @@ const Host: FC = () => (
           <QueryClientProvider client={queryClient}>
             <OmSupplyApiProvider url={Environment.API_URL}>
               <AppThemeProvider>
-                <BrowserRouter>
-                  <Viewport>
-                    <Box display="flex" style={{ minHeight: '100%' }}>
-                      <Routes>
-                        <Route
-                          path={RouteBuilder.create(AppRoute.Login).build()}
-                          element={<Login />}
-                        />
-                        <Route path="*" element={<Site />} />
-                      </Routes>
-                    </Box>
-                  </Viewport>
-                </BrowserRouter>
+                <ConfirmationModalProvider>
+                  <BrowserRouter>
+                    <Viewport>
+                      <Box display="flex" style={{ minHeight: '100%' }}>
+                        <Routes>
+                          <Route
+                            path={RouteBuilder.create(AppRoute.Login).build()}
+                            element={<Login />}
+                          />
+                          <Route path="*" element={<Site />} />
+                        </Routes>
+                      </Box>
+                    </Viewport>
+                  </BrowserRouter>
+                </ConfirmationModalProvider>
               </AppThemeProvider>
               <ReactQueryDevtools initialIsOpen />
             </OmSupplyApiProvider>


### PR DESCRIPTION
Fixes #792 

- Adds a provider with `ConfirmationModal` and a hook `useConfirmationModal`
- Adds use of the above hook in the status change area of the outbound shipment detail view
- Unsure of the copy but .. 🤷 