### PR TITLE
Remove drawer hover expand

### DIFF
--- a/packages/common/src/hooks/useDrawer.ts
+++ b/packages/common/src/hooks/useDrawer.ts
@@ -2,7 +2,6 @@ import create from 'zustand';
 import LocalStorage from '../localStorage/LocalStorage';
 
 type DrawerController = {
-  hoverActive: Record<string, boolean>;
   hoverOpen: boolean;
   isOpen: boolean;
   hasUserSet: boolean;
@@ -10,10 +9,8 @@ type DrawerController = {
   open: () => void;
   close: () => void;
   toggle: () => void;
-  setHoverActive: (key: string, active: boolean) => void;
   setHoverOpen: (open: boolean) => void;
   setClicked: (clicked?: string) => void;
-  clearHoverActive: () => void;
 };
 
 export const useDrawer = create<DrawerController>(set => {
@@ -21,20 +18,13 @@ export const useDrawer = create<DrawerController>(set => {
   return {
     hasUserSet: initialValue !== null,
     isOpen: !!initialValue,
-    hoverActive: {},
     hoverOpen: false,
     setClicked: (clicked?: string) => set(state => ({ ...state, clicked })),
-    setHoverActive: (key, active) =>
-      set(state => {
-        const newHoverActive = { ...state.hoverActive, [key]: active };
-        return { ...state, hoverActive: newHoverActive };
-      }),
     setHoverOpen: hoverOpen => set(state => ({ ...state, hoverOpen })),
     open: () => set(state => ({ ...state, isOpen: true })),
     close: () => set(state => ({ ...state, isOpen: false, hoverOpen: false })),
     toggle: () =>
       set(state => ({ ...state, isOpen: !state.isOpen, hasUserSet: true })),
-    clearHoverActive: () => set(state => ({ ...state, hoverActive: {} })),
   };
 });
 

--- a/packages/common/src/hooks/useDrawer.ts
+++ b/packages/common/src/hooks/useDrawer.ts
@@ -5,12 +5,12 @@ type DrawerController = {
   hoverOpen: boolean;
   isOpen: boolean;
   hasUserSet: boolean;
-  clicked?: string;
+  clickedNavPath?: string;
   open: () => void;
   close: () => void;
   toggle: () => void;
   setHoverOpen: (open: boolean) => void;
-  setClicked: (clicked?: string) => void;
+  setClickedNavPath: (clicked?: string) => void;
 };
 
 export const useDrawer = create<DrawerController>(set => {
@@ -19,7 +19,8 @@ export const useDrawer = create<DrawerController>(set => {
     hasUserSet: initialValue !== null,
     isOpen: !!initialValue,
     hoverOpen: false,
-    setClicked: (clicked?: string) => set(state => ({ ...state, clicked })),
+    setClickedNavPath: (clickedNavPath?: string) =>
+      set(state => ({ ...state, clickedNavPath })),
     setHoverOpen: hoverOpen => set(state => ({ ...state, hoverOpen })),
     open: () => set(state => ({ ...state, isOpen: true })),
     close: () => set(state => ({ ...state, isOpen: false, hoverOpen: false })),

--- a/packages/common/src/hooks/useDrawer.ts
+++ b/packages/common/src/hooks/useDrawer.ts
@@ -6,11 +6,13 @@ type DrawerController = {
   hoverOpen: boolean;
   isOpen: boolean;
   hasUserSet: boolean;
+  clicked?: string;
   open: () => void;
   close: () => void;
   toggle: () => void;
   setHoverActive: (key: string, active: boolean) => void;
   setHoverOpen: (open: boolean) => void;
+  setClicked: (clicked?: string) => void;
   clearHoverActive: () => void;
 };
 
@@ -21,6 +23,7 @@ export const useDrawer = create<DrawerController>(set => {
     isOpen: !!initialValue,
     hoverActive: {},
     hoverOpen: false,
+    setClicked: (clicked?: string) => set(state => ({ ...state, clicked })),
     setHoverActive: (key, active) =>
       set(state => {
         const newHoverActive = { ...state.hoverActive, [key]: active };

--- a/packages/common/src/styles/RTLProvider.tsx
+++ b/packages/common/src/styles/RTLProvider.tsx
@@ -4,6 +4,10 @@ import { useRtl } from '@common/intl';
 export const RTLProvider: FC = props => {
   const isRtl = useRtl();
 
+  React.useLayoutEffect(() => {
+    document.body.setAttribute('dir', isRtl ? 'rtl' : 'ltr');
+  }, [isRtl]);
+
   return (
     <div
       style={{

--- a/packages/common/src/styles/ThemeProvider.tsx
+++ b/packages/common/src/styles/ThemeProvider.tsx
@@ -32,6 +32,7 @@ const cacheRtl = createCache({
 
 const ThemeProvider: React.FC = ({ children }) => {
   const appTheme = useAppTheme();
+  console.info(`** app theme direction: ${appTheme.direction} **`);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/packages/common/src/styles/ThemeProvider.tsx
+++ b/packages/common/src/styles/ThemeProvider.tsx
@@ -32,7 +32,6 @@ const cacheRtl = createCache({
 
 const ThemeProvider: React.FC = ({ children }) => {
   const appTheme = useAppTheme();
-  console.info(`** app theme direction: ${appTheme.direction} **`);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.test.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.test.tsx
@@ -89,7 +89,6 @@ describe('AppNavLink', () => {
                   icon={<TruckIcon />}
                   text="Distribution"
                   end={false}
-                  expandOnHover
                 />
               </Box>
             }

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.test.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.test.tsx
@@ -89,6 +89,7 @@ describe('AppNavLink', () => {
                   icon={<TruckIcon />}
                   text="Distribution"
                   end={false}
+                  inactive
                 />
               </Box>
             }

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -3,7 +3,6 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Tooltip,
   ListItemButton,
   Box,
   ListItemProps,
@@ -50,7 +49,7 @@ const StyledListItem = styled<
 export interface AppNavLinkProps {
   end?: boolean; // denotes lowest level menu item, using terminology from useMatch
   icon?: JSX.Element;
-  expandOnHover?: boolean;
+  inactive?: boolean;
   text?: string;
   to: string;
   onClick?: () => void;
@@ -59,8 +58,8 @@ export interface AppNavLinkProps {
 export const AppNavLink: FC<AppNavLinkProps> = props => {
   const {
     end,
+    inactive,
     icon = <span style={{ width: 2 }} />,
-    expandOnHover,
     text,
     to,
     onClick,
@@ -77,10 +76,10 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   const CustomLink = React.useMemo(
     () =>
       React.forwardRef<HTMLAnchorElement>((linkProps, ref) =>
-        expandOnHover && !end ? (
+        !end && !!inactive ? (
           <span
             {...linkProps}
-            onClick={onHoverOver}
+            onClick={expandChildren}
             data-testid={`${to}_hover`}
           />
         ) : (
@@ -104,20 +103,20 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
     HOVER_DEBOUNCE_TIME
   );
 
+  const expandChildren = () => {
+    drawer.setClicked(to);
+  };
+
   const onHoverOver = () => {
-    if (expandOnHover) {
-      drawer.setHoverActive(to, true);
-      if (!drawer.isOpen) {
-        drawer.open();
-        drawer.setHoverOpen(true);
-      }
+    drawer.setHoverActive(to, true);
+    if (!drawer.isOpen) {
+      drawer.open();
+      drawer.setHoverOpen(true);
     }
   };
 
   const onHoverOut = () => {
-    if (expandOnHover) {
-      debouncedHoverActive(to, false);
-    }
+    debouncedHoverActive(to, false);
   };
 
   React.useEffect(() => {
@@ -130,13 +129,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   }, [drawer.hoverActive]);
 
   return (
-    <Tooltip
-      disableHoverListener={drawer.isOpen && !expandOnHover}
-      title={text || ''}
-      onClose={onHoverOut}
-      onOpen={onHoverOver}
-      PopperProps={expandOnHover ? { style: { display: 'none' } } : {}}
-    >
+    <span onMouseEnter={onHoverOver} onMouseLeave={onHoverOut}>
       <StyledListItem isSelected={selected} to={to}>
         <ListItemButton
           sx={{
@@ -160,6 +153,6 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
           </Box>
         </ListItemButton>
       </StyledListItem>
-    </Tooltip>
+    </span>
   );
 };

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -92,7 +92,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   );
 
   const expandChildren = () => {
-    drawer.setClicked(to);
+    drawer.setClickedNavPath(to);
   };
 
   return (

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -9,9 +9,8 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useMatch, Link } from 'react-router-dom';
-import { useDrawer, useDebounceCallback } from '@common/hooks';
+import { useDrawer } from '@common/hooks';
 
-const HOVER_DEBOUNCE_TIME = 500;
 const useSelectedNavMenuItem = (to: string, end: boolean): boolean => {
   // This nav menu item should be selected when lower level elements
   // are selected. For example, the route /outbound-shipment/{id} should
@@ -67,11 +66,6 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   const drawer = useDrawer();
 
   const selected = useSelectedNavMenuItem(to, !!end);
-  const debouncedClearHoverActive = useDebounceCallback(
-    drawer.clearHoverActive,
-    [],
-    HOVER_DEBOUNCE_TIME + 50
-  );
 
   const CustomLink = React.useMemo(
     () =>
@@ -90,69 +84,40 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
             role="link"
             aria-label={text}
             title={text}
-            onClick={onClick || debouncedClearHoverActive}
+            onClick={onClick}
           />
         )
       ),
     [to]
   );
 
-  const debouncedHoverActive = useDebounceCallback(
-    drawer.setHoverActive,
-    [],
-    HOVER_DEBOUNCE_TIME
-  );
-
   const expandChildren = () => {
     drawer.setClicked(to);
   };
 
-  const onHoverOver = () => {
-    drawer.setHoverActive(to, true);
-    if (!drawer.isOpen) {
-      drawer.open();
-      drawer.setHoverOpen(true);
-    }
-  };
-
-  const onHoverOut = () => {
-    debouncedHoverActive(to, false);
-  };
-
-  React.useEffect(() => {
-    const isActive = Object.values(drawer.hoverActive).some(active => active);
-    if (drawer.hoverOpen && !isActive) {
-      drawer.close();
-      drawer.setHoverOpen(false);
-      drawer.clearHoverActive();
-    }
-  }, [drawer.hoverActive]);
-
   return (
-    <span onMouseEnter={onHoverOver} onMouseLeave={onHoverOut}>
-      <StyledListItem isSelected={selected} to={to}>
-        <ListItemButton
-          sx={{
-            ...getListItemCommonStyles(),
-            '&.MuiListItemButton-root:hover': {
-              backgroundColor: 'transparent',
-            },
-            '& .MuiTypography-root': {
-              textOverflow: 'ellipsis',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-            },
-          }}
-          disableGutters
-          component={CustomLink}
-        >
-          <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
-          <Box className="navLinkText">
-            <Box width={10} />
-            <ListItemText primary={text} />
-          </Box>
-        </ListItemButton>
-      </StyledListItem>
-    </span>
+    <StyledListItem isSelected={selected} to={to}>
+      <ListItemButton
+        sx={{
+          ...getListItemCommonStyles(),
+          '&.MuiListItemButton-root:hover': {
+            backgroundColor: 'transparent',
+          },
+          '& .MuiTypography-root': {
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+          },
+        }}
+        disableGutters
+        component={CustomLink}
+      >
+        <ListItemIcon sx={{ minWidth: 20 }}>{icon}</ListItemIcon>
+        <Box className="navLinkText">
+          <Box width={10} />
+          <ListItemText primary={text} />
+        </Box>
+      </ListItemButton>
+    </StyledListItem>
   );
 };

--- a/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -19,6 +19,7 @@ import {
   AppNavLink,
   useIsMediumScreen,
   useLocalStorage,
+  useDebounceCallback,
 } from '@openmsupply-client/common';
 import { AppRoute, ExternalURL } from '@openmsupply-client/config';
 import {
@@ -28,6 +29,8 @@ import {
   ReplenishmentNav,
 } from '../Navigation';
 import { AppDrawerIcon } from './AppDrawerIcon';
+
+const HOVER_DEBOUNCE_TIME = 500;
 
 const ToolbarIconContainer = styled(Box)({
   display: 'flex',
@@ -126,22 +129,6 @@ const StyledDrawer = styled(Box, {
     '& div > ul > li': {
       width: 40,
     },
-    '&:hover': {
-      ...openedMixin(theme),
-      '& .navLinkText': {
-        display: 'inline-flex',
-        flex: 1,
-      },
-      '& div > ul > li': {
-        width: 200,
-      },
-    },
-    '&:not(:hover)': {
-      ...closedMixin(theme),
-      '& div > ul > li': {
-        width: 40,
-      },
-    },
   }),
 }));
 
@@ -159,6 +146,22 @@ export const AppDrawer: React.FC = () => {
     if (!isMediumScreen && !drawer.isOpen) drawer.open();
   }, [isMediumScreen]);
 
+  const onHoverOut = useDebounceCallback(
+    () => {
+      drawer.close();
+      drawer.setHoverOpen(false);
+    },
+    [],
+    HOVER_DEBOUNCE_TIME
+  );
+
+  const onHoverOver = () => {
+    if (!drawer.isOpen) {
+      drawer.open();
+      drawer.setHoverOpen(true);
+    }
+  };
+
   return (
     <StyledDrawer
       data-testid="drawer"
@@ -174,7 +177,7 @@ export const AppDrawer: React.FC = () => {
           icon={<AppDrawerIcon />}
         />
       </ToolbarIconContainer>
-      <UpperListContainer>
+      <UpperListContainer onMouseEnter={onHoverOver} onMouseLeave={onHoverOut}>
         <List>
           <AppNavLink
             to={AppRoute.Dashboard}

--- a/packages/host/src/components/Navigation/CatalogueNav.tsx
+++ b/packages/host/src/components/Navigation/CatalogueNav.tsx
@@ -22,18 +22,24 @@ export const CatalogueNav: FC = () => {
         end={false}
         to={AppRoute.Catalogue}
         icon={<ListIcon color="primary" />}
-        expandOnHover
         text={t('catalogue')}
+        inactive
       />
       <Collapse in={isActive}>
         <List>
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Catalogue)
               .addPart(AppRoute.Items)
               .build()}
             text={t('items')}
+          />
+          <AppNavLink
+            end
+            to={RouteBuilder.create(AppRoute.Catalogue)
+              .addPart(AppRoute.MasterLists)
+              .build()}
+            text={t('master-lists')}
           />
         </List>
       </Collapse>

--- a/packages/host/src/components/Navigation/DistributionNav.tsx
+++ b/packages/host/src/components/Navigation/DistributionNav.tsx
@@ -22,14 +22,13 @@ export const DistributionNav: FC = () => {
         end={false}
         to={AppRoute.Distribution}
         icon={<TruckIcon color="primary" fontSize="small" />}
-        expandOnHover
         text={t('distribution')}
+        inactive
       />
       <Collapse in={isActive}>
         <List>
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Distribution)
               .addPart(AppRoute.OutboundShipment)
               .build()}
@@ -37,7 +36,6 @@ export const DistributionNav: FC = () => {
           />
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Distribution)
               .addPart(AppRoute.CustomerRequisition)
               .build()}
@@ -45,7 +43,6 @@ export const DistributionNav: FC = () => {
           />
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Distribution)
               .addPart(AppRoute.Customer)
               .build()}

--- a/packages/host/src/components/Navigation/InventoryNav.tsx
+++ b/packages/host/src/components/Navigation/InventoryNav.tsx
@@ -22,14 +22,13 @@ export const InventoryNav: FC = () => {
         end={false}
         to={AppRoute.Inventory}
         icon={<StockIcon color="primary" fontSize="small" />}
-        expandOnHover
         text={t('inventory')}
+        inactive
       />
       <Collapse in={isActive}>
         <List>
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Inventory)
               .addPart(AppRoute.Locations)
               .build()}
@@ -37,15 +36,6 @@ export const InventoryNav: FC = () => {
           />
           <AppNavLink
             end
-            expandOnHover
-            to={RouteBuilder.create(AppRoute.Inventory)
-              .addPart(AppRoute.MasterLists)
-              .build()}
-            text={t('master-lists')}
-          />
-          <AppNavLink
-            end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Inventory)
               .addPart(AppRoute.Stock)
               .build()}
@@ -53,7 +43,6 @@ export const InventoryNav: FC = () => {
           />
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Inventory)
               .addPart(AppRoute.Stocktakes)
               .build()}

--- a/packages/host/src/components/Navigation/ReplenishmentNav.tsx
+++ b/packages/host/src/components/Navigation/ReplenishmentNav.tsx
@@ -23,14 +23,13 @@ export const ReplenishmentNav: FC = () => {
         end={false}
         to={AppRoute.Replenishment}
         icon={<SuppliersIcon color="primary" fontSize="small" />}
-        expandOnHover
         text={t('replenishment')}
+        inactive
       />
       <Collapse in={isActive}>
         <List>
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Replenishment)
               .addPart(AppRoute.InboundShipment)
               .build()}
@@ -38,7 +37,6 @@ export const ReplenishmentNav: FC = () => {
           />
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Replenishment)
               .addPart(AppRoute.InternalOrder)
               .build()}
@@ -47,7 +45,6 @@ export const ReplenishmentNav: FC = () => {
 
           <AppNavLink
             end
-            expandOnHover
             to={RouteBuilder.create(AppRoute.Replenishment)
               .addPart(AppRoute.Suppliers)
               .build()}

--- a/packages/host/src/components/Navigation/useNestedNav.ts
+++ b/packages/host/src/components/Navigation/useNestedNav.ts
@@ -4,11 +4,11 @@ interface NestedNavState {
   isActive: boolean;
 }
 
-const matchPath = (path: string, clicked?: string) =>
-  `/${clicked?.replace(/^\//, '')}/`.startsWith(path.replace(/\*$/, ''));
+const matchPath = (path: string, clickedNavPath?: string) =>
+  `/${clickedNavPath?.replace(/^\//, '')}/`.startsWith(path.replace(/\*$/, ''));
 
 export const useNestedNav = (path: string): NestedNavState => {
-  const { clicked, isOpen } = useDrawer();
+  const { clickedNavPath, isOpen } = useDrawer();
   const match = useMatch(path);
   const [expanded, setExpanded] = useState(false);
 
@@ -16,5 +16,5 @@ export const useNestedNav = (path: string): NestedNavState => {
     setExpanded(!!match);
   }, [match]);
 
-  return { isActive: isOpen && (expanded || matchPath(path, clicked)) };
+  return { isActive: isOpen && (expanded || matchPath(path, clickedNavPath)) };
 };

--- a/packages/host/src/components/Navigation/useNestedNav.ts
+++ b/packages/host/src/components/Navigation/useNestedNav.ts
@@ -1,24 +1,20 @@
 import { useEffect, useState } from 'react';
 import { useMatch, useDrawer } from '@openmsupply-client/common';
-
-const matchPath = (key: string, path: string) =>
-  `/${key.replace(/^\//, '')}/`.startsWith(path.replace(/\*$/, ''));
-
 interface NestedNavState {
   isActive: boolean;
 }
 
+const matchPath = (path: string, clicked?: string) =>
+  `/${clicked?.replace(/^\//, '')}/`.startsWith(path.replace(/\*$/, ''));
+
 export const useNestedNav = (path: string): NestedNavState => {
-  const { hoverActive, isOpen } = useDrawer();
+  const { clicked, isOpen } = useDrawer();
   const match = useMatch(path);
   const [expanded, setExpanded] = useState(false);
-  const hovered = Object.keys(hoverActive).some(
-    key => matchPath(key, path) && hoverActive[key]
-  );
 
   useEffect(() => {
     setExpanded(!!match);
   }, [match]);
 
-  return { isActive: isOpen && (expanded || hovered) };
+  return { isActive: isOpen && (expanded || matchPath(path, clicked)) };
 };

--- a/packages/host/src/routers/CatalogueRouter.tsx
+++ b/packages/host/src/routers/CatalogueRouter.tsx
@@ -6,16 +6,30 @@ const ItemService = React.lazy(
   () => import('@openmsupply-client/system/src/Item/Service/Service')
 );
 
+const MasterListService = React.lazy(
+  () => import('@openmsupply-client/system/src/MasterList/Service/Service')
+);
+
 const fullItemPath = RouteBuilder.create(AppRoute.Catalogue)
   .addPart(AppRoute.Items)
   .addWildCard()
   .build();
 
+const fullMasterListPath = RouteBuilder.create(AppRoute.Catalogue)
+  .addPart(AppRoute.MasterLists)
+  .addWildCard()
+  .build();
+
 export const CatalogueRouter: FC = () => {
   const gotoItems = useMatch(fullItemPath);
+  const gotoMasterLists = useMatch(fullMasterListPath);
 
   if (gotoItems) {
     return <ItemService />;
+  }
+
+  if (gotoMasterLists) {
+    return <MasterListService />;
   }
 
   const notFoundRoute = RouteBuilder.create(AppRoute.PageNotFound).build();

--- a/packages/host/src/routers/InventoryRouter.tsx
+++ b/packages/host/src/routers/InventoryRouter.tsx
@@ -14,10 +14,6 @@ const LocationService = React.lazy(
   () => import('@openmsupply-client/system/src/Location/Service/Service')
 );
 
-const MasterListService = React.lazy(
-  () => import('@openmsupply-client/system/src/MasterList/Service/Service')
-);
-
 const fullItemPath = RouteBuilder.create(AppRoute.Inventory)
   .addPart(AppRoute.Stock)
   .addWildCard()
@@ -32,16 +28,10 @@ const fullLocationPath = RouteBuilder.create(AppRoute.Inventory)
   .addPart(AppRoute.Locations)
   .build();
 
-const fullMasterListPath = RouteBuilder.create(AppRoute.Inventory)
-  .addPart(AppRoute.MasterLists)
-  .addWildCard()
-  .build();
-
 export const InventoryRouter: FC = () => {
   const gotoStock = useMatch(fullItemPath);
   const gotoStocktakes = useMatch(fullStocktakePath);
   const gotoLocations = useMatch(fullLocationPath);
-  const gotoMasterLists = useMatch(fullMasterListPath);
 
   if (gotoStock) {
     return <StockService />;
@@ -53,9 +43,6 @@ export const InventoryRouter: FC = () => {
 
   if (gotoLocations) {
     return <LocationService />;
-  }
-  if (gotoMasterLists) {
-    return <MasterListService />;
   }
 
   const notFoundRoute = RouteBuilder.create(AppRoute.PageNotFound).build();


### PR DESCRIPTION
Fixes #815 

Removes the dodgy hover / expand function on the drawer. Wasn't working terribly well. 
Took the hover off the menu elements and moved to the drawer itself, no need to be on elements with the move to an onClick for the parent nav items.

Also shifted master lists to Catalogue rather than Inventory as suggested by Richard - made sense to me.