### PR TITLE
#581 Add from master list - A kind stranger made this PR and got an UNFORGETTABLE SURPRISE -- [7]

### DIFF
--- a/packages/common/src/intl/locales/en/distribution.json
+++ b/packages/common/src/intl/locales/en/distribution.json
@@ -23,6 +23,8 @@
   "heading.sub-total": "Sub total",
   "heading.total": "Total",
   "heading.stock-details": "Stock details",
+  "heading.are-you-sure": "Are you sure?",
+  "message.confirm-add-from-master-list": "Are you sure you want to add all of the items from this master list?",
   "heading.create-outbound-shipment": "Create Outbound Shipment",
   "label.add-batch": "Add batch",
   "label.allocated": "Allocated",

--- a/packages/common/src/intl/locales/en/distribution.json
+++ b/packages/common/src/intl/locales/en/distribution.json
@@ -24,7 +24,7 @@
   "heading.total": "Total",
   "heading.stock-details": "Stock details",
   "heading.are-you-sure": "Are you sure?",
-  "message.confirm-add-from-master-list": "Are you sure you want to add all of the items from this master list?",
+  "message.confirm-add-from-master-list": "Do you want to add all of the items from this master list?",
   "heading.create-outbound-shipment": "Create Outbound Shipment",
   "label.add-batch": "Add batch",
   "label.allocated": "Allocated",

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -59,7 +59,7 @@ const UseConfirmationModalHook: Story = () => {
     onConfirm: () => alert('confirmed!'),
   });
 
