### PR TITLE
Set theme direction

### DIFF
--- a/packages/common/src/styles/theme.ts
+++ b/packages/common/src/styles/theme.ts
@@ -113,7 +113,7 @@ export const themeOptions = {
       xl: 1537,
     },
   },
-  direction: 'rtl' as Direction,
+  direction: 'ltr' as Direction,
   mixins: {
     dialog: {
       button: {

--- a/packages/common/src/styles/useAppTheme.ts
+++ b/packages/common/src/styles/useAppTheme.ts
@@ -1,28 +1,18 @@
 import { Direction } from '@mui/material/styles';
 import { Theme } from '@mui/material';
-import { useState, useEffect } from 'react';
 import { themeOptions, createTheme } from './theme';
 import { useRtl } from '@common/intl';
 import { useLocalStorage } from '../localStorage';
 import merge from 'lodash/merge';
 
 export const useAppTheme = (): Theme => {
-  const [customTheme] = useLocalStorage('/theme/custom');
-  const appTheme = customTheme
-    ? createTheme(merge(themeOptions, customTheme))
-    : createTheme(themeOptions);
-  const [currentTheme, setTheme] = useState(appTheme);
   const isRtl = useRtl();
+  const [customTheme] = useLocalStorage('/theme/custom');
+  const direction: Direction = isRtl ? 'rtl' : 'ltr';
+  const rtlThemeOptions = { ...themeOptions, direction };
+  const appTheme = customTheme
+    ? createTheme(merge(rtlThemeOptions, customTheme))
+    : createTheme(rtlThemeOptions);
 
-  const setDirection = (newDirection: Direction) => {
-    const newTheme = { ...currentTheme, direction: newDirection };
-    setTheme(newTheme);
-  };
-
-  useEffect(() => {
-    const newDirection = isRtl ? 'rtl' : 'ltr';
-    setDirection(newDirection);
-  }, [isRtl]);
-
-  return currentTheme;
+  return appTheme;
 };


### PR DESCRIPTION
Fixes #886 ( maybe!! )

Setting the direction to `ltr` and reloading in Arabic makes the autocomplete behave incorrectly in a different way ( the caret is incorrect and moves when the select is expanded ).. so I figure this is similar.

The actual problem was when using an ltr language, the mui classes `rtl-` were applied to all the things. so there was something amiss with the mui theme. Hoping this helps 🤞 