### PR TITLE
Add find and replace for DomainObject -> RecordWithId

### DIFF
--- a/packages/common/src/hooks/useQueryParams/useQueryParams.ts
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.ts
@@ -1,14 +1,14 @@
-import { DomainObject } from './../../types/index';
+import { RecordWithId } from './../../types/index';
 import { usePagination, PaginationState } from '../usePagination';
 import { useSortBy, SortState, SortRule } from '../useSortBy';
 import { useFilterBy, FilterState, FilterBy } from '../useFilterBy';
 
-export interface QueryParams<T extends DomainObject>
+export interface QueryParams<T extends RecordWithId>
   extends SortState<T>,
     FilterState,
     PaginationState {}
 
-export interface QueryParamsState<T extends DomainObject>
+export interface QueryParamsState<T extends RecordWithId>
   extends SortState<T>,
     FilterState,
     PaginationState {
@@ -18,7 +18,7 @@ export interface QueryParamsState<T extends DomainObject>
   queryParams: QueryParams<T>;
 }
 
-export const useQueryParams = <T extends DomainObject>({
+export const useQueryParams = <T extends RecordWithId>({
   initialSortBy,
   initialFilterBy,
 }: {

--- a/packages/common/src/hooks/useSortBy/useSortBy.ts
+++ b/packages/common/src/hooks/useSortBy/useSortBy.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { Column } from '../../ui/layout/tables';
-import { DomainObject } from '../../types';
+import { RecordWithId } from '../../types';
 export interface SortRule<T> {
   key: keyof T | string;
   isDesc?: boolean;
@@ -10,19 +10,19 @@ export interface SortBy<T> extends SortRule<T> {
   direction: 'asc' | 'desc';
   getSortValue?: (row: T) => string | number;
 }
-export interface SortController<T extends DomainObject> {
+export interface SortController<T extends RecordWithId> {
   sortBy: SortBy<T>;
   onChangeSortBy: (newSortRule: Column<T>) => SortBy<T>;
 }
 
-export interface SortState<T extends DomainObject> extends SortController<T> {
+export interface SortState<T extends RecordWithId> extends SortController<T> {
   sort: SortController<T>;
 }
 
 const getDirection = (isDesc: boolean): 'asc' | 'desc' =>
   isDesc ? 'desc' : 'asc';
 
-export const useSortBy = <T extends DomainObject>({
+export const useSortBy = <T extends RecordWithId>({
   key: initialSortKey,
   isDesc: initialIsDesc = false,
 }: SortRule<T>): SortState<T> => {

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,6 +1,4 @@
 export * from './utility';
 export * from './schema';
 
-type RecordWithId = { id: string };
-
-export type DomainObject = RecordWithId;
+export type RecordWithId = { id: string };

--- a/packages/common/src/types/utility.ts
+++ b/packages/common/src/types/utility.ts
@@ -1,5 +1,5 @@
-import { DomainObject } from './index';
+import { RecordWithId } from './index';
 
 export type ObjectWithStringKeys = Record<string, unknown>;
 
-export type RecordPatch<T extends DomainObject> = Partial<T> & { id: string };
+export type RecordPatch<T extends RecordWithId> = Partial<T> & { id: string };

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -15,11 +15,11 @@ import { TableProps } from './types';
 import { DataRow } from './components/DataRow/DataRow';
 import { PaginationRow } from './columns/PaginationRow';
 import { HeaderCell, HeaderRow } from './components/Header';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useTranslation } from '@common/intl';
 import { useTableStore } from './context';
 
-export const DataTableComponent = <T extends DomainObject>({
+export const DataTableComponent = <T extends RecordWithId>({
   columns,
   data = [],
   isLoading = false,

--- a/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/CheckboxSelectionColumn.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { Checkbox } from '@common/components';
 import { useTableStore, TableStore } from '../context';
 import { ColumnAlign, ColumnDefinition, GenericColumnKey } from './types';
@@ -29,7 +29,7 @@ const useCheckbox = (rowId: string) => {
 };
 
 export const getCheckboxSelectionColumn = <
-  T extends DomainObject
+  T extends RecordWithId
 >(): ColumnDefinition<T> => ({
   key: GenericColumnKey.Selection,
   sortable: false,

--- a/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
@@ -1,10 +1,10 @@
 import { InputAdornment, Tooltip, Typography } from '@mui/material';
 import React, { useState, useEffect } from 'react';
 import { ColumnDefinition } from './types';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { NumericTextInput } from '@common/components';
 
-interface SomeQuantityEntity extends DomainObject {
+interface SomeQuantityEntity extends RecordWithId {
   quantity: number;
   updateQuantity: (quantity: number) => void;
 }

--- a/packages/common/src/ui/layout/tables/columns/ExpiryDateInput/ExpiryDateInput.tsx
+++ b/packages/common/src/ui/layout/tables/columns/ExpiryDateInput/ExpiryDateInput.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { ExpiryDateInput } from '@common/components';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { isTypeOf, isProduction } from '@common/utils';
 import { ColumnDefinition } from '../../columns';
 
 export const getExpiryDateInputColumn = <
-  T extends DomainObject
+  T extends RecordWithId
 >(): ColumnDefinition<T> => ({
   key: 'expiryDateInput',
   label: 'label.expiry',

--- a/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
+++ b/packages/common/src/ui/layout/tables/columns/LineLabel/LineLabel.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { ColumnAlign, ColumnDefinition } from '../types';
 import { useTranslation } from '@common/intl';
 
 export const getLineLabelColumn = <
-  T extends DomainObject
+  T extends RecordWithId
 >(): ColumnDefinition<T> => ({
   key: 'lineLabel',
   sortable: false,

--- a/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
 import { ColorSelectButton } from '@common/components';
 
-interface DomainObjectWithRequiredFields extends DomainObject {
+interface RecordWithIdWithRequiredFields extends RecordWithId {
   colour?: string | null;
   otherPartyName: string;
 }
 
 export const getNameAndColorColumn = <
-  T extends DomainObjectWithRequiredFields
+  T extends RecordWithIdWithRequiredFields
 >(): ColumnDefinition<T> => ({
   label: 'label.name',
   width: 350,

--- a/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NotePopoverColumn/NotePopoverColumn.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { ColumnAlign, ColumnDefinition } from '../types';
 import { MessageSquareIcon } from '@common/icons';
 import { PaperPopover, PaperPopoverSection } from '@common/components';
@@ -29,7 +29,7 @@ const hasRequiredFields = (
   (variableToCheck as NoteObject).header !== undefined &&
   (variableToCheck as NoteObject).body !== undefined;
 
-export const getNotePopoverColumn = <T extends DomainObject>(
+export const getNotePopoverColumn = <T extends RecordWithId>(
   label?: string
 ): ColumnDefinition<T> => ({
   key: 'note',

--- a/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
+++ b/packages/common/src/ui/layout/tables/columns/RowExpand/RowExpand.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ColumnAlign, ColumnDefinition } from '../types';
 import { useExpanded, useTableStore } from '../../context';
 import { IconButton } from '@common/components';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { ChevronDownIcon, ChevronsDownIcon } from '@common/icons';
 import { useTranslation } from '@common/intl';
 
@@ -13,7 +13,7 @@ type RowExpandLabels = {
 };
 
 export const getRowExpandColumn = <
-  T extends DomainObject & { canExpand?: boolean; lines?: T[] }
+  T extends RecordWithId & { canExpand?: boolean; lines?: T[] }
 >(
   labels?: RowExpandLabels
 ): ColumnDefinition<T> => ({

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -1,9 +1,9 @@
 import { JSXElementConstructor } from 'react';
 import { SortBy } from '@common/hooks';
 import { useTranslation, useFormatDate, LocaleKey } from '@common/intl';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 
-export interface CellProps<T extends DomainObject> {
+export interface CellProps<T extends RecordWithId> {
   rowData: T;
   rows: T[];
   columns: Column<T>[];
@@ -13,7 +13,7 @@ export interface CellProps<T extends DomainObject> {
   rowIndex: number;
 }
 
-export interface HeaderProps<T extends DomainObject> {
+export interface HeaderProps<T extends RecordWithId> {
   column: Column<T>;
 }
 
@@ -31,7 +31,7 @@ export enum ColumnAlign {
   Center = 'center',
 }
 
-export type ColumnDataAccessor<T extends DomainObject> = (params: {
+export type ColumnDataAccessor<T extends RecordWithId> = (params: {
   rowData: T;
   rows: T[];
 }) => unknown;
@@ -54,7 +54,7 @@ export enum GenericColumnKey {
   Selection = 'selection',
 }
 
-export interface Column<T extends DomainObject> {
+export interface Column<T extends RecordWithId> {
   key: keyof T | GenericColumnKey | string;
   accessor: ColumnDataAccessor<T>;
 
@@ -87,7 +87,7 @@ export interface Column<T extends DomainObject> {
   setter: ColumnDataSetter<T>;
 }
 
-export interface ColumnDefinition<T extends DomainObject>
+export interface ColumnDefinition<T extends RecordWithId>
   extends Partial<Omit<Column<T>, 'key'>> {
   key: keyof T | GenericColumnKey | string;
 }

--- a/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
 import { CurrencyInput } from '@common/components';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useBufferState, useDebounceCallback } from '@common/hooks';
 
-export const CurrencyInputCell = <T extends DomainObject>({
+export const CurrencyInputCell = <T extends RecordWithId>({
   rowData,
   rows,
   column,

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
 import { BasicTextInput } from '@common/components';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useBufferState, useDebounceCallback } from '@common/hooks';
 
-export const NumberInputCell = <T extends DomainObject>({
+export const NumberInputCell = <T extends RecordWithId>({
   rowData,
   column,
   rows,

--- a/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { CellProps } from '../../../columns';
 import { BasicTextInput } from '@common/components';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useBufferState, useDebounceCallback } from '@common/hooks';
 
-export const TextInputCell = <T extends DomainObject>({
+export const TextInputCell = <T extends RecordWithId>({
   rowData,
   column,
   rows,

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -2,11 +2,11 @@ import React, { FC } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { Column } from '../../columns/types';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useExpanded, useIsDisabled, useRowStyle } from '../../context';
 import { Collapse, Fade } from '@mui/material';
 
-interface DataRowProps<T extends DomainObject> {
+interface DataRowProps<T extends RecordWithId> {
   columns: Column<T>[];
   rows: T[];
   onClick?: (rowData: T) => void;
@@ -17,7 +17,7 @@ interface DataRowProps<T extends DomainObject> {
   rowIndex: number;
 }
 
-export const DataRow = <T extends DomainObject>({
+export const DataRow = <T extends RecordWithId>({
   columns,
   onClick,
   rowData,

--- a/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
+++ b/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
@@ -1,15 +1,15 @@
 import React, { JSXElementConstructor } from 'react';
 import { Column } from './../../columns/types';
 import { Box, alpha } from '@mui/material';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { DataTable } from '../../DataTable';
 
-interface MiniTableProps<T extends DomainObject> {
+interface MiniTableProps<T extends RecordWithId> {
   rows: T[];
   columns: Column<T>[];
 }
 
-export const MiniTable = <T extends DomainObject>({
+export const MiniTable = <T extends RecordWithId>({
   rows,
   columns,
 }: MiniTableProps<T>): React.ReactElement<

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { TableCell, TableRow, TableSortLabel } from '@mui/material';
 import { Column } from '../../columns/types';
 import { SortDescIcon } from '@common/icons';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useDebounceCallback } from '@common/hooks';
 
 export const HeaderRow: FC<{ dense?: boolean }> = ({ dense, ...props }) => (
@@ -17,12 +17,12 @@ export const HeaderRow: FC<{ dense?: boolean }> = ({ dense, ...props }) => (
   />
 );
 
-interface HeaderCellProps<T extends DomainObject> {
+interface HeaderCellProps<T extends RecordWithId> {
   column: Column<T>;
   dense?: boolean;
 }
 
-export const HeaderCell = <T extends DomainObject>({
+export const HeaderCell = <T extends RecordWithId>({
   column,
   dense = false,
 }: HeaderCellProps<T>): JSX.Element => {

--- a/packages/common/src/ui/layout/tables/components/index.tsx
+++ b/packages/common/src/ui/layout/tables/components/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { CellProps, HeaderProps } from '../columns/types';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { useTranslation, useFormatDate } from '@common/intl';
 
 export * from './DataRow';
@@ -8,7 +8,7 @@ export * from './Cells';
 export * from './Header';
 export * from './Expand';
 
-export const BasicCell = <T extends DomainObject>({
+export const BasicCell = <T extends RecordWithId>({
   column,
   rowData,
   rows,
@@ -28,7 +28,7 @@ export const BasicCell = <T extends DomainObject>({
   );
 };
 
-export const BasicHeader = <T extends DomainObject>({
+export const BasicHeader = <T extends RecordWithId>({
   column,
 }: HeaderProps<T>): ReactElement => {
   const t = useTranslation();

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.test.tsx
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { ColumnAlign, ColumnFormat } from '../../columns';
 import { useColumns } from './useColumns';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 
-interface Test extends DomainObject {
+interface Test extends RecordWithId {
   id: string;
 }
 

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -1,5 +1,5 @@
 import { DependencyList, useMemo } from 'react';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import {
   ColumnDataAccessor,
   ColumnDefinition,
@@ -13,7 +13,7 @@ import { getDateOrNull } from '../../../../../utils';
 import { SortBy } from '@common/hooks';
 import { ColumnDefinitionSetBuilder, ColumnKey } from '../../utils';
 
-const getColumnWidths = <T extends DomainObject>(
+const getColumnWidths = <T extends RecordWithId>(
   column: ColumnDefinition<T>
 ) => {
   const getDefaultWidth = () => {
@@ -52,7 +52,7 @@ const getSortType = (column: { format?: ColumnFormat }) => {
  * If the key is not a value of the domain object, then you should provide your own data accessor.
  */
 const getDefaultAccessor =
-  <T extends DomainObject>(
+  <T extends RecordWithId>(
     column: ColumnDefinition<T>
   ): ColumnDataAccessor<T> =>
   ({ rowData }) => {
@@ -62,7 +62,7 @@ const getDefaultAccessor =
   };
 
 const getDefaultColumnSetter =
-  <T extends DomainObject>(column: ColumnDefinition<T>) =>
+  <T extends RecordWithId>(column: ColumnDefinition<T>) =>
   () => {
     if (process.env['NODE_ENV']) {
       throw new Error(
@@ -75,7 +75,7 @@ const getDefaultColumnSetter =
     }
   };
 
-const getDefaultFormatter = <T extends DomainObject>(
+const getDefaultFormatter = <T extends RecordWithId>(
   column: ColumnDefinition<T>
 ) => {
   switch (column.format) {
@@ -102,7 +102,7 @@ const getDefaultFormatter = <T extends DomainObject>(
   }
 };
 
-const getDefaultColumnAlign = <T extends DomainObject>(
+const getDefaultColumnAlign = <T extends RecordWithId>(
   column: ColumnDefinition<T>
 ) => {
   const { format } = column;
@@ -128,18 +128,18 @@ const getDefaultColumnAlign = <T extends DomainObject>(
   return ColumnAlign.Left;
 };
 
-interface ColumnOptions<T extends DomainObject> {
+interface ColumnOptions<T extends RecordWithId> {
   onChangeSortBy?: (column: Column<T>) => void;
   sortBy?: SortBy<T>;
 }
 
-export type ColumnDescription<T extends DomainObject> =
+export type ColumnDescription<T extends RecordWithId> =
   | ColumnDefinition<T>
   | ColumnKey
   | [ColumnKey | ColumnDefinition<T>, Omit<ColumnDefinition<T>, 'key'>]
   | [ColumnKey];
 
-export const createColumnWithDefaults = <T extends DomainObject>(
+export const createColumnWithDefaults = <T extends RecordWithId>(
   column: ColumnDefinition<T>,
   options?: ColumnOptions<T>
 ): Column<T> => {
@@ -169,7 +169,7 @@ export const createColumnWithDefaults = <T extends DomainObject>(
   return { ...defaults, ...column };
 };
 
-export const createColumns = <T extends DomainObject>(
+export const createColumns = <T extends RecordWithId>(
   columnsToCreate: ColumnDescription<T>[],
   options?: ColumnOptions<T>
 ): Column<T>[] => {
@@ -182,7 +182,7 @@ export const createColumns = <T extends DomainObject>(
   });
 };
 
-export const useColumns = <T extends DomainObject>(
+export const useColumns = <T extends RecordWithId>(
   columnsToCreate: ColumnDescription<T>[],
   options?: ColumnOptions<T>,
   depsArray: DependencyList = []

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -1,5 +1,5 @@
 import { ReactNode, FC } from 'react';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { Pagination, SortRule } from '@common/hooks';
 import { Column } from './columns/types';
 
@@ -14,7 +14,7 @@ export interface QueryResponse<T> {
   totalLength: number;
 }
 
-export interface TableProps<T extends DomainObject> {
+export interface TableProps<T extends RecordWithId> {
   columns: Column<T>[];
   data?: T[];
   isLoading?: boolean;

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.test.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.test.ts
@@ -1,7 +1,7 @@
 import { ColumnDefinitionSetBuilder } from './ColumnDefinitionSetBuilder';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 
-interface Invoice extends DomainObject {
+interface Invoice extends RecordWithId {
   id: string;
   invoiceNumber: string;
   status: string;

--- a/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
+++ b/packages/common/src/ui/layout/tables/utils/ColumnDefinitionSetBuilder.ts
@@ -1,10 +1,10 @@
 import { getCheckboxSelectionColumn } from '../columns/CheckboxSelectionColumn';
 import { ColumnAlign, ColumnFormat } from '../columns/types';
 import { formatExpiryDate } from '@common/utils';
-import { DomainObject } from '@common/types';
+import { RecordWithId } from '@common/types';
 import { ColumnDefinition } from '../columns/types';
 
-const createColumn = <T extends DomainObject>(
+const createColumn = <T extends RecordWithId>(
   column: ColumnDefinition<T>
 ): ColumnDefinition<T> => {
   return column;
@@ -41,7 +41,7 @@ export type ColumnKey =
   | 'stocktakeDatetime'
   | 'monthlyConsumption';
 
-const getColumnLookup = <T extends DomainObject>(): Record<
+const getColumnLookup = <T extends RecordWithId>(): Record<
   ColumnKey,
   ColumnDefinition<T>
 > => ({
@@ -214,7 +214,7 @@ const getColumnLookup = <T extends DomainObject>(): Record<
   },
 });
 
-export class ColumnDefinitionSetBuilder<T extends DomainObject> {
+export class ColumnDefinitionSetBuilder<T extends RecordWithId> {
   columns: ColumnDefinition<T>[];
 
   currentOrder: number;

--- a/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/GeneralTab.tsx
@@ -2,7 +2,7 @@ import React, { FC, useMemo } from 'react';
 import {
   DataTable,
   usePagination,
-  DomainObject,
+  RecordWithId,
   useTranslation,
   useIsGrouped,
   Box,
@@ -13,7 +13,7 @@ import { InboundItem } from '../../types';
 import { useInboundItems, useInboundLines, InboundLineFragment } from '../api';
 import { useExpansionColumns, useInboundShipmentColumns } from './columns';
 
-interface GeneralTabProps<T extends DomainObject> {
+interface GeneralTabProps<T extends RecordWithId> {
   onRowClick?: (rowData: T) => void;
 }
 

--- a/packages/system/src/Location/Components/LocationInputColumn.tsx
+++ b/packages/system/src/Location/Components/LocationInputColumn.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
-  DomainObject,
+  RecordWithId,
   ColumnDefinition,
   isProduction,
 } from '@openmsupply-client/common';
 import { LocationSearchInput } from './LocationSearchInput';
 import { LocationRowFragment } from '../api';
-interface LocationObject extends DomainObject {
+interface LocationObject extends RecordWithId {
   location: LocationRowFragment;
 }
 
@@ -16,7 +16,7 @@ const hasRequiredFields = (
   'location' in (variableToCheck as LocationObject);
 
 export const getLocationInputColumn = <
-  T extends DomainObject
+  T extends RecordWithId
 >(): ColumnDefinition<T> => ({
   key: 'locationInput',
   label: 'label.location',


### PR DESCRIPTION
Fixes #929 

- We can go with either `DomainObject` or `RecordWithId` whichever you prefer, but I thought it would be better to stick to one instead of having `DomainObject = RecordWithId` and using `DomainObject` everywhere 🤷 