### PR TITLE
Add adjust item search input and remove use of Item type

### DIFF
--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,4 +1,4 @@
-import { StockLineNode, ItemNode, NameNode } from './schema';
+import { StockLineNode, NameNode } from './schema';
 
 export * from './utility';
 export * from './schema';
@@ -13,15 +13,6 @@ export interface Name extends NameNode {
   name: string;
   isCustomer: boolean;
   isSupplier: boolean;
-}
-
-export interface Item extends ItemNode, DomainObject {
-  id: string;
-  isVisible: boolean;
-  code: string;
-  name: string;
-  availableQuantity: number;
-  unitName: string;
 }
 
 export interface StockLine

--- a/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.stories.tsx
@@ -4,7 +4,6 @@ import { Table, TableHead } from '@mui/material';
 import { HeaderCell, HeaderRow } from './Header';
 import { useSortBy } from '@common/hooks';
 import { useColumns } from '../../hooks';
-import { Item } from '@common/types';
 
 export default {
   title: 'Table/HeaderRow',
@@ -12,7 +11,11 @@ export default {
 } as ComponentMeta<typeof HeaderRow>;
 
 const Template: Story = () => {
-  const { onChangeSortBy, sortBy } = useSortBy<Item>({ key: 'name' });
+  const { onChangeSortBy, sortBy } = useSortBy<{
+    id: string;
+    name: string;
+    packSize: number;
+  }>({ key: 'name' });
 
   const [column1, column2] = useColumns(
     ['name', 'packSize'],

--- a/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.test.tsx
@@ -3,8 +3,13 @@ import { waitFor, render } from '@testing-library/react';
 import { HeaderCell, HeaderRow } from './Header';
 import userEvent from '@testing-library/user-event';
 import { useColumns } from '../../hooks';
-import { Item } from '@common/types';
 import { TestingProvider } from '../../../../../utils';
+
+type Item = {
+  id: string;
+  status: string;
+  packSize: number;
+};
 
 describe('HeaderRow', () => {
   const Example: FC<{

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -31,7 +31,7 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
         <Grid item flex={1}>
           <ItemSearchInput
             disabled={mode === ModalMode.Update}
-            currentItem={item}
+            currentItemId={item?.id}
             onChange={onChangeItem}
             extraFilter={itemToCheck => {
               const itemAlreadyInStocktake = items?.some(

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks.ts
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks.ts
@@ -1,13 +1,12 @@
+import React, { useEffect, Dispatch, SetStateAction } from 'react';
+import { RecordPatch, generateUUID } from '@openmsupply-client/common';
+import {
+  useStockLines,
+  ItemRowFragment,
+  StockLineFragment,
+} from '@openmsupply-client/system';
 import { useStocktakeFields } from './../../../api/hooks';
 import { StocktakeLineFragment } from './../../../api/operations.generated';
-import React, { useEffect, Dispatch, SetStateAction } from 'react';
-import {
-  StockLine,
-  RecordPatch,
-  generateUUID,
-} from '@openmsupply-client/common';
-import { useStockLines, ItemRowFragment } from '@openmsupply-client/system';
-
 import {
   useStocktakeRows,
   useStocktakeLines,
@@ -58,7 +57,7 @@ const createDraftLine = (
 
 const stockLineToDraftLine = (
   stocktakeId: string,
-  line: StockLine
+  line: StockLineFragment
 ): DraftStocktakeLine => {
   return {
     stocktakeId,
@@ -96,7 +95,7 @@ const useDraftStocktakeLines = (
 
   useEffect(() => {
     const uncountedLines =
-      stockLines?.filter(
+      stockLines?.nodes.filter(
         ({ id }) =>
           !stocktakeLines?.some(({ stockLine }) => stockLine?.id === id)
       ) ?? [];

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import {
   TableProvider,
   createTableStore,
-  Item,
   useEditModal,
   DetailViewSkeleton,
   AlertModal,
@@ -10,8 +9,8 @@ import {
   RouteBuilder,
   useTranslation,
 } from '@openmsupply-client/common';
-import { toItem } from '@openmsupply-client/system';
 import { AppRoute } from '@openmsupply-client/config';
+import { toItemRow, ItemRowFragment } from '@openmsupply-client/system';
 import { Toolbar } from './Toolbar';
 import { Footer } from './Footer';
 import { AppBarButtons } from './AppBarButtons';
@@ -23,14 +22,14 @@ import { useInbound, InboundLineFragment } from '../api';
 
 export const DetailView: FC = () => {
   const { data, isLoading } = useInbound();
-  const { onOpen, onClose, mode, entity, isOpen } = useEditModal<Item>();
+  const { onOpen, onClose, mode, entity, isOpen } =
+    useEditModal<ItemRowFragment>();
   const navigate = useNavigate();
   const t = useTranslation('replenishment');
 
   const onRowClick = React.useCallback(
     (line: InboundItem | InboundLineFragment) => {
-      const item = toItem(line);
-      onOpen(item);
+      onOpen(toItemRow(line));
     },
     [onOpen]
   );

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -14,12 +14,12 @@ import {
   DialogButton,
   useDialog,
   generateUUID,
-  Item,
   useNotification,
   ModalMode,
   useDirtyCheck,
   useConfirmOnLeaving,
 } from '@openmsupply-client/common';
+import { ItemRowFragment } from '@openmsupply-client/system';
 import { InboundLineEditPanel } from './InboundLineEditPanel';
 import { QuantityTable, PricingTable, LocationTable } from './TabTables';
 import { InboundLineEditForm } from './InboundLineEditForm';
@@ -33,7 +33,7 @@ import {
 import { DraftInboundLine } from '../../../../types';
 
 interface InboundLineEditProps {
-  item: Item | null;
+  item: ItemRowFragment | null;
   mode: ModalMode | null;
   isOpen: boolean;
   onClose: () => void;
@@ -130,7 +130,7 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
 }) => {
   const t = useTranslation('replenishment');
   const { error } = useNotification();
-  const [currentItem, setCurrentItem] = useState<Item | null>(item);
+  const [currentItem, setCurrentItem] = useState<ItemRowFragment | null>(item);
   const nextItem = useNextItem(currentItem?.id ?? '');
   const isMediumScreen = useIsMediumScreen();
   const [currentTab, setCurrentTab] = useState<Tabs>(Tabs.Batch);

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -1,19 +1,18 @@
 import React, { FC } from 'react';
 import {
-  Item,
   ModalRow,
   ModalLabel,
   Grid,
   useTranslation,
   BasicTextInput,
 } from '@openmsupply-client/common';
-import { ItemSearchInput } from '@openmsupply-client/system';
+import { ItemRowFragment, ItemSearchInput } from '@openmsupply-client/system';
 import { useInboundItems } from '../../../api';
 
 interface InboundLineEditProps {
-  item: Item | null;
+  item: ItemRowFragment | null;
   disabled: boolean;
-  onChangeItem: (item: Item) => void;
+  onChangeItem: (item: ItemRowFragment) => void;
 }
 
 export const InboundLineEditForm: FC<InboundLineEditProps> = ({
@@ -31,8 +30,8 @@ export const InboundLineEditForm: FC<InboundLineEditProps> = ({
         <Grid item flex={1}>
           <ItemSearchInput
             disabled={disabled}
-            currentItem={item}
-            onChange={(newItem: Item | null) =>
+            currentItemId={item?.id}
+            onChange={(newItem: ItemRowFragment | null) =>
               newItem && onChangeItem(newItem)
             }
             extraFilter={item => {

--- a/packages/invoices/src/InboundShipment/api/hooks.ts
+++ b/packages/invoices/src/InboundShipment/api/hooks.ts
@@ -1,12 +1,10 @@
 import { useCallback } from 'react';
-import { toItem } from '@openmsupply-client/system';
 import {
   useQueryParams,
   useTableStore,
   useTranslation,
   useNotification,
   useNavigate,
-  Item,
   getDataSorter,
   useSortBy,
   FieldSelectorControl,
@@ -19,15 +17,16 @@ import {
   useFieldsSelector,
   InvoiceNodeStatus,
 } from '@openmsupply-client/common';
+import { ItemRowFragment } from '@openmsupply-client/system';
 import { inboundLinesToSummaryItems } from './../../utils';
 import { InboundItem } from './../../types';
+import { getInboundQueries } from './api';
 import {
   getSdk,
   InboundFragment,
   InboundLineFragment,
   InboundRowFragment,
 } from './operations.generated';
-import { getInboundQueries } from './api';
 
 export const useInboundApi = () => {
   const { storeId } = useAuthContext();
@@ -115,7 +114,7 @@ export const useInboundItems = () => {
   return { data, sortBy, onSort: onChangeSortBy };
 };
 
-export const useNextItem = (currentItemId: string): Item | null => {
+export const useNextItem = (currentItemId: string): ItemRowFragment | null => {
   const { data } = useInboundItems();
 
   if (!data) return null;
@@ -123,7 +122,7 @@ export const useNextItem = (currentItemId: string): Item | null => {
   const nextItem = data?.[(currentIndex + 1) % data.length];
   if (!nextItem) return null;
 
-  return toItem(nextItem);
+  return nextItem.lines[0].item;
 };
 
 export const useSaveInboundLines = () => {

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback } from 'react';
 import {
   TableProvider,
   createTableStore,
-  Item,
   useEditModal,
   DetailViewSkeleton,
   AlertModal,
@@ -10,7 +9,7 @@ import {
   RouteBuilder,
   useTranslation,
 } from '@openmsupply-client/common';
-import { toItem } from '@openmsupply-client/system';
+import { toItemRow, ItemRowFragment } from '@openmsupply-client/system';
 import { ContentArea } from './ContentArea';
 import { OutboundLineEdit } from './modals/OutboundLineEdit';
 import { OutboundItem } from '../../types';
@@ -23,15 +22,16 @@ import { AppRoute } from '@openmsupply-client/config';
 import { OutboundLineFragment } from '../api/operations.generated';
 
 export const DetailView: FC = () => {
-  const { entity, mode, onOpen, onClose, isOpen } = useEditModal<Item>();
+  const { entity, mode, onOpen, onClose, isOpen } =
+    useEditModal<ItemRowFragment>();
   const { data, isLoading } = useOutbound();
   const t = useTranslation('distribution');
   const navigate = useNavigate();
   const onRowClick = useCallback(
     (item: OutboundLineFragment | OutboundItem) => {
-      onOpen(toItem(item));
+      onOpen(toItemRow(item));
     },
-    [toItem, onOpen]
+    [toItemRow, onOpen]
   );
 
   if (isLoading) return <DetailViewSkeleton hasGroupBy={true} hasHold={true} />;

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/OutboundLineEdit.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/OutboundLineEdit.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   DialogButton,
   Grid,
-  Item,
   useDialog,
   InlineSpinner,
   Box,
@@ -11,6 +10,7 @@ import {
   useBufferState,
   useDirtyCheck,
 } from '@openmsupply-client/common';
+import { ItemRowFragment } from '@openmsupply-client/system';
 import { OutboundLineEditTable } from './OutboundLineEditTable';
 import { OutboundLineEditForm } from './OutboundLineEditForm';
 import {
@@ -31,7 +31,7 @@ import {
 interface ItemDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
-  item: Item | null;
+  item: ItemRowFragment | null;
   mode: ModalMode | null;
 }
 

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/OutboundLineEditForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/OutboundLineEditForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Grid,
-  Item,
   BasicTextInput,
   ModalLabel,
   ModalRow,
@@ -13,15 +12,15 @@ import {
   Box,
   Typography,
 } from '@openmsupply-client/common';
-import { ItemSearchInput } from '@openmsupply-client/system';
+import { ItemSearchInput, ItemRowFragment } from '@openmsupply-client/system';
 import { PackSizeController } from './hooks';
 import { useOutboundRows } from '../../api';
 
 interface OutboundLineEditFormProps {
   allocatedQuantity: number;
   availableQuantity: number;
-  item: Item | null;
-  onChangeItem: (newItem: Item | null) => void;
+  item: ItemRowFragment | null;
+  onChangeItem: (newItem: ItemRowFragment | null) => void;
   onChangeQuantity: (quantity: number, packSize: number | null) => void;
   packSizeController: PackSizeController;
   disabled: boolean;
@@ -49,7 +48,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
         <Grid item flex={1}>
           <ItemSearchInput
             disabled={disabled}
-            currentItem={item}
+            currentItemId={item?.id}
             onChange={onChangeItem}
             extraFilter={item => !items?.some(({ id }) => id === item.id)}
           />

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/hooks/useDraftOutboundLines.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/hooks/useDraftOutboundLines.tsx
@@ -2,11 +2,10 @@ import React, { useEffect, useState, useCallback } from 'react';
 import {
   generateUUID,
   InvoiceLineNodeType,
-  Item,
   useConfirmOnLeaving,
   useDirtyCheck,
 } from '@openmsupply-client/common';
-import { useStockLines } from '@openmsupply-client/system';
+import { useStockLines, ItemRowFragment } from '@openmsupply-client/system';
 import { DraftOutboundLine } from '../../../../types';
 import { sortByExpiry, issueStock } from '../utils';
 import { useOutboundLines, useOutboundFields } from '../../../api';
@@ -100,13 +99,13 @@ interface UseDraftOutboundLinesControl {
 }
 
 export const useDraftOutboundLines = (
-  item: Item | null
+  item: ItemRowFragment | null
 ): UseDraftOutboundLinesControl => {
   const { id: invoiceId } = useOutboundFields('id');
   const { data: lines, isLoading: outboundLinesLoading } = useOutboundLines(
     item?.id ?? ''
   );
-  const { data, isLoading } = useStockLines(item?.code ?? '');
+  const { data, isLoading } = useStockLines(item?.id);
   const { isDirty, setIsDirty } = useDirtyCheck();
   const [draftOutboundLines, setDraftOutboundLines] = useState<
     DraftOutboundLine[]
@@ -122,7 +121,7 @@ export const useDraftOutboundLines = (
     if (!data) return;
 
     setDraftOutboundLines(() => {
-      const rows = data
+      const rows = data.nodes
         .map(batch => {
           const invoiceLine = lines?.find(
             ({ stockLine }) => stockLine?.id === batch.id

--- a/packages/invoices/src/OutboundShipment/DetailView/modals/hooks/useNextItem.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/modals/hooks/useNextItem.tsx
@@ -1,11 +1,10 @@
-import { Item } from '@openmsupply-client/common';
-import { toItem } from '@openmsupply-client/system';
+import { ItemRowFragment, toItemRow } from '@openmsupply-client/system';
 import { useOutboundRows } from '../../../api';
 
 export const useNextItem = (
   currentItemId?: string
-): { next: Item | null; disabled: boolean } => {
-  const next: Item | null = null;
+): { next: ItemRowFragment | null; disabled: boolean } => {
+  const next: ItemRowFragment | null = null;
   const disabled = true;
 
   const { items } = useOutboundRows();
@@ -22,7 +21,7 @@ export const useNextItem = (
   }
 
   return {
-    next: toItem(nextItem.lines[0]),
+    next: toItemRow(nextItem),
     disabled: currentIdx === numberOfItems - 1,
   };
 };

--- a/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
@@ -9,11 +9,11 @@ import {
   useTranslation,
   useEditModal,
 } from '@openmsupply-client/common';
+import { ItemRowWithStatsFragment } from '@openmsupply-client/system';
 import {
   RequestRequisitionLineFragment,
   useRequestRequisition,
   useIsRequestRequisitionDisabled,
-  ItemWithStatsFragment,
 } from '../api';
 import { Toolbar } from './Toolbar';
 import { Footer } from './Footer/Footer';
@@ -26,7 +26,7 @@ import { RequestLineEdit } from './RequestLineEdit';
 export const DetailView: FC = () => {
   const { data, isLoading } = useRequestRequisition();
   const { onOpen, onClose, mode, entity, isOpen } =
-    useEditModal<ItemWithStatsFragment>();
+    useEditModal<ItemRowWithStatsFragment>();
   const isDisabled = useIsRequestRequisitionDisabled();
   const navigate = useNavigate();
   const t = useTranslation('replenishment');

--- a/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -6,18 +6,16 @@ import {
   BasicSpinner,
   useBufferState,
 } from '@openmsupply-client/common';
+import { ItemRowWithStatsFragment } from '@openmsupply-client/system';
 import { RequestLineEditForm } from './RequestLineEditForm';
-import {
-  useIsRequestRequisitionDisabled,
-  ItemWithStatsFragment,
-} from '../../api';
+import { useIsRequestRequisitionDisabled } from '../../api';
 import { useNextRequestLine, useDraftRequisitionLine } from './hooks';
 
 interface RequestLineEditProps {
   isOpen: boolean;
   onClose: () => void;
   mode: ModalMode | null;
-  item: ItemWithStatsFragment | null;
+  item: ItemRowWithStatsFragment | null;
 }
 
 export const RequestLineEdit = ({

--- a/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -7,14 +7,17 @@ import {
   Typography,
   useTranslation,
 } from '@openmsupply-client/common';
-import { ItemSearchInput } from '@openmsupply-client/system';
-import { useRequestRequisitionLines, ItemWithStatsFragment } from '../../api';
+import {
+  ItemSearchInput,
+  ItemRowWithStatsFragment,
+} from '@openmsupply-client/system';
+import { useRequestRequisitionLines } from '../../api';
 import { DraftRequestRequisitionLine } from './hooks';
 
 interface RequestLineEditFormProps {
-  item: ItemWithStatsFragment | null;
+  item: ItemRowWithStatsFragment | null;
   disabled: boolean;
-  onChangeItem: (item: ItemWithStatsFragment) => void;
+  onChangeItem: (item: ItemRowWithStatsFragment) => void;
   update: (patch: Partial<DraftRequestRequisitionLine>) => void;
   draftLine: DraftRequestRequisitionLine | null;
 }
@@ -87,8 +90,8 @@ export const RequestLineEditForm = ({
           <ItemSearchInput
             width={300}
             disabled={disabled}
-            currentItem={item}
-            onChange={(newItem: ItemWithStatsFragment | null) =>
+            currentItemId={item?.id}
+            onChange={(newItem: ItemRowWithStatsFragment | null) =>
               newItem && onChangeItem(newItem)
             }
             extraFilter={itemToFind => {

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.stories.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { ItemSearchInput } from './ItemSearchInput';
-import { Item } from '@openmsupply-client/common';
+import { ItemRowWithStatsFragment } from '../../api';
 
 export default {
   title: 'Item/ItemSearchInput',
@@ -9,11 +9,12 @@ export default {
 };
 
 const Template: Story = () => {
-  const [selectedItem, setSelectedItem] = React.useState<Item | null>(null);
+  const [selectedItem, setSelectedItem] =
+    React.useState<ItemRowWithStatsFragment | null>(null);
 
   return (
     <ItemSearchInput
-      currentItem={selectedItem ?? undefined}
+      currentItemId={selectedItem?.id ?? undefined}
       onChange={item => {
         setSelectedItem(item);
       }}

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
@@ -7,8 +7,8 @@ import {
   Autocomplete,
   defaultOptionMapper,
 } from '@openmsupply-client/common';
+import { useItemsWithStats } from '../../api';
 import { ItemRowWithStatsFragment } from '../../api/operations.generated';
-import { useItemWithStats } from 'packages/system/src/Item/api/hooks/useItemsWithStats/useItemWithStats';
 
 const ItemOption = styled('li')(({ theme }) => ({
   color: theme.palette.gray.main,
@@ -55,7 +55,7 @@ export const ItemSearchInput: FC<ItemSearchInputProps> = ({
   extraFilter,
   width = 850,
 }) => {
-  const { data, isLoading } = useItemWithStats();
+  const { data, isLoading } = useItemsWithStats();
   const t = useTranslation('common');
   const formatNumber = useFormatNumber();
 

--- a/packages/system/src/Item/api/api.ts
+++ b/packages/system/src/Item/api/api.ts
@@ -1,29 +1,50 @@
 import {
-  Item,
   SortBy,
   ItemSortFieldInput,
   FilterBy,
 } from '@openmsupply-client/common';
-import { ItemRowFragment, ItemFragment } from './operations.generated';
-import { ItemApi } from './hooks';
+import { Sdk, ItemRowFragment, ItemFragment } from './operations.generated';
 import { getItemSortField } from '../utils';
 
-export const ItemQueries = {
+export const getItemQueries = (sdk: Sdk, storeId: string) => ({
   get: {
-    list:
-      (
-        api: ItemApi,
-        storeId: string,
-        {
-          first,
-          offset,
-          sortBy,
-        }: {
-          first: number;
-          offset: number;
-          sortBy: SortBy<Item>;
+    byId: async (itemId: string) => {
+      const result = await sdk.itemById({ storeId, itemId });
+
+      const { items } = result;
+
+      if (items.__typename === 'ItemConnector') {
+        if (items.nodes.length) {
+          return items.nodes[0];
         }
-      ) =>
+      }
+
+      throw new Error('Item not found');
+    },
+    listWithStats: async () => {
+      const result = await sdk.itemsWithStats({ storeId });
+
+      console.log(result);
+
+      const { items } = result;
+
+      if (result.items.__typename === 'ItemConnector') {
+        return items;
+      }
+
+      throw new Error('Could not fetch items');
+    },
+
+    list:
+      ({
+        first,
+        offset,
+        sortBy,
+      }: {
+        first: number;
+        offset: number;
+        sortBy: SortBy<ItemRowFragment>;
+      }) =>
       async (): Promise<{
         nodes: ItemRowFragment[];
         totalCount: number;
@@ -33,7 +54,7 @@ export const ItemQueries = {
             ? ItemSortFieldInput.Name
             : ItemSortFieldInput.Code;
 
-        const result = await api.itemsListView({
+        const result = await sdk.itemsListView({
           first,
           offset,
           key,
@@ -45,22 +66,18 @@ export const ItemQueries = {
 
         return items;
       },
-    listWithStockLines: async (
-      api: ItemApi,
-      storeId: string,
-      {
-        first,
-        offset,
-        sortBy,
-        filterBy,
-      }: {
-        first: number;
-        offset: number;
-        sortBy: SortBy<ItemFragment>;
-        filterBy: FilterBy | null;
-      }
-    ) => {
-      const result = await api.itemsWithStockLines({
+    listWithStockLines: async ({
+      first,
+      offset,
+      sortBy,
+      filterBy,
+    }: {
+      first: number;
+      offset: number;
+      sortBy: SortBy<ItemFragment>;
+      filterBy: FilterBy | null;
+    }) => {
+      const result = await sdk.itemsWithStockLines({
         key: getItemSortField(sortBy.key),
         filter: filterBy,
         first,
@@ -75,4 +92,4 @@ export const ItemQueries = {
       throw new Error('Could not fetch item');
     },
   },
-};
+});

--- a/packages/system/src/Item/api/hooks/index.ts
+++ b/packages/system/src/Item/api/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useItem';
 export * from './useStockLines';
 export * from './useItemApi';
 export * from './useItemListView';
+export * from './useItemsWithStats';

--- a/packages/system/src/Item/api/hooks/useItemApi/useItemApi.ts
+++ b/packages/system/src/Item/api/hooks/useItemApi/useItemApi.ts
@@ -1,9 +1,10 @@
-import { useOmSupplyApi } from '@openmsupply-client/common';
+import { getItemQueries } from './../../api';
+import { useAuthContext, useOmSupplyApi } from '@openmsupply-client/common';
 import { getSdk } from '../../operations.generated';
 
-export type ItemApi = ReturnType<typeof getSdk>;
-
-export const useItemApi = (): ItemApi => {
+export const useItemApi = () => {
   const { client } = useOmSupplyApi();
-  return getSdk(client);
+  const { storeId } = useAuthContext();
+  const queries = getItemQueries(getSdk(client), storeId);
+  return { ...queries, storeId };
 };

--- a/packages/system/src/Item/api/hooks/useItemListView/useItemListView.ts
+++ b/packages/system/src/Item/api/hooks/useItemListView/useItemListView.ts
@@ -5,7 +5,6 @@ import {
 } from '@openmsupply-client/common';
 import { useItemApi } from './../useItemApi';
 import { ItemRowFragment } from '../../operations.generated';
-import { ItemQueries } from '../../api';
 
 export const useItemListView = () => {
   const { storeId } = useAuthContext();
@@ -17,7 +16,7 @@ export const useItemListView = () => {
   return {
     ...useQuery(
       ['item', 'list', storeId, queryParams],
-      ItemQueries.get.list(api, storeId, {
+      api.get.list({
         first: queryParams.first,
         offset: queryParams.offset,
         sortBy: queryParams.sortBy,

--- a/packages/system/src/Item/api/hooks/useItemsWithStats/index.ts
+++ b/packages/system/src/Item/api/hooks/useItemsWithStats/index.ts
@@ -1,0 +1,1 @@
+export * from './useItemsWithStats';

--- a/packages/system/src/Item/api/hooks/useItemsWithStats/useItemWithStats.tsx
+++ b/packages/system/src/Item/api/hooks/useItemsWithStats/useItemWithStats.tsx
@@ -1,0 +1,8 @@
+import { useQuery } from '@openmsupply-client/common';
+import { useItemApi } from '../useItemApi';
+
+export const useItemWithStats = () => {
+  const api = useItemApi();
+
+  return useQuery(['item', 'list', 'stats'], api.get.listWithStats);
+};

--- a/packages/system/src/Item/api/hooks/useItemsWithStats/useItemsWithStats.tsx
+++ b/packages/system/src/Item/api/hooks/useItemsWithStats/useItemsWithStats.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@openmsupply-client/common';
 import { useItemApi } from '../useItemApi';
 
-export const useItemWithStats = () => {
+export const useItemsWithStats = () => {
   const api = useItemApi();
 
   return useQuery(['item', 'list', 'stats'], api.get.listWithStats);

--- a/packages/system/src/Item/api/hooks/useStockLines/useStockLines.tsx
+++ b/packages/system/src/Item/api/hooks/useStockLines/useStockLines.tsx
@@ -1,4 +1,4 @@
-import { useItem } from '../useItem/useItem';
+import { useItem } from '../useItem';
 
 export const useStockLines = (itemId: string | undefined) => {
   const queryState = useItem(itemId);

--- a/packages/system/src/Item/api/hooks/useStockLines/useStockLines.tsx
+++ b/packages/system/src/Item/api/hooks/useStockLines/useStockLines.tsx
@@ -1,15 +1,9 @@
-import { Item, StockLineNode } from '@openmsupply-client/common';
-import { UseQueryResult } from 'react-query';
 import { useItem } from '../useItem/useItem';
 
-export const useStockLines = (
-  itemCode: string
-): Omit<UseQueryResult<Item>, 'data'> & { data?: StockLineNode[] } => {
-  const queryState = useItem(itemCode);
-
+export const useStockLines = (itemId: string | undefined) => {
+  const queryState = useItem(itemId);
   const { data } = queryState;
-
   const { availableBatches } = data ?? {};
 
-  return { ...queryState, data: availableBatches?.nodes };
+  return { ...queryState, data: availableBatches };
 };

--- a/packages/system/src/Item/api/operations.generated.ts
+++ b/packages/system/src/Item/api/operations.generated.ts
@@ -4,7 +4,11 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
+export type StockLineFragment = { __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, note?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, location?: { __typename: 'LocationNode', code: string, id: string, name: string, onHold: boolean } | null };
+
 export type ItemRowFragment = { __typename: 'ItemNode', id: string, code: string, name: string, unitName?: string | null };
+
+export type ItemRowWithStatsFragment = { __typename: 'ItemNode', id: string, code: string, name: string, unitName?: string | null, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand: number } };
 
 export type ItemFragment = { __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, unitName?: string | null, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, packSize: number, sellPricePerPack: number, totalNumberOfPacks: number, onHold: boolean, note?: string | null, storeId: string, locationName?: string | null }> }, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand: number } };
 
@@ -32,6 +36,43 @@ export type ItemsListViewQueryVariables = Types.Exact<{
 
 export type ItemsListViewQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', id: string, code: string, name: string, unitName?: string | null }> } };
 
+export type ItemsWithStatsQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String'];
+}>;
+
+
+export type ItemsWithStatsQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', nodes: Array<{ __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, unitName?: string | null, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand: number } }> } };
+
+export type ItemByIdQueryVariables = Types.Exact<{
+  storeId: Types.Scalars['String'];
+  itemId: Types.Scalars['String'];
+}>;
+
+
+export type ItemByIdQuery = { __typename: 'Queries', items: { __typename: 'ItemConnector', totalCount: number, nodes: Array<{ __typename: 'ItemNode', code: string, id: string, isVisible: boolean, name: string, unitName?: string | null, stats: { __typename: 'ItemStatsNode', averageMonthlyConsumption: number, availableStockOnHand: number, availableMonthsOfStockOnHand: number }, availableBatches: { __typename: 'StockLineConnector', totalCount: number, nodes: Array<{ __typename: 'StockLineNode', availableNumberOfPacks: number, batch?: string | null, costPricePerPack: number, expiryDate?: string | null, id: string, itemId: string, note?: string | null, onHold: boolean, packSize: number, sellPricePerPack: number, storeId: string, totalNumberOfPacks: number, location?: { __typename: 'LocationNode', code: string, id: string, name: string, onHold: boolean } | null }> } }> } };
+
+export const StockLineFragmentDoc = gql`
+    fragment StockLine on StockLineNode {
+  availableNumberOfPacks
+  batch
+  costPricePerPack
+  expiryDate
+  id
+  itemId
+  location {
+    code
+    id
+    name
+    onHold
+  }
+  note
+  onHold
+  packSize
+  sellPricePerPack
+  storeId
+  totalNumberOfPacks
+}
+    `;
 export const ItemRowFragmentDoc = gql`
     fragment ItemRow on ItemNode {
   __typename
@@ -41,6 +82,17 @@ export const ItemRowFragmentDoc = gql`
   unitName
 }
     `;
+export const ItemRowWithStatsFragmentDoc = gql`
+    fragment ItemRowWithStats on ItemNode {
+  ...ItemRow
+  stats(storeId: $storeId) {
+    __typename
+    averageMonthlyConsumption
+    availableStockOnHand
+    availableMonthsOfStockOnHand
+  }
+}
+    ${ItemRowFragmentDoc}`;
 export const ItemFragmentDoc = gql`
     fragment Item on ItemNode {
   __typename
@@ -113,6 +165,59 @@ export const ItemsListViewDocument = gql`
   }
 }
     ${ItemRowFragmentDoc}`;
+export const ItemsWithStatsDocument = gql`
+    query itemsWithStats($storeId: String!) {
+  items(storeId: $storeId) {
+    ... on ItemConnector {
+      __typename
+      nodes {
+        __typename
+        code
+        id
+        isVisible
+        name
+        unitName
+        stats(storeId: $storeId) {
+          __typename
+          averageMonthlyConsumption
+          availableStockOnHand
+          availableMonthsOfStockOnHand
+        }
+      }
+    }
+  }
+}
+    `;
+export const ItemByIdDocument = gql`
+    query itemById($storeId: String!, $itemId: String!) {
+  items(storeId: $storeId, filter: {id: {equalTo: $itemId}}) {
+    ... on ItemConnector {
+      __typename
+      nodes {
+        __typename
+        code
+        id
+        isVisible
+        name
+        unitName
+        stats(storeId: $storeId) {
+          __typename
+          averageMonthlyConsumption
+          availableStockOnHand
+          availableMonthsOfStockOnHand
+        }
+        availableBatches(storeId: $storeId) {
+          totalCount
+          nodes {
+            ...StockLine
+          }
+        }
+      }
+      totalCount
+    }
+  }
+}
+    ${StockLineFragmentDoc}`;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
@@ -126,6 +231,12 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     itemsListView(variables: ItemsListViewQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemsListViewQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ItemsListViewQuery>(ItemsListViewDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'itemsListView');
+    },
+    itemsWithStats(variables: ItemsWithStatsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemsWithStatsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ItemsWithStatsQuery>(ItemsWithStatsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'itemsWithStats');
+    },
+    itemById(variables: ItemByIdQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ItemByIdQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ItemByIdQuery>(ItemByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'itemById');
     }
   };
 }
@@ -162,5 +273,39 @@ export const mockItemsWithStockLinesQuery = (resolver: ResponseResolver<GraphQLR
 export const mockItemsListViewQuery = (resolver: ResponseResolver<GraphQLRequest<ItemsListViewQueryVariables>, GraphQLContext<ItemsListViewQuery>, any>) =>
   graphql.query<ItemsListViewQuery, ItemsListViewQueryVariables>(
     'itemsListView',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockItemsWithStatsQuery((req, res, ctx) => {
+ *   const { storeId } = req.variables;
+ *   return res(
+ *     ctx.data({ items })
+ *   )
+ * })
+ */
+export const mockItemsWithStatsQuery = (resolver: ResponseResolver<GraphQLRequest<ItemsWithStatsQueryVariables>, GraphQLContext<ItemsWithStatsQuery>, any>) =>
+  graphql.query<ItemsWithStatsQuery, ItemsWithStatsQueryVariables>(
+    'itemsWithStats',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockItemByIdQuery((req, res, ctx) => {
+ *   const { storeId, itemId } = req.variables;
+ *   return res(
+ *     ctx.data({ items })
+ *   )
+ * })
+ */
+export const mockItemByIdQuery = (resolver: ResponseResolver<GraphQLRequest<ItemByIdQueryVariables>, GraphQLContext<ItemByIdQuery>, any>) =>
+  graphql.query<ItemByIdQuery, ItemByIdQueryVariables>(
+    'itemById',
     resolver
   )

--- a/packages/system/src/Item/api/operations.graphql
+++ b/packages/system/src/Item/api/operations.graphql
@@ -1,9 +1,40 @@
+fragment StockLine on StockLineNode {
+  availableNumberOfPacks
+  batch
+  costPricePerPack
+  expiryDate
+  id
+  itemId
+  location {
+    code
+    id
+    name
+    onHold
+  }
+  note
+  onHold
+  packSize
+  sellPricePerPack
+  storeId
+  totalNumberOfPacks
+}
+
 fragment ItemRow on ItemNode {
   __typename
   id
   code
   name
   unitName
+}
+
+fragment ItemRowWithStats on ItemNode {
+  ...ItemRow
+  stats(storeId: $storeId) {
+    __typename
+    averageMonthlyConsumption
+    availableStockOnHand
+    availableMonthsOfStockOnHand
+  }
 }
 
 fragment Item on ItemNode {
@@ -83,6 +114,57 @@ query itemsListView(
       __typename
       nodes {
         ...ItemRow
+      }
+      totalCount
+    }
+  }
+}
+
+query itemsWithStats($storeId: String!) {
+  items(storeId: $storeId) {
+    ... on ItemConnector {
+      __typename
+      nodes {
+        __typename
+        code
+        id
+        isVisible
+        name
+        unitName
+        stats(storeId: $storeId) {
+          __typename
+          averageMonthlyConsumption
+          availableStockOnHand
+          availableMonthsOfStockOnHand
+        }
+      }
+    }
+  }
+}
+
+query itemById($storeId: String!, $itemId: String!) {
+  items(storeId: $storeId, filter: { id: { equalTo: $itemId } }) {
+    ... on ItemConnector {
+      __typename
+      nodes {
+        __typename
+        code
+        id
+        isVisible
+        name
+        unitName
+        stats(storeId: $storeId) {
+          __typename
+          averageMonthlyConsumption
+          availableStockOnHand
+          availableMonthsOfStockOnHand
+        }
+        availableBatches(storeId: $storeId) {
+          totalCount
+          nodes {
+            ...StockLine
+          }
+        }
       }
       totalCount
     }

--- a/packages/system/src/Item/utils.ts
+++ b/packages/system/src/Item/utils.ts
@@ -1,55 +1,17 @@
-import { ItemSortFieldInput, Item } from '@openmsupply-client/common';
+import { ItemSortFieldInput } from '@openmsupply-client/common';
 import { ItemLike } from './types';
-import { ItemsWithStockLinesQuery } from './api';
+import { ItemRowFragment } from './api';
 
 export const getItemSortField = (sortField: string): ItemSortFieldInput => {
   if (sortField === 'name') return ItemSortFieldInput.Name;
   return ItemSortFieldInput.Code;
 };
 
-export const mapItemNodes = (
-  result: ItemsWithStockLinesQuery
-): {
-  nodes: Item[];
-  totalCount: number;
-} => {
-  const items = result.items;
-  const { totalCount } = items;
-  const nodes: Item[] = items.nodes.map(item => {
-    return {
-      ...item,
-      availableQuantity: item.availableBatches.nodes.reduce(
-        (sum, batch) =>
-          sum +
-          (batch.onHold ? 0 : batch.availableNumberOfPacks * batch.packSize),
-        0
-      ),
-      allocatedQuantity: 0,
-      unitName: item.unitName ?? '',
-    };
-  });
-
-  return { nodes, totalCount };
-};
-
-export const toItem = (line: ItemLike): Item => ({
+export const toItemRow = (line: ItemLike): ItemRowFragment => ({
   __typename: 'ItemNode',
   id: 'lines' in line ? line.lines[0].item.id : line.item.id,
   name: 'lines' in line ? line.lines[0].item.name : line.item.name,
   code: 'lines' in line ? line.lines[0].item.code : line.item.code,
-  isVisible: true,
-  availableBatches: {
-    __typename: 'StockLineConnector',
-    nodes: [],
-    totalCount: 0,
-  },
-  availableQuantity: 0,
-  stats: {
-    __typename: 'ItemStatsNode',
-    availableMonthsOfStockOnHand: 0,
-    averageMonthlyConsumption: 0,
-    availableStockOnHand: 0,
-  },
   unitName:
     ('lines' in line ? line.lines[0].item?.unitName : line.item?.unitName) ??
     '',


### PR DESCRIPTION
Fixes #871 and https://github.com/openmsupply/openmsupply-client/issues/771

- I took the easy, probably shouldn't do this route
- Essentially wanting to remove the use of the `Item` type which is problematic, like the others I've been removing. Also, wanting to fix the issue with the autocompelete invalid warning. Aaaand wanting to try and simplify the component because it was getting very confusing, difficult to understand exactly what was going on and was doing extra queries when it didn't really need to.
- So.. in the end, the easy fix was to just use some fragment types and query for all items, rather than trying to filter / paginate etc.
- The item query is also only querying for a small subset of item lines - name/code/id and the stats, but not the related stocklines etc also, so with a max of ~5000 nodes of the biggest data file I think it'd be fine..