### PR TITLE
#911 invoice type cleanup 2

### DIFF
--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -15,15 +15,6 @@ export interface Name extends NameNode {
   isSupplier: boolean;
 }
 
-export interface ItemRow extends DomainObject {
-  id: string;
-  isVisible: boolean;
-  code: string;
-  name: string;
-  availableQuantity: number;
-  unitName?: string;
-}
-
 export interface Item extends ItemNode, DomainObject {
   id: string;
   isVisible: boolean;

--- a/packages/inventory/src/Stocktake/api/hooks.ts
+++ b/packages/inventory/src/Stocktake/api/hooks.ts
@@ -1,5 +1,4 @@
 import { useMemo, useCallback } from 'react';
-
 import {
   useNavigate,
   useTranslation,
@@ -24,13 +23,13 @@ import {
 import { StocktakeSummaryItem } from '../../types';
 import { StocktakeApi, getStocktakeQueries } from './api';
 import { useStocktakeColumns } from '../DetailView';
+import { canDeleteStocktake } from '../../utils';
 import {
   getSdk,
   StocktakeFragment,
   StocktakeRowFragment,
   StocktakeLineFragment,
 } from './operations.generated';
-import { canDeleteStocktake } from '../../utils';
 
 export const useStocktakeApi = (): StocktakeApi => {
   const { client } = useOmSupplyApi();

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -18,8 +18,8 @@ import { AppBarButtons } from './AppBarButtons';
 import { SidePanel } from './SidePanel';
 import { GeneralTab } from './GeneralTab';
 import { InboundLineEdit } from './modals/InboundLineEdit';
-import { InvoiceLine, InboundShipmentItem } from '../../types';
-import { useInbound } from '../api';
+import { InboundItem } from '../../types';
+import { useInbound, InboundLineFragment } from '../api';
 
 export const DetailView: FC = () => {
   const { data, isLoading } = useInbound();
@@ -28,7 +28,7 @@ export const DetailView: FC = () => {
   const t = useTranslation('replenishment');
 
   const onRowClick = React.useCallback(
-    (line: InboundShipmentItem | InvoiceLine) => {
+    (line: InboundItem | InboundLineFragment) => {
       const item = toItem(line);
       onOpen(item);
     },

--- a/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
@@ -12,11 +12,15 @@ import {
 } from '@openmsupply-client/common';
 import React, { FC } from 'react';
 import { getStatusTranslator, inboundStatuses } from '../../../utils';
-import { Invoice } from '../../../types';
-import { useInbound, useInboundFields, useIsInboundEditable } from '../../api';
+import {
+  InboundFragment,
+  useInbound,
+  useInboundFields,
+  useIsInboundEditable,
+} from '../../api';
 import { StatusChangeButton } from './StatusChangeButton';
 
-const createStatusLog = (invoice: Invoice) => {
+const createStatusLog = (invoice: InboundFragment) => {
   const statusIdx = inboundStatuses.findIndex(s => invoice.status === s);
   const statusLog: Record<InvoiceNodeStatus, null | string | undefined> = {
     [InvoiceNodeStatus.New]: null,

--- a/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
@@ -9,8 +9,8 @@ import {
   Switch,
   MiniTable,
 } from '@openmsupply-client/common';
-import { InboundShipmentItem, InvoiceLine } from '../../types';
-import { useInboundItems, useInboundLines } from '../api';
+import { InboundItem } from '../../types';
+import { useInboundItems, useInboundLines, InboundLineFragment } from '../api';
 import { useExpansionColumns, useInboundShipmentColumns } from './columns';
 
 interface GeneralTabProps<T extends DomainObject> {
@@ -20,7 +20,7 @@ interface GeneralTabProps<T extends DomainObject> {
 const Expando = ({
   rowData,
 }: {
-  rowData: InvoiceLine | InboundShipmentItem;
+  rowData: InboundLineFragment | InboundItem;
 }) => {
   const expandoColumns = useExpansionColumns();
   if ('lines' in rowData && rowData.lines.length > 1) {
@@ -31,7 +31,7 @@ const Expando = ({
 };
 
 export const GeneralTab: FC<
-  GeneralTabProps<InboundShipmentItem | InvoiceLine>
+  GeneralTabProps<InboundItem | InboundLineFragment>
 > = React.memo(({ onRowClick }) => {
   const { pagination } = usePagination();
   const t = useTranslation('replenishment');

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -19,8 +19,9 @@ import {
   useInboundItems,
   useInboundLines,
   useIsInboundEditable,
+  InboundLineFragment,
 } from '../api';
-import { InboundShipmentItem, InvoiceLine } from '../../types';
+import { InboundItem } from '../../types';
 
 export const Toolbar: FC = () => {
   const isEditable = useIsInboundEditable();
@@ -44,7 +45,7 @@ export const Toolbar: FC = () => {
           Object.keys(state.rowState)
             .filter(id => state.rowState[id]?.isSelected)
             .map(selectedId => data?.find(({ id }) => selectedId === id))
-            .filter(Boolean) as InboundShipmentItem[]
+            .filter(Boolean) as InboundItem[]
         )
           .map(({ lines }) => lines)
           .flat()
@@ -56,7 +57,7 @@ export const Toolbar: FC = () => {
           Object.keys(state.rowState)
             .filter(id => state.rowState[id]?.isSelected)
             .map(selectedId => lines.find(({ id }) => selectedId === id))
-            .filter(Boolean) as InvoiceLine[]
+            .filter(Boolean) as InboundLineFragment[]
         ).map(({ id }) => id),
       };
     }

--- a/packages/invoices/src/InboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/columns.ts
@@ -9,12 +9,13 @@ import {
   useColumns,
   Column,
 } from '@openmsupply-client/common';
-import { InvoiceLine, InboundShipmentItem } from './../../types';
+import { InboundItem } from './../../types';
+import { InboundLineFragment } from '../api';
 
 export const useInboundShipmentColumns = (): Column<
-  InvoiceLine | InboundShipmentItem
+  InboundLineFragment | InboundItem
 >[] =>
-  useColumns<InvoiceLine | InboundShipmentItem>(
+  useColumns<InboundLineFragment | InboundItem>(
     [
       [
         getNotePopoverColumn(),
@@ -167,7 +168,7 @@ export const useInboundShipmentColumns = (): Column<
     []
   );
 
-export const useExpansionColumns = (): Column<InvoiceLine>[] =>
+export const useExpansionColumns = (): Column<InboundLineFragment>[] =>
   useColumns([
     'batch',
     'expiryDate',

--- a/packages/invoices/src/InboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/columns.ts
@@ -10,7 +10,7 @@ import {
   Column,
 } from '@openmsupply-client/common';
 import { InboundItem } from './../../types';
-import { InboundLineFragment } from '../api';
+import { InboundLineFragment, PartialLocationFragment } from '../api';
 
 export const useInboundShipmentColumns = (): Column<
   InboundLineFragment | InboundItem
@@ -44,9 +44,10 @@ export const useInboundShipmentColumns = (): Column<
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return ifTheSameElseDefault(lines, 'itemCode', '');
+              const items = lines.map(({ item }) => item);
+              return ifTheSameElseDefault(items, 'code', '');
             } else {
-              return rowData.itemCode;
+              return rowData.item.code;
             }
           },
         },
@@ -57,9 +58,10 @@ export const useInboundShipmentColumns = (): Column<
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return ifTheSameElseDefault(lines, 'itemName', '');
+              const items = lines.map(({ item }) => item);
+              return ifTheSameElseDefault(items, 'name', '');
             } else {
-              return rowData.itemName;
+              return rowData.item.name;
             }
           },
         },
@@ -102,9 +104,12 @@ export const useInboundShipmentColumns = (): Column<
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return ifTheSameElseDefault(lines, 'locationName', '');
+              const locations = lines
+                .map(({ location }) => location)
+                .filter(Boolean) as PartialLocationFragment[];
+              return ifTheSameElseDefault(locations, 'name', '');
             } else {
-              return rowData?.locationName;
+              return rowData.location?.name ?? '';
             }
           },
         },

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -20,7 +20,7 @@ import {
   useDirtyCheck,
   useConfirmOnLeaving,
 } from '@openmsupply-client/common';
-import { InvoiceLine } from '../../../../types';
+import { InboundLineEditPanel } from './InboundLineEditPanel';
 import { QuantityTable, PricingTable, LocationTable } from './TabTables';
 import { InboundLineEditForm } from './InboundLineEditForm';
 import {
@@ -28,8 +28,9 @@ import {
   useInboundFields,
   useSaveInboundLines,
   useNextItem,
+  InboundLineFragment,
 } from '../../../api';
-import { InboundLineEditPanel } from './InboundLineEditPanel';
+import { DraftInboundLine } from '../../../../types';
 
 interface InboundLineEditProps {
   item: Item | null;
@@ -44,29 +45,13 @@ enum Tabs {
   Location = 'Location',
 }
 
-export type DraftInboundLine = Pick<
-  InvoiceLine,
-  | 'id'
-  | 'batch'
-  | 'costPricePerPack'
-  | 'sellPricePerPack'
-  | 'expiryDate'
-  | 'location'
-  | 'numberOfPacks'
-  | 'packSize'
-  | 'itemId'
-  | 'invoiceId'
-> & {
-  isCreated?: boolean;
-  isUpdated?: boolean;
-};
-
 const createDraftInvoiceLine = (
   itemId: string,
   invoiceId: string,
-  seed?: InvoiceLine
+  seed?: InboundLineFragment
 ): DraftInboundLine => {
   const draftLine: DraftInboundLine = {
+    __typename: 'InvoiceLineNode',
     id: generateUUID(),
     itemId,
     invoiceId,

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -78,7 +78,7 @@ const useDraftInboundLines = (itemId: string) => {
   useEffect(() => {
     if (lines && itemId) {
       const drafts = lines.map(line =>
-        createDraftInvoiceLine(line.itemId, line.invoiceId, line)
+        createDraftInvoiceLine(line.item.id, line.invoiceId, line)
       );
       if (drafts.length === 0) drafts.push(createDraftInvoiceLine(itemId, id));
       setDraftLines(drafts);

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditPanel.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { styled, TabPanel, Box } from '@openmsupply-client/common';
-import { DraftInboundLine } from './InboundLineEdit';
+import { DraftInboundLine } from '../../../../types';
 
 const StyledTabPanel = styled(TabPanel)({
   height: '100%',

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -11,7 +11,7 @@ import {
   Theme,
   alpha,
 } from '@openmsupply-client/common';
-import { DraftInboundLine } from './InboundLineEdit';
+import { DraftInboundLine } from '../../../../types';
 import { getLocationInputColumn } from '@openmsupply-client/system';
 
 interface TableProps {

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -14,9 +14,8 @@ import {
 import { NameSearchModal } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
-import { InvoiceRow } from '../../types';
 import { getStatusTranslator } from '../../utils';
-import { useInbounds, useCreateInbound } from '../api';
+import { useInbounds, useCreateInbound, InboundRowFragment } from '../api';
 
 export const InboundListView: FC = () => {
   const { mutate } = useCreateInbound();
@@ -34,7 +33,7 @@ export const InboundListView: FC = () => {
 
   const t = useTranslation();
 
-  const columns = useColumns<InvoiceRow>(
+  const columns = useColumns<InboundRowFragment>(
     [
       [getNameAndColorColumn(), { setter: () => {} }],
       [

--- a/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/Toolbar.tsx
@@ -8,8 +8,7 @@ import {
   FilterController,
   SearchBar,
 } from '@openmsupply-client/common';
-import { InvoiceRow } from '../../types';
-import { useDeleteSelectedInbounds } from '../api';
+import { useDeleteSelectedInbounds, InboundRowFragment } from '../api';
 
 export const Toolbar: FC<{
   filter: FilterController;
@@ -17,7 +16,7 @@ export const Toolbar: FC<{
   const t = useTranslation();
   const onDelete = useDeleteSelectedInbounds();
 
-  const key = 'comment' as keyof InvoiceRow;
+  const key = 'comment' as keyof InboundRowFragment;
   const filterString = filter.filterBy?.[key]?.like as string;
 
   return (

--- a/packages/invoices/src/InboundShipment/api/api.ts
+++ b/packages/invoices/src/InboundShipment/api/api.ts
@@ -176,7 +176,7 @@ export const getInboundQueries = (sdk: Sdk, storeId: string) => ({
   ): Promise<number> => {
     const result = await sdk.insertInboundShipment({
       id: patch.id,
-      otherPartyId: patch?.otherPartyId,
+      otherPartyId: patch.otherPartyId,
       storeId,
     });
 

--- a/packages/invoices/src/InboundShipment/api/hooks.ts
+++ b/packages/invoices/src/InboundShipment/api/hooks.ts
@@ -17,8 +17,9 @@ import {
   useOmSupplyApi,
   useMutation,
   useFieldsSelector,
+  InvoiceNodeStatus,
 } from '@openmsupply-client/common';
-import { canDeleteInvoice, inboundLinesToSummaryItems } from './../../utils';
+import { inboundLinesToSummaryItems } from './../../utils';
 import { InboundItem } from './../../types';
 import {
   getSdk,
@@ -234,7 +235,9 @@ export const useDeleteSelectedInbounds = () => {
   const deleteAction = () => {
     const numberSelected = selectedRows.length;
     if (selectedRows && numberSelected > 0) {
-      const canDeleteRows = selectedRows.every(canDeleteInvoice);
+      const canDeleteRows = selectedRows.every(
+        ({ status }) => status === InvoiceNodeStatus.New
+      );
       if (!canDeleteRows) {
         const cannotDeleteSnack = info(t('messages.cant-delete-invoices'));
         cannotDeleteSnack();

--- a/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -4,11 +4,13 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type InboundShipmentLineFragment = { __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null };
+export type PartialInboundLineFragment = { __typename: 'InvoiceLineNode', id: string, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, itemId: string, invoiceId: string, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null };
 
-export type InboundShipmentFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+export type InboundLineFragment = { __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null };
 
-export type InboundShipmentRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+export type InboundFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+
+export type InboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
 
 export type InvoicesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -87,8 +89,27 @@ export type InvoiceCountsQueryVariables = Types.Exact<{
 
 export type InvoiceCountsQuery = { __typename: 'Queries', invoiceCounts: { __typename: 'InvoiceCounts', inbound: { __typename: 'InboundInvoiceCounts', created: { __typename: 'InvoiceCountsSummary', today: number, thisWeek: number } } } };
 
-export const InboundShipmentLineFragmentDoc = gql`
-    fragment InboundShipmentLine on InvoiceLineNode {
+export const PartialInboundLineFragmentDoc = gql`
+    fragment PartialInboundLine on InvoiceLineNode {
+  id
+  batch
+  costPricePerPack
+  sellPricePerPack
+  expiryDate
+  numberOfPacks
+  packSize
+  itemId
+  invoiceId
+  location {
+    id
+    code
+    name
+    onHold
+  }
+}
+    `;
+export const InboundLineFragmentDoc = gql`
+    fragment InboundLine on InvoiceLineNode {
   __typename
   type
   batch
@@ -167,8 +188,8 @@ export const InboundShipmentLineFragmentDoc = gql`
   }
 }
     `;
-export const InboundShipmentFragmentDoc = gql`
-    fragment InboundShipment on InvoiceNode {
+export const InboundFragmentDoc = gql`
+    fragment Inbound on InvoiceNode {
   __typename
   id
   comment
@@ -189,7 +210,7 @@ export const InboundShipmentFragmentDoc = gql`
   lines {
     __typename
     nodes {
-      ...InboundShipmentLine
+      ...InboundLine
     }
     totalCount
   }
@@ -211,9 +232,9 @@ export const InboundShipmentFragmentDoc = gql`
     serviceTotalBeforeTax
   }
 }
-    ${InboundShipmentLineFragmentDoc}`;
-export const InboundShipmentRowFragmentDoc = gql`
-    fragment InboundShipmentRow on InvoiceNode {
+    ${InboundLineFragmentDoc}`;
+export const InboundRowFragmentDoc = gql`
+    fragment InboundRow on InvoiceNode {
   __typename
   comment
   createdDatetime
@@ -253,17 +274,17 @@ export const InvoicesDocument = gql`
       __typename
       totalCount
       nodes {
-        ...InboundShipmentRow
+        ...InboundRow
       }
     }
   }
 }
-    ${InboundShipmentRowFragmentDoc}`;
+    ${InboundRowFragmentDoc}`;
 export const InvoiceDocument = gql`
     query invoice($id: String!, $storeId: String!) {
   invoice(id: $id, storeId: $storeId) {
     ... on InvoiceNode {
-      ...InboundShipment
+      ...Inbound
     }
     ... on NodeError {
       __typename
@@ -282,7 +303,7 @@ export const InvoiceDocument = gql`
     }
   }
 }
-    ${InboundShipmentFragmentDoc}`;
+    ${InboundFragmentDoc}`;
 export const InboundByNumberDocument = gql`
     query inboundByNumber($invoiceNumber: Int!, $storeId: String!) {
   invoiceByNumber(
@@ -291,7 +312,7 @@ export const InboundByNumberDocument = gql`
     type: INBOUND_SHIPMENT
   ) {
     ... on InvoiceNode {
-      ...InboundShipment
+      ...Inbound
     }
     ... on NodeError {
       __typename
@@ -310,7 +331,7 @@ export const InboundByNumberDocument = gql`
     }
   }
 }
-    ${InboundShipmentFragmentDoc}`;
+    ${InboundFragmentDoc}`;
 export const UpdateInboundShipmentDocument = gql`
     mutation updateInboundShipment($storeId: String!, $input: UpdateInboundShipmentInput!) {
   updateInboundShipment(storeId: $storeId, input: $input) {

--- a/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -4,13 +4,15 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type PartialInboundLineFragment = { __typename: 'InvoiceLineNode', id: string, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, itemId: string, invoiceId: string, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null };
+export type PartialLocationFragment = { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean };
 
-export type InboundLineFragment = { __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null };
+export type DraftInboundLineFragment = { __typename: 'InvoiceLineNode', id: string, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, itemId: string, invoiceId: string, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null };
 
-export type InboundFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+export type InboundLineFragment = { __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null };
 
-export type InboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+export type InboundFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+
+export type InboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyName: string, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } };
 
 export type InvoicesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -22,7 +24,7 @@ export type InvoicesQueryVariables = Types.Exact<{
 }>;
 
 
-export type InvoicesQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } }> } };
+export type InvoicesQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyName: string, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } }> } };
 
 export type InvoiceQueryVariables = Types.Exact<{
   id: Types.Scalars['String'];
@@ -30,7 +32,7 @@ export type InvoiceQueryVariables = Types.Exact<{
 }>;
 
 
-export type InvoiceQuery = { __typename: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type InvoiceQuery = { __typename: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type InboundByNumberQueryVariables = Types.Exact<{
   invoiceNumber: Types.Scalars['Int'];
@@ -38,7 +40,7 @@ export type InboundByNumberQueryVariables = Types.Exact<{
 }>;
 
 
-export type InboundByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type InboundByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, sellPricePerPack: number, expiryDate?: string | null, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, code: string, name: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type UpdateInboundShipmentMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String'];
@@ -89,8 +91,17 @@ export type InvoiceCountsQueryVariables = Types.Exact<{
 
 export type InvoiceCountsQuery = { __typename: 'Queries', invoiceCounts: { __typename: 'InvoiceCounts', inbound: { __typename: 'InboundInvoiceCounts', created: { __typename: 'InvoiceCountsSummary', today: number, thisWeek: number } } } };
 
-export const PartialInboundLineFragmentDoc = gql`
-    fragment PartialInboundLine on InvoiceLineNode {
+export const PartialLocationFragmentDoc = gql`
+    fragment PartialLocation on LocationNode {
+  __typename
+  id
+  code
+  name
+  onHold
+}
+    `;
+export const DraftInboundLineFragmentDoc = gql`
+    fragment DraftInboundLine on InvoiceLineNode {
   id
   batch
   costPricePerPack
@@ -101,31 +112,23 @@ export const PartialInboundLineFragmentDoc = gql`
   itemId
   invoiceId
   location {
-    id
-    code
-    name
-    onHold
+    ...PartialLocation
   }
 }
-    `;
+    ${PartialLocationFragmentDoc}`;
 export const InboundLineFragmentDoc = gql`
     fragment InboundLine on InvoiceLineNode {
   __typename
+  id
   type
   batch
   costPricePerPack
+  sellPricePerPack
   expiryDate
-  id
-  itemCode
-  itemId
-  itemName
   numberOfPacks
   packSize
   note
   invoiceId
-  locationName
-  sellPricePerPack
-  type
   item {
     __typename
     id
@@ -133,43 +136,9 @@ export const InboundLineFragmentDoc = gql`
     code
     isVisible
     unitName
-    availableBatches(storeId: $storeId) {
-      totalCount
-      nodes {
-        id
-        availableNumberOfPacks
-        costPricePerPack
-        itemId
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-        expiryDate
-      }
-    }
   }
   location {
-    __typename
-    id
-    name
-    code
-    onHold
-    stock {
-      __typename
-      totalCount
-      nodes {
-        id
-        costPricePerPack
-        itemId
-        availableNumberOfPacks
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-      }
-    }
+    ...PartialLocation
   }
   stockLine {
     __typename
@@ -187,7 +156,7 @@ export const InboundLineFragmentDoc = gql`
     note
   }
 }
-    `;
+    ${PartialLocationFragmentDoc}`;
 export const InboundFragmentDoc = gql`
     fragment Inbound on InvoiceNode {
   __typename
@@ -239,26 +208,14 @@ export const InboundRowFragmentDoc = gql`
   comment
   createdDatetime
   allocatedDatetime
-  deliveredDatetime
-  pickedDatetime
-  shippedDatetime
-  verifiedDatetime
   id
   invoiceNumber
-  otherPartyId
   otherPartyName
-  theirReference
-  type
   status
   colour
   pricing {
     __typename
     totalAfterTax
-    totalBeforeTax
-    stockTotalBeforeTax
-    stockTotalAfterTax
-    serviceTotalAfterTax
-    serviceTotalBeforeTax
   }
 }
     `;

--- a/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -1,4 +1,23 @@
-fragment InboundShipmentLine on InvoiceLineNode {
+fragment PartialInboundLine on InvoiceLineNode {
+  id
+  batch
+  costPricePerPack
+  sellPricePerPack
+  expiryDate
+  numberOfPacks
+  packSize
+  itemId
+  invoiceId
+
+  location {
+    id
+    code
+    name
+    onHold
+  }
+}
+
+fragment InboundLine on InvoiceLineNode {
   __typename
   type
   batch
@@ -80,7 +99,7 @@ fragment InboundShipmentLine on InvoiceLineNode {
   }
 }
 
-fragment InboundShipment on InvoiceNode {
+fragment Inbound on InvoiceNode {
   __typename
   id
   comment
@@ -102,7 +121,7 @@ fragment InboundShipment on InvoiceNode {
   lines {
     __typename
     nodes {
-      ...InboundShipmentLine
+      ...InboundLine
     }
     totalCount
   }
@@ -127,7 +146,7 @@ fragment InboundShipment on InvoiceNode {
   }
 }
 
-fragment InboundShipmentRow on InvoiceNode {
+fragment InboundRow on InvoiceNode {
   __typename
   comment
   createdDatetime
@@ -173,7 +192,7 @@ query invoices(
       __typename
       totalCount
       nodes {
-        ...InboundShipmentRow
+        ...InboundRow
       }
     }
   }
@@ -182,7 +201,7 @@ query invoices(
 query invoice($id: String!, $storeId: String!) {
   invoice(id: $id, storeId: $storeId) {
     ... on InvoiceNode {
-      ...InboundShipment
+      ...Inbound
     }
 
     ... on NodeError {
@@ -210,7 +229,7 @@ query inboundByNumber($invoiceNumber: Int!, $storeId: String!) {
     type: INBOUND_SHIPMENT
   ) {
     ... on InvoiceNode {
-      ...InboundShipment
+      ...Inbound
     }
 
     ... on NodeError {

--- a/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -1,4 +1,12 @@
-fragment PartialInboundLine on InvoiceLineNode {
+fragment PartialLocation on LocationNode {
+  __typename
+  id
+  code
+  name
+  onHold
+}
+
+fragment DraftInboundLine on InvoiceLineNode {
   id
   batch
   costPricePerPack
@@ -10,30 +18,22 @@ fragment PartialInboundLine on InvoiceLineNode {
   invoiceId
 
   location {
-    id
-    code
-    name
-    onHold
+    ...PartialLocation
   }
 }
 
 fragment InboundLine on InvoiceLineNode {
   __typename
+  id
   type
   batch
   costPricePerPack
+  sellPricePerPack
   expiryDate
-  id
-  itemCode
-  itemId
-  itemName
   numberOfPacks
   packSize
   note
   invoiceId
-  locationName
-  sellPricePerPack
-  type
 
   item {
     __typename
@@ -42,44 +42,10 @@ fragment InboundLine on InvoiceLineNode {
     code
     isVisible
     unitName
-    availableBatches(storeId: $storeId) {
-      totalCount
-      nodes {
-        id
-        availableNumberOfPacks
-        costPricePerPack
-        itemId
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-        expiryDate
-      }
-    }
   }
 
   location {
-    __typename
-    id
-    name
-    code
-    onHold
-    stock {
-      __typename
-      totalCount
-      nodes {
-        id
-        costPricePerPack
-        itemId
-        availableNumberOfPacks
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-      }
-    }
+    ...PartialLocation
   }
 
   stockLine {
@@ -151,26 +117,14 @@ fragment InboundRow on InvoiceNode {
   comment
   createdDatetime
   allocatedDatetime
-  deliveredDatetime
-  pickedDatetime
-  shippedDatetime
-  verifiedDatetime
   id
   invoiceNumber
-  otherPartyId
   otherPartyName
-  theirReference
-  type
   status
   colour
   pricing {
     __typename
     totalAfterTax
-    totalBeforeTax
-    stockTotalBeforeTax
-    stockTotalAfterTax
-    serviceTotalAfterTax
-    serviceTotalBeforeTax
   }
 }
 

--- a/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -7,6 +7,7 @@ import {
   useColumns,
   MiniTable,
   useIsGrouped,
+  getUnitQuantity,
 } from '@openmsupply-client/common';
 import { OutboundItem } from '../../types';
 import { useOutboundRows } from '../api';
@@ -27,7 +28,19 @@ const Expand: FC<{
     'itemUnit',
     'numberOfPacks',
     'packSize',
-    'unitQuantity',
+    [
+      'unitQuantity',
+      {
+        accessor: () => {
+          if ('lines' in rowData) {
+            const { lines } = rowData;
+            return lines.reduce(getUnitQuantity, 0);
+          } else {
+            return 10 + rowData.packSize * rowData.numberOfPacks;
+          }
+        },
+      },
+    ],
     'sellPricePerUnit',
   ]);
 

--- a/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -11,14 +11,14 @@ import {
 import { OutboundItem } from '../../types';
 import { useOutboundRows } from '../api';
 import { useOutboundColumns } from './columns';
-import { OutboundShipmentLineFragment } from '../api/operations.generated';
+import { OutboundLineFragment } from '../api/operations.generated';
 
 interface GeneralTabProps<T> {
   onRowClick?: (rowData: T) => void;
 }
 
 const Expand: FC<{
-  rowData: OutboundShipmentLineFragment | OutboundItem;
+  rowData: OutboundLineFragment | OutboundItem;
 }> = ({ rowData }) => {
   const columns = useColumns([
     'batch',
@@ -39,7 +39,7 @@ const Expand: FC<{
 };
 
 export const ContentAreaComponent: FC<
-  GeneralTabProps<OutboundShipmentLineFragment | OutboundItem>
+  GeneralTabProps<OutboundLineFragment | OutboundItem>
 > = ({ onRowClick }) => {
   const t = useTranslation('distribution');
   const { isGrouped, toggleIsGrouped } = useIsGrouped('outboundShipment');

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -20,7 +20,7 @@ import { AppBarButtons } from './AppBarButtons';
 import { SidePanel } from './SidePanel';
 import { useOutbound } from '../api';
 import { AppRoute } from '@openmsupply-client/config';
-import { OutboundShipmentLineFragment } from '../api/operations.generated';
+import { OutboundLineFragment } from '../api/operations.generated';
 
 export const DetailView: FC = () => {
   const { entity, mode, onOpen, onClose, isOpen } = useEditModal<Item>();
@@ -28,7 +28,7 @@ export const DetailView: FC = () => {
   const t = useTranslation('distribution');
   const navigate = useNavigate();
   const onRowClick = useCallback(
-    (item: OutboundShipmentLineFragment | OutboundItem) => {
+    (item: OutboundLineFragment | OutboundItem) => {
       onOpen(toItem(item));
     },
     [toItem, onOpen]

--- a/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
@@ -16,11 +16,11 @@ import {
   useIsOutboundDisabled,
   useOutbound,
   useOutboundFields,
+  OutboundShipmentFragment,
 } from '../../api';
-import { Invoice } from '../../../types';
 import { StatusChangeButton } from './StatusChangeButton';
 
-const createStatusLog = (invoice: Invoice) => {
+const createStatusLog = (invoice: OutboundShipmentFragment) => {
   const statusIdx = outboundStatuses.findIndex(s => invoice.status === s);
 
   const statusLog: Record<InvoiceNodeStatus, null | undefined | string> = {

--- a/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Footer/Footer.tsx
@@ -16,11 +16,11 @@ import {
   useIsOutboundDisabled,
   useOutbound,
   useOutboundFields,
-  OutboundShipmentFragment,
+  OutboundFragment,
 } from '../../api';
 import { StatusChangeButton } from './StatusChangeButton';
 
-const createStatusLog = (invoice: OutboundShipmentFragment) => {
+const createStatusLog = (invoice: OutboundFragment) => {
   const statusIdx = outboundStatuses.findIndex(s => invoice.status === s);
 
   const statusLog: Record<InvoiceNodeStatus, null | undefined | string> = {

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -11,28 +11,26 @@ import {
   useCurrency,
 } from '@openmsupply-client/common';
 import { OutboundItem } from '../../types';
-import { OutboundShipmentLineFragment } from '../api/operations.generated';
+import { OutboundLineFragment } from '../api/operations.generated';
 
 interface UseOutboundColumnOptions {
-  sortBy: SortBy<OutboundShipmentLineFragment | OutboundItem>;
+  sortBy: SortBy<OutboundLineFragment | OutboundItem>;
   onChangeSortBy: (
-    column: Column<OutboundShipmentLineFragment | OutboundItem>
-  ) => SortBy<OutboundShipmentLineFragment | OutboundItem>;
+    column: Column<OutboundLineFragment | OutboundItem>
+  ) => SortBy<OutboundLineFragment | OutboundItem>;
 }
 
 const expansionColumn = getRowExpandColumn<
-  OutboundShipmentLineFragment | OutboundItem
+  OutboundLineFragment | OutboundItem
 >();
 const notePopoverColumn = getNotePopoverColumn<
-  OutboundShipmentLineFragment | OutboundItem
+  OutboundLineFragment | OutboundItem
 >();
 
 export const useOutboundColumns = ({
   sortBy,
   onChangeSortBy,
-}: UseOutboundColumnOptions): Column<
-  OutboundShipmentLineFragment | OutboundItem
->[] => {
+}: UseOutboundColumnOptions): Column<OutboundLineFragment | OutboundItem>[] => {
   const { c } = useCurrency();
   return useColumns(
     [
@@ -63,17 +61,19 @@ export const useOutboundColumns = ({
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
-              return ifTheSameElseDefault(lines, 'itemCode', '');
+              const items = lines.map(({ item }) => item);
+              return ifTheSameElseDefault(items, 'code', '');
             } else {
-              return row.itemCode;
+              return row.item.code;
             }
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return ifTheSameElseDefault(lines, 'itemCode', '');
+              const items = lines.map(({ item }) => item);
+              return ifTheSameElseDefault(items, 'code', '');
             } else {
-              return rowData.itemCode;
+              return rowData.item.code;
             }
           },
         },
@@ -84,17 +84,19 @@ export const useOutboundColumns = ({
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
-              return ifTheSameElseDefault(lines, 'itemName', '');
+              const items = lines.map(({ item }) => item);
+              return ifTheSameElseDefault(items, 'name', '');
             } else {
-              return row.itemName;
+              return row.item.name;
             }
           },
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return ifTheSameElseDefault(lines, 'itemName', '');
+              const items = lines.map(({ item }) => item);
+              return ifTheSameElseDefault(items, 'name', '');
             } else {
-              return rowData.itemName;
+              return rowData.item.name;
             }
           },
         },

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -9,6 +9,7 @@ import {
   Column,
   ifTheSameElseDefault,
   useCurrency,
+  getUnitQuantity,
 } from '@openmsupply-client/common';
 import { OutboundItem } from '../../types';
 import { OutboundLineFragment } from '../api/operations.generated';
@@ -234,7 +235,19 @@ export const useOutboundColumns = ({
           },
         },
       ],
-      'unitQuantity',
+      [
+        'unitQuantity',
+        {
+          accessor: ({ rowData }) => {
+            if ('lines' in rowData) {
+              const { lines } = rowData;
+              return lines.reduce(getUnitQuantity, 0);
+            } else {
+              return rowData.packSize * rowData.numberOfPacks;
+            }
+          },
+        },
+      ],
       {
         label: 'label.unit-price',
         key: 'sellPricePerUnit',

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/hooks/useDraftOutboundLines.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/hooks/useDraftOutboundLines.tsx
@@ -11,7 +11,7 @@ import { DraftOutboundLine } from '../../../../types';
 import { sortByExpiry, issueStock } from '../utils';
 import { useOutboundLines, useOutboundFields } from '../../../api';
 import {
-  PartialOutboundLineFragment,
+  OutboundLineFragment,
   PartialStockLineFragment,
 } from '../../../api/operations.generated';
 
@@ -34,7 +34,7 @@ export const createPlaceholderRow = (
 
 interface DraftOutboundLineSeeds {
   invoiceId: string;
-  invoiceLine: PartialOutboundLineFragment;
+  invoiceLine: OutboundLineFragment;
 }
 
 export const createDraftOutboundLineFromStockLine = ({

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -17,7 +17,7 @@ import { getStatusTranslator } from '../../utils';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { useOutbounds, useCreateOutbound, useUpdateOutbound } from '../api';
-import { OutboundShipmentRowFragment } from '../api/operations.generated';
+import { OutboundRowFragment } from '../api/operations.generated';
 
 export const OutboundShipmentListViewComponent: FC = () => {
   const { mutate: onUpdate } = useUpdateOutbound();
@@ -37,7 +37,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
   } = useOutbounds();
 
   const { c } = useCurrency();
-  const columns = useColumns<OutboundShipmentRowFragment>(
+  const columns = useColumns<OutboundRowFragment>(
     [
       [getNameAndColorColumn(), { setter: onUpdate }],
       [

--- a/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
@@ -8,8 +8,10 @@ import {
   SearchBar,
   FilterController,
 } from '@openmsupply-client/common';
-import { InvoiceRow } from '../../types';
-import { useDeleteSelectedOutbounds } from '../api';
+import {
+  useDeleteSelectedOutbounds,
+  OutboundShipmentRowFragment,
+} from '../api';
 
 export const Toolbar: FC<{
   filter: FilterController;
@@ -18,7 +20,7 @@ export const Toolbar: FC<{
 
   const onDelete = useDeleteSelectedOutbounds();
 
-  const key = 'comment' as keyof InvoiceRow;
+  const key = 'comment' as keyof OutboundShipmentRowFragment;
   const filterString = filter.filterBy?.[key]?.like as string;
 
   return (

--- a/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/Toolbar.tsx
@@ -8,10 +8,7 @@ import {
   SearchBar,
   FilterController,
 } from '@openmsupply-client/common';
-import {
-  useDeleteSelectedOutbounds,
-  OutboundShipmentRowFragment,
-} from '../api';
+import { useDeleteSelectedOutbounds, OutboundRowFragment } from '../api';
 
 export const Toolbar: FC<{
   filter: FilterController;
@@ -20,7 +17,7 @@ export const Toolbar: FC<{
 
   const onDelete = useDeleteSelectedOutbounds();
 
-  const key = 'comment' as keyof OutboundShipmentRowFragment;
+  const key = 'comment' as keyof OutboundRowFragment;
   const filterString = filter.filterBy?.[key]?.like as string;
 
   return (

--- a/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/packages/invoices/src/OutboundShipment/api/api.ts
@@ -17,8 +17,8 @@ import {
 import { DraftOutboundLine } from '../../types';
 import {
   getSdk,
-  OutboundShipmentRowFragment,
-  OutboundShipmentFragment,
+  OutboundRowFragment,
+  OutboundFragment,
   InsertOutboundShipmentMutationVariables,
   Sdk,
 } from './operations.generated';
@@ -26,9 +26,7 @@ import {
 export type OutboundShipmentApi = ReturnType<typeof getSdk>;
 
 const outboundParsers = {
-  toSortKey: (
-    sortBy: SortBy<OutboundShipmentRowFragment>
-  ): InvoiceSortFieldInput => {
+  toSortKey: (sortBy: SortBy<OutboundRowFragment>): InvoiceSortFieldInput => {
     switch (sortBy.key) {
       case 'createdDatetime': {
         return InvoiceSortFieldInput.CreatedDatetime;
@@ -48,7 +46,7 @@ const outboundParsers = {
       }
     }
   },
-  toStatus: (patch: RecordPatch<OutboundShipmentRowFragment>) => {
+  toStatus: (patch: RecordPatch<OutboundRowFragment>) => {
     switch (patch.status) {
       case InvoiceNodeStatus.Allocated:
         return UpdateOutboundShipmentStatusInput.Allocated;
@@ -69,7 +67,7 @@ const outboundParsers = {
     storeId,
   }),
   toUpdate: (
-    patch: RecordPatch<OutboundShipmentFragment>
+    patch: RecordPatch<OutboundFragment>
   ): UpdateOutboundShipmentInput => ({
     id: patch.id,
     colour: patch.colour,
@@ -131,10 +129,10 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
     }: {
       first: number;
       offset: number;
-      sortBy: SortBy<OutboundShipmentRowFragment>;
+      sortBy: SortBy<OutboundRowFragment>;
       filterBy: FilterBy | null;
     }): Promise<{
-      nodes: OutboundShipmentRowFragment[];
+      nodes: OutboundRowFragment[];
       totalCount: number;
     }> => {
       const filter = {
@@ -151,7 +149,7 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
       });
       return result.invoices;
     },
-    byId: async (id: string): Promise<OutboundShipmentFragment> => {
+    byId: async (id: string): Promise<OutboundFragment> => {
       const result = await sdk.invoice({ id, storeId });
       const invoice = result.invoice;
 
@@ -161,9 +159,7 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
         throw new Error('Could not find invoice');
       }
     },
-    byNumber: async (
-      invoiceNumber: string
-    ): Promise<OutboundShipmentFragment> => {
+    byNumber: async (invoiceNumber: string): Promise<OutboundFragment> => {
       const result = await sdk.outboundByNumber({
         invoiceNumber: Number(invoiceNumber),
         storeId,
@@ -194,9 +190,7 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
 
     throw new Error('Could not insert invoice');
   },
-  delete: async (
-    invoices: OutboundShipmentRowFragment[]
-  ): Promise<string[]> => {
+  delete: async (invoices: OutboundRowFragment[]): Promise<string[]> => {
     const result = await sdk.deleteOutboundShipments({
       storeId,
       deleteOutboundShipments: invoices.map(invoice => invoice.id),
@@ -210,8 +204,8 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
     throw new Error('Could not delete invoices');
   },
   update: async (
-    patch: RecordPatch<OutboundShipmentFragment>
-  ): Promise<RecordPatch<OutboundShipmentFragment>> => {
+    patch: RecordPatch<OutboundFragment>
+  ): Promise<RecordPatch<OutboundFragment>> => {
     const result = await sdk.upsertOutboundShipment({
       storeId,
       input: {

--- a/packages/invoices/src/OutboundShipment/api/api.ts
+++ b/packages/invoices/src/OutboundShipment/api/api.ts
@@ -67,14 +67,14 @@ const outboundParsers = {
     storeId,
   }),
   toUpdate: (
-    patch: RecordPatch<OutboundFragment>
+    patch: RecordPatch<OutboundRowFragment> | RecordPatch<OutboundFragment>
   ): UpdateOutboundShipmentInput => ({
     id: patch.id,
     colour: patch.colour,
     comment: patch.comment,
     status: outboundParsers.toStatus(patch),
-    onHold: patch.onHold,
-    otherPartyId: patch.otherParty?.id,
+    onHold: 'onHold' in patch ? patch.onHold : undefined,
+    otherPartyId: 'otherParty' in patch ? patch.otherParty?.id : undefined,
     theirReference: patch.theirReference,
   }),
   toInsertLine: (line: DraftOutboundLine): InsertOutboundShipmentLineInput => {
@@ -204,8 +204,10 @@ export const getOutboundQueries = (sdk: Sdk, storeId: string) => ({
     throw new Error('Could not delete invoices');
   },
   update: async (
-    patch: RecordPatch<OutboundFragment>
-  ): Promise<RecordPatch<OutboundFragment>> => {
+    patch: RecordPatch<OutboundRowFragment> | RecordPatch<OutboundFragment>
+  ): Promise<
+    RecordPatch<OutboundRowFragment> | RecordPatch<OutboundFragment>
+  > => {
     const result = await sdk.upsertOutboundShipment({
       storeId,
       input: {

--- a/packages/invoices/src/OutboundShipment/api/hooks.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks.ts
@@ -30,9 +30,9 @@ import { useOutboundColumns } from '../DetailView/columns';
 import {
   getSdk,
   DeleteOutboundShipmentLinesMutation,
-  OutboundShipmentRowFragment,
-  OutboundShipmentFragment,
-  OutboundShipmentLineFragment,
+  OutboundRowFragment,
+  OutboundFragment,
+  OutboundLineFragment,
 } from './operations.generated';
 import { canDeleteInvoice } from '../../utils';
 
@@ -55,7 +55,7 @@ export const useOutboundDetailQueryKey = (): ['invoice', string] => {
 };
 
 export const useOutbounds = () => {
-  const queryParams = useQueryParams<OutboundShipmentRowFragment>({
+  const queryParams = useQueryParams<OutboundRowFragment>({
     initialSortBy: { key: 'otherPartyName' },
   });
   const api = useOutboundApi();
@@ -73,7 +73,7 @@ export const useOutbounds = () => {
   };
 };
 
-export const useOutbound = (): UseQueryResult<OutboundShipmentFragment> => {
+export const useOutbound = (): UseQueryResult<OutboundFragment> => {
   const outboundNumber = useOutboundNumber();
   const api = useOutboundApi();
   const queryKey = useOutboundDetailQueryKey();
@@ -120,7 +120,7 @@ export const useDeleteSelectedOutbounds = () => {
     selectedRows: Object.keys(state.rowState)
       .filter(id => state.rowState[id]?.isSelected)
       .map(selectedId => rows?.nodes?.find(({ id }) => selectedId === id))
-      .filter(Boolean) as OutboundShipmentRowFragment[],
+      .filter(Boolean) as OutboundRowFragment[],
   }));
 
   const deleteAction = () => {
@@ -149,11 +149,9 @@ export const useDeleteSelectedOutbounds = () => {
   return deleteAction;
 };
 
-export const useOutboundFields = <
-  KeyOfOutbound extends keyof OutboundShipmentFragment
->(
+export const useOutboundFields = <KeyOfOutbound extends keyof OutboundFragment>(
   keys: KeyOfOutbound | KeyOfOutbound[]
-): FieldSelectorControl<OutboundShipmentFragment, KeyOfOutbound> => {
+): FieldSelectorControl<OutboundFragment, KeyOfOutbound> => {
   const { data } = useOutbound();
   const api = useOutboundApi();
   const queryKey = useOutboundDetailQueryKey();
@@ -161,7 +159,7 @@ export const useOutboundFields = <
   return useFieldsSelector(
     queryKey,
     () => api.get.byNumber(queryKey[1]),
-    (patch: Partial<OutboundShipmentFragment>) =>
+    (patch: Partial<OutboundFragment>) =>
       api.update({ ...patch, id: data?.id ?? '' }),
     keys
   );
@@ -177,7 +175,7 @@ export const useIsOutboundDisabled = (): boolean => {
 };
 
 const useOutboundSelector = <ReturnType>(
-  select: (data: OutboundShipmentFragment) => ReturnType
+  select: (data: OutboundFragment) => ReturnType
 ) => {
   const queryKey = useOutboundDetailQueryKey();
   const api = useOutboundApi();
@@ -190,13 +188,11 @@ const useOutboundSelector = <ReturnType>(
 
 export const useOutboundLines = (
   itemId?: string
-): UseQueryResult<OutboundShipmentLineFragment[], unknown> => {
+): UseQueryResult<OutboundLineFragment[], unknown> => {
   const selectLines = useCallback(
-    (invoice: OutboundShipmentFragment) => {
+    (invoice: OutboundFragment) => {
       return itemId
-        ? invoice.lines.nodes.filter(
-            ({ itemId: invoiceLineItemId }) => itemId === invoiceLineItemId
-          )
+        ? invoice.lines.nodes.filter(({ item }) => itemId === item.id)
         : invoice.lines.nodes;
     },
     [itemId]
@@ -206,7 +202,7 @@ export const useOutboundLines = (
 };
 
 export const useOutboundItems = (): UseQueryResult<OutboundItem[]> => {
-  const selectLines = useCallback((invoice: OutboundShipmentFragment) => {
+  const selectLines = useCallback((invoice: OutboundFragment) => {
     const { lines } = invoice;
 
     return Object.entries(groupBy(lines.nodes, 'itemId')).map(
@@ -221,7 +217,7 @@ export const useOutboundItems = (): UseQueryResult<OutboundItem[]> => {
 
 export const useOutboundRows = (isGrouped = true) => {
   const { sortBy, onChangeSortBy } = useSortBy<
-    OutboundShipmentLineFragment | OutboundItem
+    OutboundLineFragment | OutboundItem
   >({
     key: 'itemName',
   });
@@ -241,9 +237,9 @@ export const useOutboundRows = (isGrouped = true) => {
 
   const sortedLines = useMemo(() => {
     const sorter = getDataSorter<
-      OutboundShipmentLineFragment,
-      keyof OutboundShipmentLineFragment
-    >(sortBy.key as keyof OutboundShipmentLineFragment, !!sortBy.isDesc);
+      OutboundLineFragment,
+      keyof OutboundLineFragment
+    >(sortBy.key as keyof OutboundLineFragment, !!sortBy.isDesc);
     return [...(lines ?? [])].sort(sorter);
   }, [lines, sortBy.key, sortBy.isDesc]);
 
@@ -273,7 +269,7 @@ export const useDeleteInboundLine = (): UseMutationResult<
   DeleteOutboundShipmentLinesMutation,
   unknown,
   string[],
-  { previous?: OutboundShipmentFragment; ids: string[] }
+  { previous?: OutboundFragment; ids: string[] }
 > => {
   // TODO: Shouldn't need to get the invoice ID here from the params as the mutation
   // input object should not require the invoice ID. Waiting for an API change.
@@ -286,13 +282,12 @@ export const useDeleteInboundLine = (): UseMutationResult<
     onMutate: async (ids: string[]) => {
       await queryClient.cancelQueries(queryKey);
 
-      const previous =
-        queryClient.getQueryData<OutboundShipmentFragment>(queryKey);
+      const previous = queryClient.getQueryData<OutboundFragment>(queryKey);
       if (previous) {
         const nodes = previous.lines.nodes.filter(
           ({ id: lineId }) => !ids.includes(lineId)
         );
-        queryClient.setQueryData<OutboundShipmentFragment>(queryKey, {
+        queryClient.setQueryData<OutboundFragment>(queryKey, {
           ...previous,
           lines: {
             __typename: 'InvoiceLineConnector',
@@ -342,7 +337,7 @@ export const useDeleteSelectedLines = (): {
           Object.keys(state.rowState)
             .filter(id => state.rowState[id]?.isSelected)
             .map(selectedId => lines.find(({ id }) => selectedId === id))
-            .filter(Boolean) as OutboundShipmentLineFragment[]
+            .filter(Boolean) as OutboundLineFragment[]
         ).map(({ id }) => id),
       };
     }

--- a/packages/invoices/src/OutboundShipment/api/index.ts
+++ b/packages/invoices/src/OutboundShipment/api/index.ts
@@ -1,11 +1,8 @@
 export {
-  OutboundShipmentFragment,
-  PartialLocationFragment,
+  OutboundFragment,
   PartialStockLineFragment,
-  PartialItemFragment,
-  PartialOutboundLineFragment,
-  OutboundShipmentLineFragment,
-  OutboundShipmentRowFragment,
+  OutboundLineFragment,
+  OutboundRowFragment,
 } from './operations.generated';
 
 export * from './api';

--- a/packages/invoices/src/OutboundShipment/api/index.ts
+++ b/packages/invoices/src/OutboundShipment/api/index.ts
@@ -1,2 +1,12 @@
+export {
+  OutboundShipmentFragment,
+  PartialLocationFragment,
+  PartialStockLineFragment,
+  PartialItemFragment,
+  PartialOutboundLineFragment,
+  OutboundShipmentLineFragment,
+  OutboundShipmentRowFragment,
+} from './operations.generated';
+
 export * from './api';
 export * from './hooks';

--- a/packages/invoices/src/OutboundShipment/api/operations.generated.ts
+++ b/packages/invoices/src/OutboundShipment/api/operations.generated.ts
@@ -10,7 +10,7 @@ export type OutboundLineFragment = { __typename: 'InvoiceLineNode', id: string, 
 
 export type OutboundFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
 
-export type OutboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+export type OutboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } };
 
 export type InvoicesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -22,7 +22,7 @@ export type InvoicesQueryVariables = Types.Exact<{
 }>;
 
 
-export type InvoicesQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } }> } };
+export type InvoicesQuery = { __typename: 'Queries', invoices: { __typename: 'InvoiceConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number } }> } };
 
 export type InvoiceQueryVariables = Types.Exact<{
   id: Types.Scalars['String'];
@@ -213,11 +213,6 @@ export const OutboundRowFragmentDoc = gql`
   pricing {
     __typename
     totalAfterTax
-    totalBeforeTax
-    stockTotalBeforeTax
-    stockTotalAfterTax
-    serviceTotalAfterTax
-    serviceTotalBeforeTax
   }
 }
     `;

--- a/packages/invoices/src/OutboundShipment/api/operations.generated.ts
+++ b/packages/invoices/src/OutboundShipment/api/operations.generated.ts
@@ -4,19 +4,13 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type PartialLocationFragment = { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean };
-
 export type PartialStockLineFragment = { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null };
 
-export type PartialItemFragment = { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null };
+export type OutboundLineFragment = { __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null } | null };
 
-export type PartialOutboundLineFragment = { __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null } | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null };
+export type OutboundFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
 
-export type OutboundShipmentLineFragment = { __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null };
-
-export type OutboundShipmentFragment = { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
-
-export type OutboundShipmentRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
+export type OutboundRowFragment = { __typename: 'InvoiceNode', comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, id: string, invoiceNumber: number, otherPartyId: string, otherPartyName: string, theirReference?: string | null, type: Types.InvoiceNodeType, status: Types.InvoiceNodeStatus, colour?: string | null, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } };
 
 export type InvoicesQueryVariables = Types.Exact<{
   first?: Types.InputMaybe<Types.Scalars['Int']>;
@@ -36,7 +30,7 @@ export type InvoiceQueryVariables = Types.Exact<{
 }>;
 
 
-export type InvoiceQuery = { __typename: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type InvoiceQuery = { __typename: 'Queries', invoice: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type OutboundByNumberQueryVariables = Types.Exact<{
   invoiceNumber: Types.Scalars['Int'];
@@ -44,7 +38,7 @@ export type OutboundByNumberQueryVariables = Types.Exact<{
 }>;
 
 
-export type OutboundByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', type: Types.InvoiceLineNodeType, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemCode: string, itemId: string, itemName: string, numberOfPacks: number, packSize: number, note?: string | null, invoiceId: string, locationName?: string | null, sellPricePerPack: number, item: { __typename: 'ItemNode', id: string, name: string, code: string, isVisible: boolean, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, availableNumberOfPacks: number, costPricePerPack: number, itemId: string, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, expiryDate?: string | null }> } }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean, stock: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', id: string, costPricePerPack: number, itemId: string, availableNumberOfPacks: number, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number }> } } | null, stockLine?: { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, onHold: boolean, note?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
+export type OutboundByNumberQuery = { __typename: 'Queries', invoiceByNumber: { __typename: 'InvoiceNode', id: string, comment?: string | null, createdDatetime: string, allocatedDatetime?: string | null, deliveredDatetime?: string | null, pickedDatetime?: string | null, shippedDatetime?: string | null, verifiedDatetime?: string | null, invoiceNumber: number, colour?: string | null, onHold: boolean, otherPartyId: string, otherPartyName: string, status: Types.InvoiceNodeStatus, theirReference?: string | null, type: Types.InvoiceNodeType, lines: { __typename: 'InvoiceLineConnector', totalCount: number, nodes: Array<{ __typename: 'InvoiceLineNode', id: string, type: Types.InvoiceLineNodeType, batch?: string | null, expiryDate?: string | null, numberOfPacks: number, packSize: number, invoiceId: string, sellPricePerPack: number, note?: string | null, item: { __typename: 'ItemNode', id: string, name: string, code: string, unitName?: string | null }, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string, itemId: string, availableNumberOfPacks: number, totalNumberOfPacks: number, onHold: boolean, sellPricePerPack: number, packSize: number, expiryDate?: string | null } | null }> }, otherParty: { __typename: 'NameNode', id: string, name: string, code: string, isCustomer: boolean, isSupplier: boolean }, pricing: { __typename: 'InvoicePricingNode', totalAfterTax: number, totalBeforeTax: number, stockTotalBeforeTax: number, stockTotalAfterTax: number, serviceTotalAfterTax: number, serviceTotalBeforeTax: number } } | { __typename: 'NodeError', error: { __typename: 'DatabaseError', description: string, fullError: string } | { __typename: 'RecordNotFound', description: string } } };
 
 export type InsertOutboundShipmentMutationVariables = Types.Exact<{
   id: Types.Scalars['String'];
@@ -95,14 +89,6 @@ export type InvoiceCountsQueryVariables = Types.Exact<{
 
 export type InvoiceCountsQuery = { __typename: 'Queries', invoiceCounts: { __typename: 'InvoiceCounts', outbound: { __typename: 'OutboundInvoiceCounts', toBePicked: number, created: { __typename: 'InvoiceCountsSummary', today: number, thisWeek: number } } } };
 
-export const PartialLocationFragmentDoc = gql`
-    fragment PartialLocation on LocationNode {
-  id
-  name
-  code
-  onHold
-}
-    `;
 export const PartialStockLineFragmentDoc = gql`
     fragment PartialStockLine on StockLineNode {
   id
@@ -114,20 +100,16 @@ export const PartialStockLineFragmentDoc = gql`
   packSize
   expiryDate
   location {
-    ...PartialLocation
+    __typename
+    id
+    name
+    code
+    onHold
   }
-}
-    ${PartialLocationFragmentDoc}`;
-export const PartialItemFragmentDoc = gql`
-    fragment PartialItem on ItemNode {
-  id
-  name
-  code
-  unitName
 }
     `;
-export const PartialOutboundLineFragmentDoc = gql`
-    fragment PartialOutboundLine on InvoiceLineNode {
+export const OutboundLineFragmentDoc = gql`
+    fragment OutboundLine on InvoiceLineNode {
   __typename
   id
   type
@@ -137,59 +119,13 @@ export const PartialOutboundLineFragmentDoc = gql`
   packSize
   invoiceId
   sellPricePerPack
-  stockLine {
-    ...PartialStockLine
-  }
-  item {
-    ...PartialItem
-  }
-  location {
-    ...PartialLocation
-  }
-}
-    ${PartialStockLineFragmentDoc}
-${PartialItemFragmentDoc}
-${PartialLocationFragmentDoc}`;
-export const OutboundShipmentLineFragmentDoc = gql`
-    fragment OutboundShipmentLine on InvoiceLineNode {
-  __typename
-  type
-  batch
-  costPricePerPack
-  expiryDate
-  id
-  itemCode
-  itemId
-  itemName
-  numberOfPacks
-  packSize
   note
-  invoiceId
-  locationName
-  sellPricePerPack
-  type
   item {
     __typename
     id
     name
     code
-    isVisible
     unitName
-    availableBatches(storeId: $storeId) {
-      totalCount
-      nodes {
-        id
-        availableNumberOfPacks
-        costPricePerPack
-        itemId
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-        expiryDate
-      }
-    }
   }
   location {
     __typename
@@ -197,41 +133,22 @@ export const OutboundShipmentLineFragmentDoc = gql`
     name
     code
     onHold
-    stock {
-      __typename
-      totalCount
-      nodes {
-        id
-        costPricePerPack
-        itemId
-        availableNumberOfPacks
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-      }
-    }
   }
   stockLine {
     __typename
-    availableNumberOfPacks
-    batch
-    costPricePerPack
-    expiryDate
     id
     itemId
-    packSize
-    sellPricePerPack
-    storeId
+    availableNumberOfPacks
     totalNumberOfPacks
     onHold
-    note
+    sellPricePerPack
+    packSize
+    expiryDate
   }
 }
     `;
-export const OutboundShipmentFragmentDoc = gql`
-    fragment OutboundShipment on InvoiceNode {
+export const OutboundFragmentDoc = gql`
+    fragment Outbound on InvoiceNode {
   __typename
   id
   comment
@@ -252,7 +169,7 @@ export const OutboundShipmentFragmentDoc = gql`
   lines {
     __typename
     nodes {
-      ...OutboundShipmentLine
+      ...OutboundLine
     }
     totalCount
   }
@@ -274,9 +191,9 @@ export const OutboundShipmentFragmentDoc = gql`
     serviceTotalBeforeTax
   }
 }
-    ${OutboundShipmentLineFragmentDoc}`;
-export const OutboundShipmentRowFragmentDoc = gql`
-    fragment OutboundShipmentRow on InvoiceNode {
+    ${OutboundLineFragmentDoc}`;
+export const OutboundRowFragmentDoc = gql`
+    fragment OutboundRow on InvoiceNode {
   __typename
   comment
   createdDatetime
@@ -315,13 +232,13 @@ export const InvoicesDocument = gql`
     ... on InvoiceConnector {
       __typename
       nodes {
-        ...OutboundShipmentRow
+        ...OutboundRow
       }
       totalCount
     }
   }
 }
-    ${OutboundShipmentRowFragmentDoc}`;
+    ${OutboundRowFragmentDoc}`;
 export const InvoiceDocument = gql`
     query invoice($id: String!, $storeId: String!) {
   invoice(id: $id, storeId: $storeId) {
@@ -342,11 +259,11 @@ export const InvoiceDocument = gql`
       }
     }
     ... on InvoiceNode {
-      ...OutboundShipment
+      ...Outbound
     }
   }
 }
-    ${OutboundShipmentFragmentDoc}`;
+    ${OutboundFragmentDoc}`;
 export const OutboundByNumberDocument = gql`
     query outboundByNumber($invoiceNumber: Int!, $storeId: String!) {
   invoiceByNumber(
@@ -371,11 +288,11 @@ export const OutboundByNumberDocument = gql`
       }
     }
     ... on InvoiceNode {
-      ...OutboundShipment
+      ...Outbound
     }
   }
 }
-    ${OutboundShipmentFragmentDoc}`;
+    ${OutboundFragmentDoc}`;
 export const InsertOutboundShipmentDocument = gql`
     mutation insertOutboundShipment($id: String!, $otherPartyId: String!, $storeId: String!) {
   insertOutboundShipment(

--- a/packages/invoices/src/OutboundShipment/api/operations.graphql
+++ b/packages/invoices/src/OutboundShipment/api/operations.graphql
@@ -124,11 +124,6 @@ fragment OutboundRow on InvoiceNode {
   pricing {
     __typename
     totalAfterTax
-    totalBeforeTax
-    stockTotalBeforeTax
-    stockTotalAfterTax
-    serviceTotalAfterTax
-    serviceTotalBeforeTax
   }
 }
 

--- a/packages/invoices/src/OutboundShipment/api/operations.graphql
+++ b/packages/invoices/src/OutboundShipment/api/operations.graphql
@@ -1,10 +1,3 @@
-fragment PartialLocation on LocationNode {
-  id
-  name
-  code
-  onHold
-}
-
 fragment PartialStockLine on StockLineNode {
   id
   itemId
@@ -15,18 +8,15 @@ fragment PartialStockLine on StockLineNode {
   packSize
   expiryDate
   location {
-    ...PartialLocation
+    __typename
+    id
+    name
+    code
+    onHold
   }
 }
 
-fragment PartialItem on ItemNode {
-  id
-  name
-  code
-  unitName
-}
-
-fragment PartialOutboundLine on InvoiceLineNode {
+fragment OutboundLine on InvoiceLineNode {
   __typename
   id
   type
@@ -36,60 +26,14 @@ fragment PartialOutboundLine on InvoiceLineNode {
   packSize
   invoiceId
   sellPricePerPack
-
-  stockLine {
-    ...PartialStockLine
-  }
-
-  item {
-    ...PartialItem
-  }
-
-  location {
-    ...PartialLocation
-  }
-}
-
-fragment OutboundShipmentLine on InvoiceLineNode {
-  __typename
-  type
-  batch
-  costPricePerPack
-  expiryDate
-  id
-  itemCode
-  itemId
-  itemName
-  numberOfPacks
-  packSize
   note
-  invoiceId
-  locationName
-  sellPricePerPack
-  type
 
   item {
     __typename
     id
     name
     code
-    isVisible
     unitName
-    availableBatches(storeId: $storeId) {
-      totalCount
-      nodes {
-        id
-        availableNumberOfPacks
-        costPricePerPack
-        itemId
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-        expiryDate
-      }
-    }
   }
 
   location {
@@ -98,41 +42,22 @@ fragment OutboundShipmentLine on InvoiceLineNode {
     name
     code
     onHold
-    stock {
-      __typename
-      totalCount
-      nodes {
-        id
-        costPricePerPack
-        itemId
-        availableNumberOfPacks
-        onHold
-        packSize
-        sellPricePerPack
-        storeId
-        totalNumberOfPacks
-      }
-    }
   }
 
   stockLine {
     __typename
-    availableNumberOfPacks
-    batch
-    costPricePerPack
-    expiryDate
     id
     itemId
-    packSize
-    sellPricePerPack
-    storeId
+    availableNumberOfPacks
     totalNumberOfPacks
     onHold
-    note
+    sellPricePerPack
+    packSize
+    expiryDate
   }
 }
 
-fragment OutboundShipment on InvoiceNode {
+fragment Outbound on InvoiceNode {
   __typename
   id
   comment
@@ -154,7 +79,7 @@ fragment OutboundShipment on InvoiceNode {
   lines {
     __typename
     nodes {
-      ...OutboundShipmentLine
+      ...OutboundLine
     }
     totalCount
   }
@@ -179,7 +104,7 @@ fragment OutboundShipment on InvoiceNode {
   }
 }
 
-fragment OutboundShipmentRow on InvoiceNode {
+fragment OutboundRow on InvoiceNode {
   __typename
   comment
   createdDatetime
@@ -224,7 +149,7 @@ query invoices(
     ... on InvoiceConnector {
       __typename
       nodes {
-        ...OutboundShipmentRow
+        ...OutboundRow
       }
       totalCount
     }
@@ -250,7 +175,7 @@ query invoice($id: String!, $storeId: String!) {
       }
     }
     ... on InvoiceNode {
-      ...OutboundShipment
+      ...Outbound
     }
   }
 }
@@ -278,7 +203,7 @@ query outboundByNumber($invoiceNumber: Int!, $storeId: String!) {
       }
     }
     ... on InvoiceNode {
-      ...OutboundShipment
+      ...Outbound
     }
   }
 }

--- a/packages/invoices/src/types.ts
+++ b/packages/invoices/src/types.ts
@@ -2,17 +2,14 @@ import {
   InboundLineFragment,
   PartialInboundLineFragment,
 } from './InboundShipment/api';
-import {
-  OutboundShipmentLineFragment,
-  PartialOutboundLineFragment,
-} from './OutboundShipment/api';
+import { OutboundLineFragment } from './OutboundShipment/api';
 
 export interface DraftInboundLine extends PartialInboundLineFragment {
   isCreated?: boolean;
   isUpdated?: boolean;
 }
 
-export interface DraftOutboundLine extends PartialOutboundLineFragment {
+export interface DraftOutboundLine extends OutboundLineFragment {
   isCreated: boolean;
   isUpdated: boolean;
 }
@@ -26,5 +23,5 @@ export type InboundItem = {
 export type OutboundItem = {
   id: string;
   itemId: string;
-  lines: [OutboundShipmentLineFragment, ...OutboundShipmentLineFragment[]];
+  lines: [OutboundLineFragment, ...OutboundLineFragment[]];
 };

--- a/packages/invoices/src/types.ts
+++ b/packages/invoices/src/types.ts
@@ -1,57 +1,15 @@
 import {
+  InboundLineFragment,
+  PartialInboundLineFragment,
+} from './InboundShipment/api';
+import {
   OutboundShipmentLineFragment,
   PartialOutboundLineFragment,
-  // OutboundShipmentFragment,
-} from './OutboundShipment/api/operations.generated';
-import { LocationRowFragment } from '@openmsupply-client/system/src/Location/api/operations.generated';
-import {
-  StockLine,
-  InvoiceNode,
-  InvoiceNodeStatus,
-  DomainObject,
-  InvoicePricingNode,
-  Name,
-  InvoiceLineNode,
-} from '@openmsupply-client/common';
+} from './OutboundShipment/api';
 
-export interface InvoiceLine
-  extends Omit<InvoiceLineNode, 'item' | 'location' | 'stockLine'>,
-    DomainObject {
-  stockLine?: StockLine | null;
-  stockLineId: string;
-  unitName?: string;
-  invoiceId: string;
-  location?: LocationRowFragment | null;
-}
-
-export interface InvoiceRow
-  extends Pick<
-      InvoiceNode,
-      | '__typename'
-      | 'comment'
-      | 'createdDatetime'
-      | 'id'
-      | 'invoiceNumber'
-      | 'otherPartyId'
-      | 'otherPartyName'
-      | 'status'
-      | 'colour'
-      | 'theirReference'
-      | 'type'
-    >,
-    DomainObject {
-  pricing: InvoicePricingNode;
-}
-
-export interface Invoice
-  extends Omit<InvoiceNode, 'lines' | 'status' | 'otherParty' | 'pricing'>,
-    DomainObject {
-  status: InvoiceNodeStatus;
-  otherParty?: Name;
-  lines: InvoiceLine[];
-  pricing: {
-    totalAfterTax: number;
-  };
+export interface DraftInboundLine extends PartialInboundLineFragment {
+  isCreated?: boolean;
+  isUpdated?: boolean;
 }
 
 export interface DraftOutboundLine extends PartialOutboundLineFragment {
@@ -59,10 +17,10 @@ export interface DraftOutboundLine extends PartialOutboundLineFragment {
   isUpdated: boolean;
 }
 
-export type InboundShipmentItem = {
+export type InboundItem = {
   id: string;
   itemId: string;
-  lines: [InvoiceLine, ...InvoiceLine[]];
+  lines: [InboundLineFragment, ...InboundLineFragment[]];
 };
 
 export type OutboundItem = {

--- a/packages/invoices/src/types.ts
+++ b/packages/invoices/src/types.ts
@@ -1,10 +1,10 @@
 import {
   InboundLineFragment,
-  PartialInboundLineFragment,
+  DraftInboundLineFragment,
 } from './InboundShipment/api';
 import { OutboundLineFragment } from './OutboundShipment/api';
 
-export interface DraftInboundLine extends PartialInboundLineFragment {
+export interface DraftInboundLine extends DraftInboundLineFragment {
   isCreated?: boolean;
   isUpdated?: boolean;
 }

--- a/packages/invoices/src/utils.ts
+++ b/packages/invoices/src/utils.ts
@@ -1,3 +1,4 @@
+import { InboundRowFragment } from './InboundShipment/api/operations.generated';
 import {
   LocaleKey,
   InvoiceNodeStatus,
@@ -7,8 +8,9 @@ import {
 import {
   OutboundShipmentRowFragment,
   OutboundShipmentFragment,
-} from './OutboundShipment/api/operations.generated';
-import { InboundShipmentItem, Invoice, InvoiceLine } from './types';
+} from './OutboundShipment/api';
+import { InboundLineFragment } from './InboundShipment/api';
+import { InboundItem } from './types';
 
 export const outboundStatuses: InvoiceNodeStatus[] = [
   InvoiceNodeStatus.New,
@@ -98,16 +100,15 @@ export const isInvoiceEditable = (
   return outbound.status === 'NEW' || outbound.status === 'ALLOCATED';
 };
 
-export const isInboundEditable = (inbound: Invoice): boolean => {
-  // return inbound.status !== 'VERIFIED' && inbound.status !== 'DELIVERED';
+export const isInboundEditable = (inbound: InboundRowFragment): boolean => {
   return inbound.status === 'NEW';
 };
 
 export const createSummaryItem = (
   itemId: string,
-  lines: [InvoiceLine, ...InvoiceLine[]]
-): InboundShipmentItem => {
-  const item: InboundShipmentItem = {
+  lines: [InboundLineFragment, ...InboundLineFragment[]]
+): InboundItem => {
+  const item: InboundItem = {
     // TODO: Could generate a unique UUID here if wanted for the id. But not needed for now.
     // the lines all have the itemID in common, so we can use that. Have added the itemID also
     // as it is explicit that this is the itemID in common for all of the invoice lines.
@@ -120,8 +121,8 @@ export const createSummaryItem = (
 };
 
 export const inboundLinesToSummaryItems = (
-  lines: InvoiceLine[]
-): InboundShipmentItem[] => {
+  lines: InboundLineFragment[]
+): InboundItem[] => {
   const grouped = groupBy(lines, 'itemId');
   return Object.entries(grouped).map(([itemId, lines]) =>
     createSummaryItem(itemId, lines)

--- a/packages/invoices/src/utils.ts
+++ b/packages/invoices/src/utils.ts
@@ -5,10 +5,7 @@ import {
   useTranslation,
   groupBy,
 } from '@openmsupply-client/common';
-import {
-  OutboundShipmentRowFragment,
-  OutboundShipmentFragment,
-} from './OutboundShipment/api';
+import { OutboundRowFragment, OutboundFragment } from './OutboundShipment/api';
 import { InboundLineFragment } from './InboundShipment/api';
 import { InboundItem } from './types';
 
@@ -94,9 +91,7 @@ export const getStatusTranslator =
     );
   };
 
-export const isInvoiceEditable = (
-  outbound: OutboundShipmentFragment
-): boolean => {
+export const isInvoiceEditable = (outbound: OutboundFragment): boolean => {
   return outbound.status === 'NEW' || outbound.status === 'ALLOCATED';
 };
 
@@ -128,8 +123,6 @@ export const inboundLinesToSummaryItems = (
     createSummaryItem(itemId, lines)
   );
 };
-export const canDeleteInvoice = (
-  invoice: OutboundShipmentRowFragment
-): boolean =>
+export const canDeleteInvoice = (invoice: OutboundRowFragment): boolean =>
   invoice.status === InvoiceNodeStatus.New ||
   invoice.status === InvoiceNodeStatus.Allocated;

--- a/packages/system/src/Item/types.ts
+++ b/packages/system/src/Item/types.ts
@@ -1,14 +1,9 @@
-export interface ItemRow {
-  id: string;
-  code: string;
-  name: string;
-  unitName?: string | null;
-}
+import { ItemRowFragment } from './api';
 
 export type ItemLike = ItemLikeLine | ItemLikeAggregate;
 
 export interface ItemLikeLine {
-  item: ItemRow;
+  item: ItemRowFragment;
 }
 
 export interface ItemLikeAggregate {

--- a/packages/system/src/Item/types.ts
+++ b/packages/system/src/Item/types.ts
@@ -2,14 +2,13 @@ export interface ItemRow {
   id: string;
   code: string;
   name: string;
+  unitName?: string | null;
 }
 
 export type ItemLike = ItemLikeLine | ItemLikeAggregate;
 
 export interface ItemLikeLine {
-  itemId: string;
-  itemName: string;
-  itemCode: string;
+  item: ItemRow;
 }
 
 export interface ItemLikeAggregate {

--- a/packages/system/src/Item/utils.ts
+++ b/packages/system/src/Item/utils.ts
@@ -34,9 +34,9 @@ export const mapItemNodes = (
 
 export const toItem = (line: ItemLike): Item => ({
   __typename: 'ItemNode',
-  id: 'lines' in line ? line.lines[0].itemId : line.itemId,
-  name: 'lines' in line ? line.lines[0].itemName : line.itemName,
-  code: 'lines' in line ? line.lines[0].itemCode : line.itemCode,
+  id: 'lines' in line ? line.lines[0].item.id : line.item.id,
+  name: 'lines' in line ? line.lines[0].item.name : line.item.name,
+  code: 'lines' in line ? line.lines[0].item.code : line.item.code,
   isVisible: true,
   availableBatches: {
     __typename: 'StockLineConnector',
@@ -50,5 +50,7 @@ export const toItem = (line: ItemLike): Item => ({
     averageMonthlyConsumption: 0,
     availableStockOnHand: 0,
   },
-  unitName: '',
+  unitName:
+    ('lines' in line ? line.lines[0].item?.unitName : line.item?.unitName) ??
+    '',
 });


### PR DESCRIPTION
Fixes #911 

- Removes PartialOutboundLine and renames to `OutboundX` over `OutboundShipmentX`
- Removes `Invoice` and `InvoiceLine` types completely
- Removed unused fields in the queries