-  return <BaseButton onClick={getConfirmation}>Open Modal</BaseButton>;
+  return <BaseButton onClick={() => getConfirmation()}>Open Modal</BaseButton>;
 };
 
 export const Primary = Template.bind({});

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModal.tsx
@@ -8,7 +8,7 @@ interface ConfirmationModalProps {
   open: boolean;
   width?: number;
   height?: number;
-  onConfirm: (() => void) | (() => Promise<void>);
+  onConfirm: (() => void) | (() => Promise<void>) | undefined;
   onCancel: () => void;
   title: string;
   message: string;
@@ -69,7 +69,7 @@ export const ConfirmationModal = ({
               color="secondary"
               isLoading={loading}
               onClick={async () => {
-                const result = onConfirm();
+                const result = onConfirm && onConfirm();
                 if (result instanceof Promise) {
                   setLoading(true);
                   await result;

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.stories.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.stories.tsx
@@ -15,7 +15,7 @@ const UseConfirmationModalStory: Story = () => {
     onConfirm: () => alert('confirmed!'),
   });
 
-  return <BaseButton onClick={getConfirmation}>Open Modal</BaseButton>;
+  return <BaseButton onClick={() => getConfirmation()}>Open Modal</BaseButton>;
 };
 
 export const UseConfirmationModalHook = UseConfirmationModalStory.bind({});

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
@@ -82,7 +82,6 @@ export const ConfirmationModalProvider: FC = ({ children }) => {
         onConfirm={onConfirm}
         onCancel={() => {
           setState(state => ({ ...state, open: false }));
-          console.log('cancel', onCancel);
           onCancel && onCancel();
         }}
         iconType={iconType}

--- a/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
+++ b/packages/common/src/ui/components/modals/ConfirmationModal/ConfirmationModalProvider.tsx
@@ -13,14 +13,20 @@ interface ConfirmationModalState {
   message: string;
   title: string;
   iconType?: 'alert' | 'info';
-  onConfirm: (() => void) | (() => Promise<void>);
+  onConfirm?: (() => void) | (() => Promise<void>);
+  onCancel?: (() => void) | (() => Promise<void>);
 }
 
 interface ConfirmationModalControllerState extends ConfirmationModalState {
   setState: (state: ConfirmationModalState) => void;
   setMessage: (message: string) => void;
   setTitle: (title: string) => void;
-  setOnConfirm: (onConfirm: (() => Promise<void>) | (() => void)) => void;
+  setOnConfirm: (
+    onConfirm: (() => Promise<void>) | (() => void) | undefined
+  ) => void;
+  setOnCancel: (
+    onCancel: (() => Promise<void>) | (() => void) | undefined
+  ) => void;
   setOpen: (open: boolean) => void;
 }
 
@@ -34,6 +40,7 @@ const Context = createContext<ConfirmationModalControllerState>({
   setMessage: () => {},
   setTitle: () => {},
   setOnConfirm: () => {},
+  setOnCancel: () => {},
   setOpen: () => {},
 });
 
@@ -43,17 +50,21 @@ export const ConfirmationModalProvider: FC = ({ children }) => {
     message: '',
     title: '',
     iconType: 'info',
-    onConfirm: async () => {},
   });
-  const { open, message, title, iconType, onConfirm } = confirmationModalState;
+  const { open, message, title, iconType, onConfirm, onCancel } =
+    confirmationModalState;
 
   const confirmationModalController: ConfirmationModalControllerState = useMemo(
     () => ({
       setMessage: (message: string) =>
         setState(state => ({ ...state, message })),
       setTitle: (title: string) => setState(state => ({ ...state, title })),
-      setOnConfirm: (onConfirm: (() => Promise<void>) | (() => void)) =>
-        setState(state => ({ ...state, onConfirm })),
+      setOnConfirm: (
+        onConfirm: (() => Promise<void>) | (() => void) | undefined
+      ) => setState(state => ({ ...state, onConfirm })),
+      setOnCancel: (
+        onCancel: (() => Promise<void>) | (() => void) | undefined
+      ) => setState(state => ({ ...state, onCancel })),
       setOpen: (open: boolean) => setState(state => ({ ...state, open })),
       setState,
       ...confirmationModalState,
@@ -69,7 +80,11 @@ export const ConfirmationModalProvider: FC = ({ children }) => {
         message={message}
         title={title}
         onConfirm={onConfirm}
-        onCancel={() => setState(state => ({ ...state, open: false }))}
+        onCancel={() => {
+          setState(state => ({ ...state, open: false }));
+          console.log('cancel', onCancel);
+          onCancel && onCancel();
+        }}
         iconType={iconType}
       />
     </Context.Provider>
@@ -82,13 +97,18 @@ export const useConfirmationModal = ({
   onConfirm,
   message,
   title,
+  onCancel,
 }: PartialBy<ConfirmationModalState, 'open'>) => {
-  const { setOpen, setMessage, setOnConfirm, setTitle } = useContext(Context);
+  const { setOpen, setMessage, setOnConfirm, setOnCancel, setTitle } =
+    useContext(Context);
 
-  const trigger = () => {
-    setMessage(message);
-    setOnConfirm(onConfirm);
-    setTitle(title);
+  const trigger = (
+    paramPatch?: Partial<PartialBy<ConfirmationModalState, 'open'>>
+  ) => {
+    setMessage(paramPatch?.message ?? message);
+    setOnConfirm(paramPatch?.onConfirm ?? onConfirm);
+    setTitle(paramPatch?.title ?? title);
+    setOnCancel(paramPatch?.onCancel ?? onCancel);
     setOpen(true);
   };
 

--- a/packages/inventory/src/Stocktake/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Footer/StatusChangeButton.tsx
@@ -75,7 +75,7 @@ const useStatusChangeButton = () => {
     }
   };
 
-  const onGetConfirmation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-status-as', {
       status: selectedOption?.value
@@ -95,19 +95,14 @@ const useStatusChangeButton = () => {
     options,
     selectedOption,
     setSelectedOption,
-    onGetConfirmation,
+    getConfirmation,
     lines,
   };
 };
 
 export const StatusChangeButton = () => {
-  const {
-    options,
-    selectedOption,
-    setSelectedOption,
-    onGetConfirmation,
-    lines,
-  } = useStatusChangeButton();
+  const { options, selectedOption, setSelectedOption, getConfirmation, lines } =
+    useStatusChangeButton();
   const isDisabled = useIsStocktakeDisabled();
 
   if (!selectedOption) return null;
@@ -120,7 +115,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={() => onGetConfirmation()}
+      onClick={() => getConfirmation()}
     />
   );
 };

--- a/packages/inventory/src/Stocktake/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Footer/StatusChangeButton.tsx
@@ -120,7 +120,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={onGetConfirmation}
+      onClick={() => onGetConfirmation()}
     />
   );
 };

--- a/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
@@ -31,7 +31,7 @@ export const StocktakeLockButton: FC = () => {
       disabled={status !== StocktakeNodeStatus.New}
       value={isLocked}
       selected={isLocked}
-      onClick={getUpdateConfirmation}
+      onClick={() => getUpdateConfirmation}
       label={t('label.locked')}
     />
   );

--- a/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
@@ -20,7 +20,7 @@ export const StocktakeLockButton: FC = () => {
     ? 'messages.unlocked-description'
     : 'messages.locked-description';
 
-  const getUpdateConfirmation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     onConfirm: () => update({ isLocked: !isLocked }),
     title: t('heading.are-you-sure'),
     message: t(message),
@@ -31,7 +31,7 @@ export const StocktakeLockButton: FC = () => {
       disabled={status !== StocktakeNodeStatus.New}
       value={isLocked}
       selected={isLocked}
-      onClick={() => getUpdateConfirmation}
+      onClick={() => getConfirmation()}
       label={t('label.locked')}
     />
   );

--- a/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -108,7 +108,7 @@ const useStatusChangeButton = () => {
     }
   };
 
-  const onGetConfirmation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-status-as', {
       status: selectedOption?.value
@@ -124,11 +124,11 @@ const useStatusChangeButton = () => {
     setSelectedOption(() => getNextStatusOption(status, options));
   }, [status, options]);
 
-  return { options, selectedOption, setSelectedOption, onGetConfirmation };
+  return { options, selectedOption, setSelectedOption, getConfirmation };
 };
 
 export const StatusChangeButton = () => {
-  const { options, selectedOption, setSelectedOption, onGetConfirmation } =
+  const { options, selectedOption, setSelectedOption, getConfirmation } =
     useStatusChangeButton();
   const isDisabled = !useIsInboundEditable();
 
@@ -141,7 +141,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={() => onGetConfirmation()}
+      onClick={() => getConfirmation()}
     />
   );
 };

--- a/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -141,7 +141,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={onGetConfirmation}
+      onClick={() => onGetConfirmation()}
     />
   );
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -150,7 +150,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={onGetConfirmation}
+      onClick={() => onGetConfirmation()}
     />
   );
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -117,7 +117,7 @@ const useStatusChangeButton = () => {
     }
   };
 
