### PR TITLE
#854 use requisition numbers for responses

### DIFF
--- a/packages/host/src/CommandK.tsx
+++ b/packages/host/src/CommandK.tsx
@@ -184,6 +184,17 @@ export const CommandK: FC = ({ children }) => {
         ),
     },
     {
+      id: 'navigation:internal-order',
+      name: `${t('cmdk.goto-internal-order')}`,
+      keywords: 'replenishment',
+      perform: () =>
+        navigate(
+          RouteBuilder.create(AppRoute.Replenishment)
+            .addPart(AppRoute.InternalOrder)
+            .build()
+        ),
+    },
+    {
       id: 'navigation:reports',
       name: `${t('cmdk.goto-reports')} (r)`,
       shortcut: ['r'],

--- a/packages/requisitions/src/RequisitionService.tsx
+++ b/packages/requisitions/src/RequisitionService.tsx
@@ -17,7 +17,7 @@ const customerRequisitionsRoute = RouteBuilder.create(
 const customerRequisitionRoute = RouteBuilder.create(
   AppRoute.CustomerRequisition
 )
-  .addPart(':id')
+  .addPart(':requisitionNumber')
   .build();
 
 const internalOrdersRoute = RouteBuilder.create(AppRoute.InternalOrder).build();

--- a/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -45,7 +45,7 @@ export const ResponseRequisitionListView: FC = () => {
         columns={columns}
         data={data?.nodes}
         onRowClick={row => {
-          navigate(row.id);
+          navigate(String(row.requisitionNumber));
         }}
       />
     </>

--- a/packages/requisitions/src/ResponseRequisition/api/api.ts
+++ b/packages/requisitions/src/ResponseRequisition/api/api.ts
@@ -21,7 +21,6 @@ export const requisitionToInput = (
 ): UpdateResponseRequisitionInput => {
   return {
     id: requisition.id,
-    // otherPartyId: requisition.otherParty?.id,
     comment: requisition.comment,
     theirReference: requisition.theirReference,
     colour: requisition.colour,

--- a/packages/requisitions/src/ResponseRequisition/api/hooks.ts
+++ b/packages/requisitions/src/ResponseRequisition/api/hooks.ts
@@ -51,11 +51,14 @@ export const useResponseRequisitions = () => {
 
 export const useResponseRequisition =
   (): UseQueryResult<ResponseRequisitionFragment> => {
-    const { id = '' } = useParams();
+    const { requisitionNumber = '' } = useParams();
     const { store } = useHostContext();
     const api = useResponseRequisitionApi();
-    return useQuery(['requisition', id], () =>
-      ResponseRequisitionQueries.get.byNumber(api)(Number(id), store.id)
+    return useQuery(['requisition', requisitionNumber], () =>
+      ResponseRequisitionQueries.get.byNumber(api)(
+        Number(requisitionNumber),
+        store.id
+      )
     );
   };
 
@@ -65,13 +68,21 @@ export const useResponseRequisitionFields = <
   keys: KeyOfRequisition | KeyOfRequisition[]
 ): FieldSelectorControl<ResponseRequisitionFragment, KeyOfRequisition> => {
   const { store } = useHostContext();
-  const { id = '' } = useParams();
+  const { data } = useResponseRequisition();
+  const { requisitionNumber = '' } = useParams();
   const api = useResponseRequisitionApi();
   return useFieldsSelector(
-    ['requisition', id],
-    () => ResponseRequisitionQueries.get.byNumber(api)(Number(id), store.id),
+    ['requisition', requisitionNumber],
+    () =>
+      ResponseRequisitionQueries.get.byNumber(api)(
+        Number(requisitionNumber),
+        store.id
+      ),
     (patch: Partial<ResponseRequisitionFragment>) =>
-      ResponseRequisitionQueries.update(api, store.id)({ ...patch, id }),
+      ResponseRequisitionQueries.update(
+        api,
+        store.id
+      )({ ...patch, id: data?.id ?? '' }),
     keys
   );
 };


### PR DESCRIPTION
Fixes #854 

- Adds use of `requisitionNumber` for navigating to response reqs (I had to use a local copy of remote-server to test this, rather than the demo server)
- Off-road added internal orders to commandK - though I didn't add a shortcut as all the letters are taken!!