### PR TITLE
#895 internal order columns

### DIFF
--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -113,6 +113,7 @@
   "label.selected": "Selected",
   "label.sell": "Sell",
   "label.shipped": "Shipped",
+  "label.months": "Months",
   "label.status": "Status",
   "label.supplier": "Supplier",
   "label.total": "Total",

--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -113,7 +113,7 @@
   "label.selected": "Selected",
   "label.sell": "Sell",
   "label.shipped": "Shipped",
-  "label.months": "Months",
+  "label.month": "month",
   "label.status": "Status",
   "label.supplier": "Supplier",
   "label.total": "Total",

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -39,46 +39,19 @@ export type ColumnKey =
   | 'stocktakeNumber'
   | 'description'
   | 'stocktakeDatetime'
-  | 'monthlyConsumption'
-  | 'previousStockOnHand'
-  | 'calculatedQuantity'
-  | 'requestedQuantity'
-  | 'forecastMethod';
+  | 'monthlyConsumption';
 
 const getColumnLookup = <T extends DomainObject>(): Record<
   ColumnKey,
   ColumnDefinition<T>
 > => ({
-  requestedQuantity: {
-    key: 'requestedQuantity',
-    label: 'label.requested-quantity',
-    align: ColumnAlign.Right,
-    width: 100,
-  },
   monthlyConsumption: {
     key: 'monthlyConsumption',
     label: 'label.average-monthly-consumption',
     align: ColumnAlign.Left,
     width: 100,
   },
-  previousStockOnHand: {
-    key: 'previousStockOnHand',
-    label: 'label.stock-on-hand',
-    align: ColumnAlign.Left,
-    width: 125,
-  },
-  calculatedQuantity: {
-    key: 'calculatedQuantity',
-    label: 'label.forecast-quantity',
-    align: ColumnAlign.Left,
-    width: 125,
-  },
-  forecastMethod: {
-    key: 'forecastMethod',
-    label: 'label.forecast-method',
-    align: ColumnAlign.Left,
-    width: 55,
-  },
+
   numberOfPacks: {
     key: 'numberOfPacks',
     format: ColumnFormat.Integer,

--- a/packages/common/src/utils/NumUtils.test.ts
+++ b/packages/common/src/utils/NumUtils.test.ts
@@ -1,0 +1,12 @@
+import { NumUtils } from './NumUtils';
+describe('NumUtils', () => {
+  it('is defined', () => {
+    expect(NumUtils.isPositive).toBeDefined();
+  });
+
+  it('isPositive', () => {
+    expect(NumUtils.isPositive(0)).toBe(false);
+    expect(NumUtils.isPositive(1)).toBe(true);
+    expect(NumUtils.isPositive(-1)).toBe(false);
+  });
+});

--- a/packages/common/src/utils/NumUtils.ts
+++ b/packages/common/src/utils/NumUtils.ts
@@ -1,0 +1,5 @@
+export const NumUtils = {
+  isPositive: (num: number): boolean => {
+    return num > 0;
+  },
+};

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { v4 } from 'uuid';
 
+export * from './quantities';
 export * from './formatters';
 export * from './testing';
 export * from './debounce';

--- a/packages/common/src/utils/quantities.test.ts
+++ b/packages/common/src/utils/quantities.test.ts
@@ -1,0 +1,39 @@
+import { suggestedQuantity } from './quantities';
+
+describe('suggestedQuantity', () => {
+  it('is defined', () => {
+    expect(suggestedQuantity).toBeDefined();
+  });
+
+  it('calculates the correct suggested quantity for a basic case', () => {
+    expect(suggestedQuantity(100, 100, 3)).toBe(200);
+  });
+
+  it('calculates the correct suggested quantity when amc is zero', () => {
+    expect(suggestedQuantity(0, 100, 3)).toBe(0);
+  });
+
+  it('calculates the correct suggested quantity when amc is negative', () => {
+    expect(suggestedQuantity(-10, 100, 3)).toBe(0);
+  });
+
+  it('calculates the correct suggested quantity when soh is zero', () => {
+    expect(suggestedQuantity(100, 0, 3)).toBe(300);
+  });
+
+  it('calculates the correct suggested quantity when soh is negative', () => {
+    expect(suggestedQuantity(100, -100, 3)).toBe(300);
+  });
+
+  it('calculates the correct suggested quantity when soh is very high', () => {
+    expect(suggestedQuantity(10, 1000, 3)).toBe(0);
+  });
+
+  it('calculates the correct suggested quantity when mos is zero', () => {
+    expect(suggestedQuantity(10, 100, 0)).toBe(0);
+  });
+
+  it('calculates the correct suggested quantity when mos is negative', () => {
+    expect(suggestedQuantity(-10, 100, 3)).toBe(0);
+  });
+});

--- a/packages/common/src/utils/quantities.ts
+++ b/packages/common/src/utils/quantities.ts
@@ -1,8 +1,9 @@
+import { NumUtils } from './NumUtils';
 export const suggestedQuantity = (amc: number, soh: number, mos: number) => {
   // If there is no consumption, don't suggest any
-  if (!amc || amc < 0) return 0;
+  if (!NumUtils.isPositive(amc)) return 0;
   // If there is no months of stock to order to, don't suggest stock to be ordered
-  if (!mos || amc < 0) return 0;
+  if (!NumUtils.isPositive(mos)) return 0;
 
   // Total amount to potentially order
   const total = amc * mos;

--- a/packages/common/src/utils/quantities.ts
+++ b/packages/common/src/utils/quantities.ts
@@ -1,14 +1,14 @@
 export const suggestedQuantity = (amc: number, soh: number, mos: number) => {
   // If there is no consumption, don't suggest any
-  if (!amc) return 0;
+  if (!amc || amc < 0) return 0;
   // If there is no months of stock to order to, don't suggest stock to be ordered
-  if (!mos) return 0;
+  if (!mos || amc < 0) return 0;
 
   // Total amount to potentially order
   const total = amc * mos;
 
   // Subtract the available stock on hand
-  const suggested = total - soh;
+  const suggested = total - Math.max(soh, 0);
 
-  return suggested;
+  return Math.max(suggested, 0);
 };

--- a/packages/common/src/utils/quantities.ts
+++ b/packages/common/src/utils/quantities.ts
@@ -1,0 +1,14 @@
+export const suggestedQuantity = (amc: number, soh: number, mos: number) => {
+  // If there is no consumption, don't suggest any
+  if (!amc) return 0;
+  // If there is no months of stock to order to, don't suggest stock to be ordered
+  if (!mos) return 0;
+
+  // Total amount to potentially order
+  const total = amc * mos;
+
+  // Subtract the available stock on hand
+  const suggested = total - soh;
+
+  return suggested;
+};

--- a/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
+++ b/packages/requisitions/src/RequestRequisition/DetailView/columns.ts
@@ -53,7 +53,9 @@ export const useRequestRequisitionColumns = ({
             itemStats;
 
           const monthsString = availableMonthsOfStockOnHand
-            ? `${availableMonthsOfStockOnHand} ${t('label.months')}`
+            ? `${availableMonthsOfStockOnHand} (${t('label.month', {
+                count: availableMonthsOfStockOnHand,
+              })})`
             : '';
           return `${availableStockOnHand} ${monthsString}`;
         },

--- a/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/columns.ts
@@ -18,7 +18,12 @@ export const useResponseRequisitionColumns = ({
   sortBy,
 }: UseResponseRequisitionColumnOptions): Column<ResponseRequisitionLineFragment>[] =>
   useColumns<ResponseRequisitionLineFragment>(
-    ['itemCode', 'itemName', 'comment', GenericColumnKey.Selection],
+    [
+      ['itemCode', { accessor: ({ rowData }) => rowData.item.code }],
+      ['itemName', { accessor: ({ rowData }) => rowData.item.name }],
+      'comment',
+      GenericColumnKey.Selection,
+    ],
     { onChangeSortBy, sortBy },
     [sortBy]
   );


### PR DESCRIPTION
Fixes #895

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/35858975/155628111-03d09e65-0f79-4275-ac03-dd5533076fbf.png">


- Have updated the columns for request and the item columns for responses. I'm not sure about the columns for responses I don't think the spreadsheet is accurate https://docs.google.com/spreadsheets/d/1H0Rv1DEOgW0cE07wpfc_KivLf8TcNhYDqlwRp92x-To/edit#gid=320810900&range=A233:S233 and haven't seen any mock ups 🤔 