-  const onGetConfirmation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-status-as', {
       status: selectedOption?.value
@@ -133,11 +133,11 @@ const useStatusChangeButton = () => {
     setSelectedOption(() => getNextStatusOption(status, options));
   }, [status, options]);
 
-  return { options, selectedOption, setSelectedOption, onGetConfirmation };
+  return { options, selectedOption, setSelectedOption, getConfirmation };
 };
 
 export const StatusChangeButton = () => {
-  const { options, selectedOption, setSelectedOption, onGetConfirmation } =
+  const { options, selectedOption, setSelectedOption, getConfirmation } =
     useStatusChangeButton();
   const isDisabled = useIsOutboundDisabled();
 
@@ -150,7 +150,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={() => onGetConfirmation()}
+      onClick={() => getConfirmation()}
     />
   );
 };

--- a/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons.tsx
@@ -9,7 +9,7 @@ import {
   useToggle,
 } from '@openmsupply-client/common';
 import { MasterListSearchModal } from '@openmsupply-client/system';
-
+import { useAddFromMasterList } from '../api';
 interface AppBarButtonProps {
   isDisabled: boolean;
   onAddItem: (newState: boolean) => void;
@@ -19,6 +19,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   isDisabled,
   onAddItem,
 }) => {
+  const { addFromMasterList } = useAddFromMasterList();
   const { OpenButton } = useDetailPanel();
   const t = useTranslation('distribution');
   const modalController = useToggle();
@@ -34,7 +35,10 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
         <MasterListSearchModal
           open={modalController.isOn}
           onClose={modalController.toggleOff}
-          onChange={masterList => console.log(masterList)}
+          onChange={masterList => {
+            modalController.toggleOff();
+            addFromMasterList(masterList);
+          }}
         />
         <ButtonWithIcon
           disabled={isDisabled}

--- a/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -121,7 +121,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={onGetConfirmation}
+      onClick={() => onGetConfirmation()}
     />
   );
 };

