### PR TITLE
#831 Use storeID and requisition number for request requisition queries

### DIFF
--- a/packages/requisitions/src/RequisitionService.tsx
+++ b/packages/requisitions/src/RequisitionService.tsx
@@ -26,7 +26,7 @@ const supplierRequisitionsRoute = RouteBuilder.create(
 const supplierRequisitionRoute = RouteBuilder.create(
   AppRoute.SupplierRequisition
 )
-  .addPart(':id')
+  .addPart(':requisitionNumber')
   .build();
 
 export const RequisitionService: FC = () => {

--- a/packages/requisitions/src/SupplierRequisition/ListView/ListView.tsx
+++ b/packages/requisitions/src/SupplierRequisition/ListView/ListView.tsx
@@ -61,7 +61,7 @@ export const SupplierRequisitionListView: FC = () => {
         columns={columns}
         data={data?.nodes ?? []}
         onRowClick={row => {
-          navigate(row.id);
+          navigate(String(row.requisitionNumber));
         }}
       />
     </>

--- a/packages/requisitions/src/SupplierRequisition/api/api.ts
+++ b/packages/requisitions/src/SupplierRequisition/api/api.ts
@@ -76,7 +76,7 @@ export const RequestRequisitionQueries = {
       throw new Error('Unable to update requisition');
     },
   create:
-    (api: RequestRequisitionApi) =>
+    (api: RequestRequisitionApi, storeId: string) =>
     async ({
       id,
       otherPartyId,
@@ -89,7 +89,7 @@ export const RequestRequisitionQueries = {
       requisitionNumber: number;
     }> => {
       const result = await api.insertRequestRequisition({
-        storeId: '8D967C2618BE4D78B3A6FAD6C1C8FF25',
+        storeId,
         input: {
           id,
           otherPartyId,

--- a/packages/requisitions/src/SupplierRequisition/api/api.ts
+++ b/packages/requisitions/src/SupplierRequisition/api/api.ts
@@ -30,19 +30,22 @@ export const requisitionToInput = (
 export const RequestRequisitionQueries = {
   get: {
     list:
-      (api: RequestRequisitionApi) =>
+      (api: RequestRequisitionApi, storeId: string) =>
       async (): Promise<RequestRequisitionsQuery['requisitions']> => {
         const result = await api.requestRequisitions({
-          storeId: '8D967C2618BE4D78B3A6FAD6C1C8FF25',
+          storeId,
         });
         return result.requisitions;
       },
     byNumber:
       (api: RequestRequisitionApi) =>
-      async (): Promise<RequestRequisitionFragment> => {
+      async (
+        requisitionNumber: number,
+        storeId: string
+      ): Promise<RequestRequisitionFragment> => {
         const result = await api.requestRequisition({
-          storeId: '8D967C2618BE4D78B3A6FAD6C1C8FF25',
-          requisitionNumber: 1,
+          storeId,
+          requisitionNumber,
         });
 
         if (result.requisitionByNumber.__typename === 'RequisitionNode') {
@@ -80,7 +83,11 @@ export const RequestRequisitionQueries = {
     }: {
       id: string;
       otherPartyId: string;
-    }): Promise<{ __typename: 'RequisitionNode'; id: string }> => {
+    }): Promise<{
+      __typename: 'RequisitionNode';
+      id: string;
+      requisitionNumber: number;
+    }> => {
       const result = await api.insertRequestRequisition({
         storeId: '8D967C2618BE4D78B3A6FAD6C1C8FF25',
         input: {

--- a/packages/requisitions/src/SupplierRequisition/api/hooks.ts
+++ b/packages/requisitions/src/SupplierRequisition/api/hooks.ts
@@ -44,7 +44,7 @@ export const useCreateRequestRequisition = () => {
   const api = useRequestRequisitionApi();
   return useMutation(RequestRequisitionQueries.create(api), {
     onSuccess: ({ requisitionNumber }) => {
-      navigate(requisitionNumber);
+      navigate(String(requisitionNumber));
       queryClient.invalidateQueries(['requisition']);
     },
   });

--- a/packages/requisitions/src/SupplierRequisition/api/hooks.ts
+++ b/packages/requisitions/src/SupplierRequisition/api/hooks.ts
@@ -15,6 +15,7 @@ import {
   useSortBy,
   usePagination,
   getDataSorter,
+  useHostContext,
 } from '@openmsupply-client/common';
 import { RequestRequisitionQueries } from './api';
 import {
@@ -29,8 +30,12 @@ export const useRequestRequisitionApi = () => {
 };
 
 export const useRequestRequisitions = () => {
+  const { store } = useHostContext();
   const api = useRequestRequisitionApi();
-  return useQuery(['requisition'], RequestRequisitionQueries.get.list(api));
+  return useQuery(
+    ['requisition', store.id],
+    RequestRequisitionQueries.get.list(api, store.id)
+  );
 };
 
 export const useCreateRequestRequisition = () => {
@@ -38,8 +43,8 @@ export const useCreateRequestRequisition = () => {
   const navigate = useNavigate();
   const api = useRequestRequisitionApi();
   return useMutation(RequestRequisitionQueries.create(api), {
-    onSuccess: ({ id }) => {
-      navigate(id);
+    onSuccess: ({ requisitionNumber }) => {
+      navigate(requisitionNumber);
       queryClient.invalidateQueries(['requisition']);
     },
   });
@@ -47,10 +52,14 @@ export const useCreateRequestRequisition = () => {
 
 export const useRequestRequisition =
   (): UseQueryResult<RequestRequisitionFragment> => {
-    const { id = '' } = useParams();
+    const { requisitionNumber = '' } = useParams();
+    const { store } = useHostContext();
     const api = useRequestRequisitionApi();
-    return useQuery(['requisition', id], () =>
-      RequestRequisitionQueries.get.byNumber(api)()
+    return useQuery(['requisition', store.id, requisitionNumber], () =>
+      RequestRequisitionQueries.get.byNumber(api)(
+        Number(requisitionNumber),
+        store.id
+      )
     );
   };
 
@@ -59,13 +68,19 @@ export const useRequestRequisitionFields = <
 >(
   keys: KeyOfRequisition | KeyOfRequisition[]
 ): FieldSelectorControl<RequestRequisitionFragment, KeyOfRequisition> => {
-  const { id = '' } = useParams();
+  const { store } = useHostContext();
+  const { data } = useRequestRequisition();
+  const { requisitionNumber = '' } = useParams();
   const api = useRequestRequisitionApi();
   return useFieldsSelector(
-    ['requisition', id],
-    () => RequestRequisitionQueries.get.byNumber(api)(),
+    ['requisition', store.id, requisitionNumber],
+    () =>
+      RequestRequisitionQueries.get.byNumber(api)(
+        Number(requisitionNumber),
+        store.id
+      ),
     (patch: Partial<RequestRequisitionFragment>) =>
-      RequestRequisitionQueries.update(api)({ ...patch, id }),
+      RequestRequisitionQueries.update(api)({ ...patch, id: data?.id ?? '' }),
     keys
   );
 };

--- a/packages/requisitions/src/SupplierRequisition/api/hooks.ts
+++ b/packages/requisitions/src/SupplierRequisition/api/hooks.ts
@@ -40,9 +40,10 @@ export const useRequestRequisitions = () => {
 
 export const useCreateRequestRequisition = () => {
   const queryClient = useQueryClient();
+  const { store } = useHostContext();
   const navigate = useNavigate();
   const api = useRequestRequisitionApi();
-  return useMutation(RequestRequisitionQueries.create(api), {
+  return useMutation(RequestRequisitionQueries.create(api, store.id), {
     onSuccess: ({ requisitionNumber }) => {
       navigate(String(requisitionNumber));
       queryClient.invalidateQueries(['requisition']);

--- a/packages/requisitions/src/SupplierRequisition/api/operations.generated.ts
+++ b/packages/requisitions/src/SupplierRequisition/api/operations.generated.ts
@@ -10,7 +10,7 @@ export type InsertRequestRequisitionMutationVariables = Types.Exact<{
 }>;
 
 
-export type InsertRequestRequisitionMutation = { __typename: 'Mutations', insertRequestRequisition: { __typename: 'InsertRequestRequisitionError' } | { __typename: 'RequisitionNode', id: string } };
+export type InsertRequestRequisitionMutation = { __typename: 'Mutations', insertRequestRequisition: { __typename: 'InsertRequestRequisitionError' } | { __typename: 'RequisitionNode', id: string, requisitionNumber: number } };
 
 export type UpdateRequestRequisitionMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -106,6 +106,7 @@ export const InsertRequestRequisitionDocument = gql`
     ... on RequisitionNode {
       __typename
       id
+      requisitionNumber
     }
   }
 }

--- a/packages/requisitions/src/SupplierRequisition/api/operations.graphql
+++ b/packages/requisitions/src/SupplierRequisition/api/operations.graphql
@@ -6,6 +6,7 @@ mutation insertRequestRequisition(
     ... on RequisitionNode {
       __typename
       id
+      requisitionNumber
     }
   }
 }


### PR DESCRIPTION
#831 

- Using `storeID` from host context in the request requisition queries
- Using `requisitionNumber` for querying for the detail view