### PR TITLE
add store selector

### DIFF
--- a/packages/common/src/authentication/AuthContext.tsx
+++ b/packages/common/src/authentication/AuthContext.tsx
@@ -40,6 +40,7 @@ interface AuthControl {
   ) => Promise<AuthenticationResponse>;
   logout: () => void;
   mostRecentlyUsedCredentials?: MRUCredentials | null;
+  setStore: (store: Store) => void;
   store?: Store;
   storeId: string;
   token?: string;
@@ -74,6 +75,7 @@ const AuthContext = createContext<AuthControl>({
     })),
   logout: () => {},
   storeId: '',
+  setStore: () => {},
 });
 
 const { Provider } = AuthContext;
@@ -107,6 +109,13 @@ export const AuthProvider: FC = ({ children }) => {
     return { token, error };
   };
 
+  const setStore = (store: Store) => {
+    if (!localToken) return;
+
+    setLocalStore(store);
+    setMRUCredentials({ username: user?.name ?? '', store: store });
+  };
+
   const logout = () => {
     Cookies.remove('auth');
     setLocalStore(undefined);
@@ -122,6 +131,7 @@ export const AuthProvider: FC = ({ children }) => {
       user,
       store: localStore,
       mostRecentlyUsedCredentials,
+      setStore,
     }),
     [
       login,
@@ -130,6 +140,7 @@ export const AuthProvider: FC = ({ children }) => {
       user,
       mostRecentlyUsedCredentials,
       isLoggingIn,
+      setStore,
     ]
   );
 

--- a/packages/common/src/intl/locales/en/app.json
+++ b/packages/common/src/intl/locales/en/app.json
@@ -57,5 +57,6 @@
   "heading.password": "Password",
   "heading.store": "Store",
   "button.login": "Log in",
-  "error.login": "Invalid username or password"
+  "error.login": "Invalid username or password",
+  "select-store": "Select store"
 }

--- a/packages/host/src/components/Footer/Footer.tsx
+++ b/packages/host/src/components/Footer/Footer.tsx
@@ -24,15 +24,15 @@ export const Footer: React.FC = () => {
       <StoreSelector>
         <PaddedCell>
           <HomeIcon sx={iconStyles} />
-          <Typography sx={textStyles}>{store.code}</Typography>
+          <Typography sx={textStyles}>{store?.code}</Typography>
         </PaddedCell>
       </StoreSelector>
-      {user?.name && (
+      {user ? (
         <PaddedCell>
           <UserIcon sx={iconStyles} />
           <Typography sx={textStyles}>{user.name}</Typography>
         </PaddedCell>
-      )}
+      ) : null}
     </Box>
   );
 };

--- a/packages/host/src/components/Footer/Footer.tsx
+++ b/packages/host/src/components/Footer/Footer.tsx
@@ -7,6 +7,7 @@ import {
   useAuthContext,
   UserIcon,
 } from '@openmsupply-client/common';
+import { StoreSelector } from './StoreSelector';
 
 export const Footer: React.FC = () => {
   const { user, store } = useAuthContext();
@@ -20,12 +21,12 @@ export const Footer: React.FC = () => {
 
   return (
     <Box gap={2} display="flex" flex={1} alignItems="center">
-      {store?.code && (
+      <StoreSelector>
         <PaddedCell>
           <HomeIcon sx={iconStyles} />
           <Typography sx={textStyles}>{store.code}</Typography>
         </PaddedCell>
-      )}
+      </StoreSelector>
       {user?.name && (
         <PaddedCell>
           <UserIcon sx={iconStyles} />

--- a/packages/host/src/components/Footer/StoreSelector.tsx
+++ b/packages/host/src/components/Footer/StoreSelector.tsx
@@ -1,0 +1,64 @@
+import React, { FC } from 'react';
+import {
+  Box,
+  CircularProgress,
+  FlatButton,
+  PaperPopoverSection,
+  useAuthContext,
+  usePaperClickPopover,
+  useTranslation,
+} from '@openmsupply-client/common';
+import { StoreRowFragment, useStores } from '@openmsupply-client/system';
+
+export const StoreSelector: FC = ({ children }) => {
+  const { store, setStore } = useAuthContext();
+  const { hide, PaperClickPopover } = usePaperClickPopover();
+  const { data, isLoading } = useStores();
+  const t = useTranslation('app');
+
+  const storeSorter = (a: StoreRowFragment, b: StoreRowFragment) => {
+    if (a.code < b.code) return -1;
+    if (a.code > b.code) return 1;
+    return 0;
+  };
+  const stores = (data?.nodes ?? []).sort(storeSorter);
+
+  if (!store?.code) return undefined;
+
+  if (stores.length < 2) return <>{children}</>;
+
+  const storeButtons = stores.map(s => (
+    <FlatButton
+      label={s.code}
+      disabled={s.id === store.id}
+      onClick={() => {
+        setStore(s);
+        hide();
+      }}
+      key={s.id}
+    />
+  ));
+  return (
+    <PaperClickPopover
+      placement="top"
+      width={250}
+      Content={
+        <PaperPopoverSection label={t('select-store')}>
+          {isLoading ? (
+            <CircularProgress size={12} />
+          ) : (
+            <Box
+              style={{ maxHeight: '200px', overflowY: 'auto' }}
+              display="flex"
+              flexDirection="column"
+            >
+              {storeButtons}
+            </Box>
+          )}
+        </PaperPopoverSection>
+      }
+    >
+      {children}
+    </PaperClickPopover>
+  );
+};

--- a/packages/host/src/components/Footer/StoreSelector.tsx
+++ b/packages/host/src/components/Footer/StoreSelector.tsx
@@ -23,7 +23,7 @@ export const StoreSelector: FC = ({ children }) => {
   };
   const stores = (data?.nodes ?? []).sort(storeSorter);
 
-  if (!store?.code) return undefined;
+  if (!store?.code) return null;
 
   if (stores.length < 2) return <>{children}</>;
 


### PR DESCRIPTION
Fixes #958

While not strictly speaking a requirement.. it is handy. 
Just popped in a sneaky `onClick` on the store, pop up a list of stores, click and change. No one needs to know..

<img width="306" alt="Screen Shot 2022-03-04 at 4 39 28 PM" src="https://user-images.githubusercontent.com/9192912/156695875-6131a07d-0f4a-408f-a53d-e6bfb9a0cc7f.png">