--- a/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -88,7 +88,7 @@ const useStatusChangeButton = () => {
     }
   };
 
-  const onGetConfirmation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-status-as', {
       status: selectedOption?.value
@@ -104,11 +104,11 @@ const useStatusChangeButton = () => {
     setSelectedOption(() => getNextStatusOption(status, options));
   }, [status, options]);
 
-  return { options, selectedOption, setSelectedOption, onGetConfirmation };
+  return { options, selectedOption, setSelectedOption, getConfirmation };
 };
 
 export const StatusChangeButton = () => {
-  const { options, selectedOption, setSelectedOption, onGetConfirmation } =
+  const { options, selectedOption, setSelectedOption, getConfirmation } =
     useStatusChangeButton();
   const isDisabled = useIsRequestDisabled();
 
@@ -121,7 +121,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={() => onGetConfirmation()}
+      onClick={() => getConfirmation()}
     />
   );
 };

--- a/packages/requisitions/src/RequestRequisition/api/api.ts
+++ b/packages/requisitions/src/RequestRequisition/api/api.ts
@@ -211,4 +211,28 @@ export const getRequestQueries = (sdk: Sdk, storeId: string) => ({
 
     throw new Error('Could not delete requisitions');
   },
+
+  addFromMasterList: async ({
+    requestId,
+    masterListId,
+  }: {
+    requestId: string;
+    masterListId: string;
+  }) => {
+    const result = await sdk.addFromMasterList({
+      requestId,
+      masterListId,
+      storeId,
+    });
+
+    if (result.addFromMasterList.__typename === 'RequisitionLineConnector') {
+      return result.addFromMasterList;
+    }
+
+    if (result.addFromMasterList.__typename === 'AddFromMasterListError') {
+      throw new Error(result.addFromMasterList.error.__typename);
+    }
+
+    throw new Error('Could not add from master list');
+  },
 });

--- a/packages/requisitions/src/RequestRequisition/api/hooks.ts
+++ b/packages/requisitions/src/RequestRequisition/api/hooks.ts
@@ -221,7 +221,6 @@ export const useAddFromMasterList = () => {
   const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('message.confirm-add-from-master-list'),
-    onConfirm: () => {},
   });
 
   const addFromMasterList = async ({

--- a/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -70,6 +70,15 @@ export type UpdateRequestLineMutationVariables = Types.Exact<{
 
 export type UpdateRequestLineMutation = { __typename: 'FullMutation', updateRequestRequisitionLine: { __typename: 'RequisitionLineNode', id: string } | { __typename: 'UpdateRequestRequisitionLineError', error: { __typename: 'CannotEditRequisition', description: string } | { __typename: 'ForeignKeyError', description: string, key: Types.ForeignKey } | { __typename: 'RecordNotFound', description: string } } };
 
+export type AddFromMasterListMutationVariables = Types.Exact<{
+  storeId: Types.Scalars['String'];
+  requestId: Types.Scalars['String'];
+  masterListId: Types.Scalars['String'];
+}>;
+
+
+export type AddFromMasterListMutation = { __typename: 'FullMutation', addFromMasterList: { __typename: 'AddFromMasterListError', error: { __typename: 'CannotEditRequisition', description: string } | { __typename: 'MasterListNotFoundForThisStore', description: string } | { __typename: 'RecordNotFound', description: string } } | { __typename: 'RequisitionLineConnector', totalCount: number } };
+
 export const ItemWithStatsFragmentDoc = gql`
     fragment ItemWithStats on ItemNode {
   id
@@ -334,6 +343,37 @@ export const UpdateRequestLineDocument = gql`
   }
 }
     `;
+export const AddFromMasterListDocument = gql`
+    mutation addFromMasterList($storeId: String!, $requestId: String!, $masterListId: String!) {
+  addFromMasterList(
+    input: {requestRequisitionId: $requestId, masterListId: $masterListId}
+    storeId: $storeId
+  ) {
+    ... on RequisitionLineConnector {
+      __typename
+      totalCount
+    }
+    ... on AddFromMasterListError {
+      __typename
+      error {
+        description
+        ... on RecordNotFound {
+          __typename
+          description
+        }
+        ... on CannotEditRequisition {
+          __typename
+          description
+        }
+        ... on MasterListNotFoundForThisStore {
+          __typename
+          description
+        }
+      }
+    }
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string) => Promise<T>;
 
@@ -362,6 +402,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     updateRequestLine(variables: UpdateRequestLineMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpdateRequestLineMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<UpdateRequestLineMutation>(UpdateRequestLineDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateRequestLine');
+    },
+    addFromMasterList(variables: AddFromMasterListMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<AddFromMasterListMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AddFromMasterListMutation>(AddFromMasterListDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'addFromMasterList');
     }
   };
 }
@@ -483,5 +526,22 @@ export const mockInsertRequestLineMutation = (resolver: ResponseResolver<GraphQL
 export const mockUpdateRequestLineMutation = (resolver: ResponseResolver<GraphQLRequest<UpdateRequestLineMutationVariables>, GraphQLContext<UpdateRequestLineMutation>, any>) =>
   graphql.mutation<UpdateRequestLineMutation, UpdateRequestLineMutationVariables>(
     'updateRequestLine',
+    resolver
+  )
+
+/**
+ * @param resolver a function that accepts a captured request and may return a mocked response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ * @example
+ * mockAddFromMasterListMutation((req, res, ctx) => {
+ *   const { storeId, requestId, masterListId } = req.variables;
+ *   return res(
+ *     ctx.data({ addFromMasterList })
+ *   )
+ * })
+ */
+export const mockAddFromMasterListMutation = (resolver: ResponseResolver<GraphQLRequest<AddFromMasterListMutationVariables>, GraphQLContext<AddFromMasterListMutation>, any>) =>
+  graphql.mutation<AddFromMasterListMutation, AddFromMasterListMutationVariables>(
+    'addFromMasterList',
     resolver
   )

--- a/packages/requisitions/src/RequestRequisition/api/operations.graphql
+++ b/packages/requisitions/src/RequestRequisition/api/operations.graphql
@@ -271,3 +271,37 @@ mutation updateRequestLine(
     }
   }
 }
+
+mutation addFromMasterList(
+  $storeId: String!
+  $requestId: String!
+  $masterListId: String!
+) {
+  addFromMasterList(
+    input: { requestRequisitionId: $requestId, masterListId: $masterListId }
+    storeId: $storeId
+  ) {
+    ... on RequisitionLineConnector {
+      __typename
+      totalCount
+    }
+    ... on AddFromMasterListError {
+      __typename
+      error {
+        description
+        ... on RecordNotFound {
+          __typename
+          description
+        }
+        ... on CannotEditRequisition {
+          __typename
+          description
+        }
+        ... on MasterListNotFoundForThisStore {
+          __typename
+          description
+        }
+      }
+    }
+  }
+}

--- a/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons.tsx
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons.tsx
@@ -14,7 +14,7 @@ export const AppBarButtonsComponent: FC = () => {
   const { OpenButton } = useDetailPanel();
   const t = useTranslation('distribution');
   const { mutate: createOutbound } = useCreateOutboundFromResponse();
-  const confirmOutboundCreation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     onConfirm: createOutbound,
     message: t('messages.create-outbound-from-requisition'),
     title: t('heading.create-outbound-shipment'),
@@ -26,7 +26,7 @@ export const AppBarButtonsComponent: FC = () => {
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.create-shipment')}
-          onClick={() => confirmOutboundCreation()}
+          onClick={() => getConfirmation()}
         />
         {OpenButton}
       </Grid>

--- a/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons.tsx
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons.tsx
@@ -26,7 +26,7 @@ export const AppBarButtonsComponent: FC = () => {
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.create-shipment')}
-          onClick={confirmOutboundCreation}
+          onClick={() => confirmOutboundCreation}
         />
         {OpenButton}
       </Grid>

--- a/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons.tsx
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons.tsx
@@ -26,7 +26,7 @@ export const AppBarButtonsComponent: FC = () => {
         <ButtonWithIcon
           Icon={<PlusCircleIcon />}
           label={t('button.create-shipment')}
-          onClick={() => confirmOutboundCreation}
+          onClick={() => confirmOutboundCreation()}
         />
         {OpenButton}
       </Grid>

--- a/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -82,7 +82,7 @@ const useStatusChangeButton = () => {
     }
   };
 
-  const onGetConfirmation = useConfirmationModal({
+  const getConfirmation = useConfirmationModal({
     title: t('heading.are-you-sure'),
     message: t('messages.confirm-status-as', {
       status: selectedOption?.value
@@ -98,11 +98,11 @@ const useStatusChangeButton = () => {
     setSelectedOption(() => getNextStatusOption(status, options));
   }, [status, options]);
 
-  return { options, selectedOption, setSelectedOption, onGetConfirmation };
+  return { options, selectedOption, setSelectedOption, getConfirmation };
 };
 
 export const StatusChangeButton = () => {
-  const { options, selectedOption, setSelectedOption, onGetConfirmation } =
+  const { options, selectedOption, setSelectedOption, getConfirmation } =
     useStatusChangeButton();
   const isDisabled = useIsResponseDisabled();
 
@@ -115,7 +115,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={() => onGetConfirmation()}
+      onClick={() => getConfirmation()}
     />
   );
 };

--- a/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/Footer/StatusChangeButton.tsx
@@ -115,7 +115,7 @@ export const StatusChangeButton = () => {
       selectedOption={selectedOption}
       onSelectOption={setSelectedOption}
       Icon={<ArrowRightIcon />}
-      onClick={onGetConfirmation}
+      onClick={() => onGetConfirmation()}
     />
   );
 };

--- a/packages/system/src/MasterList/api/index.ts
+++ b/packages/system/src/MasterList/api/index.ts
@@ -1,3 +1,2 @@
-export * from './api';
 export * from './hooks';
 export { MasterListRowFragment } from './operations.generated';

--- a/packages/system/src/MasterList/index.ts
+++ b/packages/system/src/MasterList/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './Service';
 export * from './Components';
+export * from './api';


### PR DESCRIPTION
Fixes #581 

- Minor change to `useConfirmationModal` which I hope is a good change, but made diffs in a fair amount of files


Essentially the issue being:

```
const { mutate } = useMutation(api.addFromMasterList)

const addFromMasterList = async (masterList) => {
    await  mutate(masterList)
}

const getConfirmation = useConfirmation({text: "are you sure", message: "yes I'm sure!", onConfirm: () => { ... } })

return <MasterListSearchModalList onChange={masterList => { 
    toggleOff(); 
    // ---- Need to open the confirm here and also pass the master list into the onConfirm callback ----
    // ---- would need to set some state with the master list and then trigger the getConfirmation   ----
   // ----  with a useEffect.. Then, remember to clear the state! 
   // ---- so, instead:
   getConfirmation({ onChange: addFromMasterList })
}
/>
```

Though, I've made it so you can pass the `onConfirm` in either with the initial call or the extra call.. which means it's optional in both, ending with a situation where you can have no onConfirm 🤔 





