### PR TITLE
#933 Cells should be disabled when a document is -- You won't believe how many files were touched for this ONE SIMPLE CHANGE -- [14]

### DIFF
--- a/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
+++ b/packages/common/src/ui/components/inputs/DatePickers/BaseDatePickerInput/BaseDatePickerInput.tsx
@@ -8,12 +8,15 @@ export const BaseDatePickerInput: FC<
 > = props => {
   return (
     <DatePicker
+      disabled={props.disabled}
       renderInput={(params: TextFieldProps) => {
-        const props: StandardTextFieldProps = {
+        const textInputProps: StandardTextFieldProps = {
           ...params,
           variant: 'standard',
         };
-        return <BasicTextInput {...props} />;
+        return (
+          <BasicTextInput disabled={!!props.disabled} {...textInputProps} />
+        );
       }}
       {...props}
     />

--- a/packages/common/src/ui/components/inputs/DatePickers/ExpiryDateInput/ExpiryDateInput.tsx
+++ b/packages/common/src/ui/components/inputs/DatePickers/ExpiryDateInput/ExpiryDateInput.tsx
@@ -5,14 +5,17 @@ import lastDayOfMonth from 'date-fns/lastDayOfMonth';
 interface ExpiryDateInputProps {
   value: Date | null;
   onChange: (value: Date | null) => void;
+  disabled?: boolean;
 }
 
 export const ExpiryDateInput: FC<ExpiryDateInputProps> = ({
   value,
   onChange,
+  disabled,
 }) => {
   return (
     <BaseDatePickerInput
+      disabled={disabled}
       views={['year', 'month']}
       inputFormat="MM/yyyy"
       value={value}

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -32,12 +32,19 @@ export const DataTableComponent = <T extends RecordWithId>({
   isDisabled = false,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation('common');
-  const { setActiveRows, setDisabledRows } = useTableStore();
+  const { setActiveRows, setDisabledRows, rowState } = useTableStore();
+
+  console.log(rowState);
+
   useEffect(() => {
     if (data.length) setActiveRows(data.map(({ id }) => id));
   }, [data]);
 
   useEffect(() => {
+    console.log(
+      'setting disabled',
+      data.map(({ id }) => id)
+    );
     if (isDisabled) setDisabledRows(data.map(({ id }) => id));
   }, [isDisabled, data]);
 

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -29,12 +29,17 @@ export const DataTableComponent = <T extends RecordWithId>({
   noDataMessage,
   ExpandContent,
   dense = false,
+  isDisabled = false,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation('common');
-  const { setActiveRows } = useTableStore();
+  const { setActiveRows, setDisabledRows } = useTableStore();
   useEffect(() => {
-    if (data.length) setActiveRows(data.map(({ id }) => id as string));
+    if (data.length) setActiveRows(data.map(({ id }) => id));
   }, [data]);
+
+  useEffect(() => {
+    if (isDisabled) setDisabledRows(data.map(({ id }) => id));
+  }, [isDisabled, data]);
 
   // guard against a page number being set which is greater than the data allows
   useEffect(() => {

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -32,19 +32,13 @@ export const DataTableComponent = <T extends RecordWithId>({
   isDisabled = false,
 }: TableProps<T>): JSX.Element => {
   const t = useTranslation('common');
-  const { setActiveRows, setDisabledRows, rowState } = useTableStore();
-
-  console.log(rowState);
+  const { setActiveRows, setDisabledRows } = useTableStore();
 
   useEffect(() => {
     if (data.length) setActiveRows(data.map(({ id }) => id));
   }, [data]);
 
   useEffect(() => {
-    console.log(
-      'setting disabled',
-      data.map(({ id }) => id)
-    );
     if (isDisabled) setDisabledRows(data.map(({ id }) => id));
   }, [isDisabled, data]);
 

--- a/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/EditableQuantityColumn.tsx
@@ -14,7 +14,7 @@ export const getEditableQuantityColumn = <
 >(): ColumnDefinition<T> => ({
   key: 'quantity',
   width: 100,
-  Cell: ({ rowData }) => {
+  Cell: ({ rowData, isDisabled }) => {
     const { quantity } = rowData;
     const [buffer, setBuffer] = useState(String(quantity));
     const [value, setValue] = useState(quantity);
@@ -52,6 +52,7 @@ export const getEditableQuantityColumn = <
           maxHeight: 40,
         }}
         error={error}
+        disabled={isDisabled}
         size="small"
         hiddenLabel
         value={buffer}

--- a/packages/common/src/ui/layout/tables/columns/ExpiryDateInput/ExpiryDateInput.tsx
+++ b/packages/common/src/ui/layout/tables/columns/ExpiryDateInput/ExpiryDateInput.tsx
@@ -30,13 +30,19 @@ export const getExpiryDateInputColumn = <
       }
     }
   },
-  Cell: ({ rowData, column, rows }) => {
+  Cell: ({ rowData, column, rows, isDisabled }) => {
     const value = column.accessor({ rowData, rows }) as Date | null;
 
     const onChange = (newValue: Date | null) => {
       column.setter({ ...rowData, expiryDate: newValue });
     };
 
-    return <ExpiryDateInput value={value} onChange={onChange} />;
+    return (
+      <ExpiryDateInput
+        value={value}
+        onChange={onChange}
+        disabled={!!isDisabled}
+      />
+    );
   },
 });

--- a/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
@@ -27,7 +27,7 @@ export const getNameAndColorColumn = <
   },
   accessor: ({ rowData }) => rowData.otherPartyName,
   key: 'otherPartyName',
-  Cell: ({ rowData, column, rows }) => (
+  Cell: ({ rowData, column, rows, isDisabled }) => (
     <Box
       sx={{
         flexDirection: 'row',
@@ -37,6 +37,7 @@ export const getNameAndColorColumn = <
       }}
     >
       <ColorSelectButton
+        disabled={isDisabled}
         onChange={color => column.setter({ ...rowData, colour: color.hex })}
         color={rowData.colour}
       />

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -11,6 +11,7 @@ export interface CellProps<T extends RecordWithId> {
   rowKey: string;
   columnIndex: number;
   rowIndex: number;
+  isDisabled?: boolean;
 }
 
 export interface HeaderProps<T extends RecordWithId> {

--- a/packages/common/src/ui/layout/tables/components/Cells/CheckboxCell/CheckboxCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/CheckboxCell/CheckboxCell.tsx
@@ -8,6 +8,7 @@ export const CheckboxCell = <T extends RecordWithId>({
   rowData,
   column,
   rows,
+  isDisabled,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     column.accessor({ rowData, rows })
@@ -15,6 +16,7 @@ export const CheckboxCell = <T extends RecordWithId>({
 
   return (
     <Checkbox
+      disabled={isDisabled}
       checked={!!buffer}
       size="small"
       onChange={e => {

--- a/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/CurrencyInputCell/CurrencyInputCell.tsx
@@ -10,6 +10,7 @@ export const CurrencyInputCell = <T extends RecordWithId>({
   column,
   rowIndex,
   columnIndex,
+  isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     Number(Number(column.accessor({ rowData, rows })))
@@ -21,9 +22,10 @@ export const CurrencyInputCell = <T extends RecordWithId>({
 
   return (
     <CurrencyInput
+      disabled={isDisabled}
       autoFocus={autoFocus}
       maxWidth={column.width}
-      defaultValue={buffer}
+      value={buffer}
       onChangeNumber={newNumber => {
         setBuffer(newNumber);
         updater({ ...rowData, [column.key]: Number(newNumber) });

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeNumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeNumberInputCell.tsx
@@ -12,20 +12,23 @@ export const NonNegativeNumberInputCell = <T extends RecordWithId>({
   rows,
   rowIndex,
   columnIndex,
+  isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     column.accessor({ rowData, rows })
   );
+
   const updater = useDebounceCallback(column.setter, [column.setter], 250);
 
   const autoFocus = rowIndex === 0 && columnIndex === 0;
 
   return (
     <BasicTextInput
+      disabled={isDisabled}
       autoFocus={autoFocus}
       InputProps={{ sx: { '& .MuiInput-input': { textAlign: 'right' } } }}
       type="number"
-      value={buffer}
+      value={buffer ?? ''}
       onChange={e => {
         const newValue = NumUtils.parseString(e.target.value);
         setBuffer(newValue.toString());

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NumberInputCell.tsx
@@ -10,6 +10,7 @@ export const NumberInputCell = <T extends RecordWithId>({
   rows,
   rowIndex,
   columnIndex,
+  isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     column.accessor({ rowData, rows })
@@ -20,6 +21,7 @@ export const NumberInputCell = <T extends RecordWithId>({
 
   return (
     <BasicTextInput
+      disabled={isDisabled}
       autoFocus={autoFocus}
       InputProps={{ sx: { '& .MuiInput-input': { textAlign: 'right' } } }}
       type="number"

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/PositiveNumberInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/PositiveNumberInputCell.tsx
@@ -12,6 +12,7 @@ export const PositiveNumberInputCell = <T extends RecordWithId>({
   rows,
   rowIndex,
   columnIndex,
+  isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     column.accessor({ rowData, rows })
@@ -22,6 +23,7 @@ export const PositiveNumberInputCell = <T extends RecordWithId>({
 
   return (
     <BasicTextInput
+      disabled={isDisabled}
       autoFocus={autoFocus}
       InputProps={{ sx: { '& .MuiInput-input': { textAlign: 'right' } } }}
       type="number"

--- a/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/TextInputCell/TextInputCell.tsx
@@ -8,6 +8,7 @@ export const TextInputCell = <T extends RecordWithId>({
   rowData,
   column,
   rows,
+  isDisabled = false,
 }: CellProps<T>): React.ReactElement<CellProps<T>> => {
   const [buffer, setBuffer] = useBufferState(
     column.accessor({ rowData, rows })
@@ -17,6 +18,7 @@ export const TextInputCell = <T extends RecordWithId>({
 
   return (
     <BasicTextInput
+      disabled={isDisabled}
       InputProps={maxLength ? { inputProps: { maxLength } } : undefined}
       value={buffer}
       onChange={e => {

--- a/packages/common/src/ui/layout/tables/components/Cells/index.ts
+++ b/packages/common/src/ui/layout/tables/components/Cells/index.ts
@@ -1,3 +1,4 @@
 export * from './TextInputCell';
 export * from './NumberInputCell';
 export * from './CurrencyInputCell';
+export * from './CheckboxCell';

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -83,6 +83,7 @@ export const DataRow = <T extends RecordWithId>({
                 }}
               >
                 <column.Cell
+                  isDisabled={isDisabled}
                   rows={rows}
                   rowData={rowData}
                   columns={columns}

--- a/packages/common/src/ui/layout/tables/types.ts
+++ b/packages/common/src/ui/layout/tables/types.ts
@@ -15,6 +15,7 @@ export interface QueryResponse<T> {
 }
 
 export interface TableProps<T extends RecordWithId> {
+  isDisabled?: boolean;
   columns: Column<T>[];
   data?: T[];
   isLoading?: boolean;

--- a/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
@@ -31,7 +31,7 @@ export const StocktakeLockButton: FC = () => {
       disabled={status !== StocktakeNodeStatus.New}
       value={isLocked}
       selected={isLocked}
-      onClick={() => getUpdateConfirmation}
+      onClick={() => getUpdateConfirmation()}
       label={t('label.locked')}
     />
   );

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -41,7 +41,6 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
   const t = useTranslation(['common', 'inventory']);
   const { draftLines, update, addLine, isLoading, save, nextItem } =
     useStocktakeLineEdit(currentItem);
-  console.log(draftLines);
 
   const onNext = async () => {
     await save(draftLines);

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -18,6 +18,7 @@ import {
 import { DraftStocktakeLine } from './hooks';
 
 interface StocktakeLineEditTableProps {
+  isDisabled?: boolean;
   batches: DraftStocktakeLine[];
   update: (patch: RecordPatch<DraftStocktakeLine>) => void;
 }
@@ -63,6 +64,7 @@ const getCountThisLineColumn = (
 export const BatchTable: FC<StocktakeLineEditTableProps> = ({
   batches,
   update,
+  isDisabled = false,
 }) => {
   const t = useTranslation('inventory');
   const theme = useTheme();
@@ -109,6 +111,7 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
 
   return (
     <DataTable
+      isDisabled={isDisabled}
       columns={columns}
       data={batches}
       noDataMessage={t('label.add-new-line')}
@@ -120,7 +123,9 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
 export const PricingTable: FC<StocktakeLineEditTableProps> = ({
   batches,
   update,
+  isDisabled,
 }) => {
+  console.log(batches);
   const theme = useTheme();
   const t = useTranslation('inventory');
   const columns = useColumns<DraftStocktakeLine>([
@@ -150,6 +155,7 @@ export const PricingTable: FC<StocktakeLineEditTableProps> = ({
 
   return (
     <DataTable
+      isDisabled={isDisabled}
       columns={columns}
       data={batches}
       noDataMessage={t('label.add-new-line')}

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -125,7 +125,6 @@ export const PricingTable: FC<StocktakeLineEditTableProps> = ({
   update,
   isDisabled,
 }) => {
-  console.log(batches);
   const theme = useTheme();
   const t = useTranslation('inventory');
   const columns = useColumns<DraftStocktakeLine>([

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
@@ -26,10 +26,10 @@ export const StyledTabContainer = styled(Box)(() => ({
   display: 'flex',
 }));
 
-export const StocktakeLineEditTabs: FC<{ onAddLine: () => void }> = ({
-  children,
-  onAddLine,
-}) => {
+export const StocktakeLineEditTabs: FC<{
+  onAddLine: () => void;
+  isDisabled: boolean;
+}> = ({ children, onAddLine, isDisabled }) => {
   const t = useTranslation('inventory');
   const [currentTab, setCurrentTab] = useState(Tabs.Batch);
 
@@ -48,6 +48,7 @@ export const StocktakeLineEditTabs: FC<{ onAddLine: () => void }> = ({
         </TabList>
         <Box flex={1} justifyContent="flex-end" display="flex">
           <ButtonWithIcon
+            disabled={isDisabled}
             color="primary"
             variant="outlined"
             onClick={onAddLine}

--- a/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useNavigate,
   StocktakeNodeStatus,
@@ -7,12 +7,21 @@ import {
   TableProvider,
   createTableStore,
   useTranslation,
+  useTableStore,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
-import { getStocktakeTranslator } from '../../utils';
+import { getStocktakeTranslator, isStocktakeDisabled } from '../../utils';
 import { StocktakeRowFragment } from '../api/operations.generated';
 import { useStocktakes } from '../api';
+
+const useDisableStocktakeRows = (rows?: StocktakeRowFragment[]) => {
+  const { setDisabledRows } = useTableStore();
+  useEffect(() => {
+    const disabledRows = rows?.filter(isStocktakeDisabled).map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [rows]);
+};
 
 export const StocktakeListView: FC = () => {
   const navigate = useNavigate();
@@ -27,6 +36,7 @@ export const StocktakeListView: FC = () => {
     pagination,
     filter,
   } = useStocktakes();
+  useDisableStocktakeRows(data?.nodes);
 
   const statusTranslator = getStocktakeTranslator(t);
 

--- a/packages/inventory/src/Stocktake/api/hooks.ts
+++ b/packages/inventory/src/Stocktake/api/hooks.ts
@@ -1,10 +1,10 @@
+import { isStocktakeDisabled } from './../../utils';
 import { useMemo, useCallback } from 'react';
 import {
   useNavigate,
   useTranslation,
   useNotification,
   useQuerySelector,
-  StocktakeNodeStatus,
   useQueryClient,
   useParams,
   useOmSupplyApi,
@@ -117,8 +117,9 @@ export const useStocktakeFields = <
 };
 
 export const useIsStocktakeDisabled = (): boolean => {
-  const { status, isLocked } = useStocktakeFields(['status', 'isLocked']);
-  return status === StocktakeNodeStatus.Finalised || isLocked;
+  const { data } = useStocktake();
+  if (!data) return true;
+  return isStocktakeDisabled(data);
 };
 
 const useStocktakeSelector = <ReturnType>(

--- a/packages/inventory/src/Stocktake/api/operations.generated.ts
+++ b/packages/inventory/src/Stocktake/api/operations.generated.ts
@@ -4,7 +4,7 @@ import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
-export type StocktakeRowFragment = { __typename: 'StocktakeNode', id: string, comment?: string | null, description?: string | null, createdDatetime: any, finalisedDatetime?: any | null, stocktakeDate?: string | null, stocktakeNumber: number, status: Types.StocktakeNodeStatus };
+export type StocktakeRowFragment = { __typename: 'StocktakeNode', id: string, comment?: string | null, description?: string | null, createdDatetime: any, finalisedDatetime?: any | null, stocktakeDate?: string | null, stocktakeNumber: number, status: Types.StocktakeNodeStatus, isLocked: boolean };
 
 export type StocktakeLineFragment = { __typename: 'StocktakeLineNode', stocktakeId: string, batch?: string | null, itemId: string, id: string, expiryDate?: string | null, packSize?: number | null, snapshotNumberOfPacks: number, countedNumberOfPacks?: number | null, sellPricePerPack?: number | null, costPricePerPack?: number | null, location?: { __typename: 'LocationNode', id: string, name: string, code: string, onHold: boolean } | null, stockLine?: { __typename: 'StockLineNode', id: string } | null, item: { __typename: 'ItemNode', id: string, code: string, name: string, unitName?: string | null } };
 
@@ -18,7 +18,7 @@ export type StocktakesQueryVariables = Types.Exact<{
 }>;
 
 
-export type StocktakesQuery = { __typename: 'FullQuery', stocktakes: { __typename: 'StocktakeConnector', totalCount: number, nodes: Array<{ __typename: 'StocktakeNode', id: string, comment?: string | null, description?: string | null, createdDatetime: any, finalisedDatetime?: any | null, stocktakeDate?: string | null, stocktakeNumber: number, status: Types.StocktakeNodeStatus }> } };
+export type StocktakesQuery = { __typename: 'FullQuery', stocktakes: { __typename: 'StocktakeConnector', totalCount: number, nodes: Array<{ __typename: 'StocktakeNode', id: string, comment?: string | null, description?: string | null, createdDatetime: any, finalisedDatetime?: any | null, stocktakeDate?: string | null, stocktakeNumber: number, status: Types.StocktakeNodeStatus, isLocked: boolean }> } };
 
 export type StocktakeQueryVariables = Types.Exact<{
   stocktakeId: Types.Scalars['String'];
@@ -81,6 +81,7 @@ export const StocktakeRowFragmentDoc = gql`
   stocktakeDate
   stocktakeNumber
   status
+  isLocked
 }
     `;
 export const StocktakeLineFragmentDoc = gql`

--- a/packages/inventory/src/Stocktake/api/operations.graphql
+++ b/packages/inventory/src/Stocktake/api/operations.graphql
@@ -8,6 +8,7 @@ fragment StocktakeRow on StocktakeNode {
   stocktakeDate
   stocktakeNumber
   status
+  isLocked
 }
 
 fragment StocktakeLine on StocktakeLineNode {

--- a/packages/inventory/src/utils.ts
+++ b/packages/inventory/src/utils.ts
@@ -39,3 +39,6 @@ export const getStocktakeTranslator =
 
 export const canDeleteStocktake = (row: StocktakeRowFragment): boolean =>
   row.status === StocktakeNodeStatus.New;
+
+export const isStocktakeDisabled = (row: StocktakeRowFragment): boolean =>
+  row.status !== StocktakeNodeStatus.New || row.isLocked;

--- a/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -7,7 +7,7 @@ import {
   useDetailPanel,
   useTranslation,
 } from '@openmsupply-client/common';
-import { useIsInboundEditable } from '../api';
+import { useIsInboundDisabled } from '../api';
 
 interface AppBarButtonProps {
   onAddItem: (newState: boolean) => void;
@@ -16,7 +16,7 @@ interface AppBarButtonProps {
 export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   onAddItem,
 }) => {
-  const isEditable = useIsInboundEditable();
+  const isDisabled = useIsInboundDisabled();
   const { OpenButton } = useDetailPanel();
   const t = useTranslation('common');
 
@@ -24,7 +24,7 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
     <AppBarButtonsPortal>
       <Grid container gap={1}>
         <ButtonWithIcon
-          disabled={!isEditable}
+          disabled={isDisabled}
           label={t('button.add-item')}
           Icon={<PlusCircleIcon />}
           onClick={() => onAddItem(true)}

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -18,10 +18,11 @@ import { SidePanel } from './SidePanel';
 import { ContentArea } from './ContentArea';
 import { InboundLineEdit } from './modals/InboundLineEdit';
 import { InboundItem } from '../../types';
-import { useInbound, InboundLineFragment } from '../api';
+import { useInbound, InboundLineFragment, useIsInboundDisabled } from '../api';
 
 export const DetailView: FC = () => {
   const { data, isLoading } = useInbound();
+  const isDisabled = useIsInboundDisabled();
   const { onOpen, onClose, mode, entity, isOpen } =
     useEditModal<ItemRowFragment>();
   const navigate = useNavigate();
@@ -53,6 +54,7 @@ export const DetailView: FC = () => {
 
           {isOpen && (
             <InboundLineEdit
+              isDisabled={isDisabled}
               isOpen={isOpen}
               onClose={onClose}
               mode={mode}

--- a/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer/Footer.tsx
@@ -16,7 +16,7 @@ import {
   InboundFragment,
   useInbound,
   useInboundFields,
-  useIsInboundEditable,
+  useIsInboundDisabled,
 } from '../../api';
 import { StatusChangeButton } from './StatusChangeButton';
 
@@ -57,7 +57,7 @@ export const Footer: FC = () => {
   const t = useTranslation('replenishment');
   const navigate = useNavigate();
   const { onHold, update } = useInboundFields('onHold');
-  const isEditable = useIsInboundEditable();
+  const isDisabled = useIsInboundDisabled();
   const { data } = useInbound();
   const [onHoldBuffer, setOnHoldBuffer] = useBufferState(onHold);
 
@@ -73,7 +73,7 @@ export const Footer: FC = () => {
             height={64}
           >
             <ToggleButton
-              disabled={!isEditable}
+              disabled={isDisabled}
               value={onHoldBuffer}
               selected={onHoldBuffer}
               onClick={(_, value) => {

--- a/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -9,7 +9,7 @@ import {
   useConfirmationModal,
 } from '@openmsupply-client/common';
 import { getStatusTranslation, getNextInboundStatus } from '../../../utils';
-import { useIsInboundEditable, useInboundFields } from '../../api';
+import { useIsInboundDisabled, useInboundFields } from '../../api';
 
 const getStatusOptions = (
   currentStatus: InvoiceNodeStatus,
@@ -130,7 +130,7 @@ const useStatusChangeButton = () => {
 export const StatusChangeButton = () => {
   const { options, selectedOption, setSelectedOption, onGetConfirmation } =
     useStatusChangeButton();
-  const isDisabled = !useIsInboundEditable();
+  const isDisabled = useIsInboundDisabled();
 
   if (!selectedOption) return null;
   if (isDisabled) return null;

--- a/packages/invoices/src/InboundShipment/DetailView/SidePanel.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/SidePanel.tsx
@@ -14,11 +14,11 @@ import {
   ColorSelectButton,
   useBufferState,
 } from '@openmsupply-client/common';
-import { useInboundFields, useInbound, useIsInboundEditable } from '../api';
+import { useInboundFields, useInbound, useIsInboundDisabled } from '../api';
 
 const AdditionalInfoSection: FC = () => {
   const { comment, colour, update } = useInboundFields(['comment', 'colour']);
-  const isEditable = useIsInboundEditable();
+  const isDisabled = useIsInboundDisabled();
   const t = useTranslation(['common', 'replenishment']);
   const [bufferedColor, setBufferedColor] = useBufferState(colour);
 
@@ -33,7 +33,7 @@ const AdditionalInfoSection: FC = () => {
           <PanelLabel>{t('label.color')}</PanelLabel>
           <PanelField>
             <ColorSelectButton
-              disabled={!isEditable}
+              disabled={isDisabled}
               onChange={({ hex }) => {
                 setBufferedColor(hex);
                 update({ colour: hex });
@@ -45,7 +45,7 @@ const AdditionalInfoSection: FC = () => {
 
         <PanelLabel>{t('heading.comment')}</PanelLabel>
         <BufferedTextArea
-          disabled={!isEditable}
+          disabled={isDisabled}
           onChange={e => update({ comment: e.target.value })}
           value={comment}
         />

--- a/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -15,11 +15,11 @@ import {
   useDeleteSelectedLines,
   useInboundFields,
   useInboundItems,
-  useIsInboundEditable,
+  useIsInboundDisabled,
 } from '../api';
 
 export const Toolbar: FC = () => {
-  const isEditable = useIsInboundEditable();
+  const isDisabled = useIsInboundDisabled();
   const { data } = useInboundItems();
 
   const { onDelete } = useDeleteSelectedLines();
@@ -49,7 +49,7 @@ export const Toolbar: FC = () => {
                 Input={
                   <NameSearchInput
                     type="supplier"
-                    disabled={!isEditable}
+                    disabled={isDisabled}
                     value={otherParty}
                     onChange={name => {
                       update({ otherParty: name });
@@ -62,7 +62,7 @@ export const Toolbar: FC = () => {
               label={t('label.supplier-ref')}
               Input={
                 <BufferedTextInput
-                  disabled={!isEditable}
+                  disabled={isDisabled}
                   size="small"
                   sx={{ width: 250 }}
                   value={theirReference ?? ''}
@@ -74,7 +74,7 @@ export const Toolbar: FC = () => {
             />
           </Box>
         </Grid>
-        <DropdownMenu disabled={!isEditable} label={t('label.select')}>
+        <DropdownMenu disabled={isDisabled} label={t('label.select')}>
           <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
             {t('button.delete-lines', { ns: 'distribution' })}
           </DropdownMenuItem>

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -18,6 +18,7 @@ import { getLocationInputColumn } from '@openmsupply-client/system';
 interface TableProps {
   lines: DraftInboundLine[];
   updateDraftLine: (patch: Partial<DraftInboundLine> & { id: string }) => void;
+  isDisabled?: boolean;
 }
 
 const expiryInputColumn = getExpiryDateInputColumn<DraftInboundLine>();
@@ -51,6 +52,7 @@ const getExpiryColumn = (
 export const QuantityTableComponent: FC<TableProps> = ({
   lines,
   updateDraftLine,
+  isDisabled = false,
 }) => {
   const theme = useTheme();
   const columns = useColumns<DraftInboundLine>(
@@ -78,6 +80,7 @@ export const QuantityTableComponent: FC<TableProps> = ({
 
   return (
     <DataTable
+      isDisabled={isDisabled}
       columns={columns}
       data={lines}
       noDataMessage="Add a new line"
@@ -91,6 +94,7 @@ export const QuantityTable = React.memo(QuantityTableComponent);
 export const PricingTableComponent: FC<TableProps> = ({
   lines,
   updateDraftLine,
+  isDisabled = false,
 }) => {
   const theme = useTheme();
   const columns = useColumns<DraftInboundLine>(
@@ -123,6 +127,7 @@ export const PricingTableComponent: FC<TableProps> = ({
 
   return (
     <DataTable
+      isDisabled={isDisabled}
       columns={columns}
       data={lines}
       noDataMessage="Add a new line"
@@ -136,6 +141,7 @@ export const PricingTable = React.memo(PricingTableComponent);
 export const LocationTableComponent: FC<TableProps> = ({
   lines,
   updateDraftLine,
+  isDisabled,
 }) => {
   const theme = useTheme();
   const columns = useColumns<DraftInboundLine>(
@@ -148,7 +154,9 @@ export const LocationTableComponent: FC<TableProps> = ({
     [updateDraftLine]
   );
 
-  return <DataTable columns={columns} data={lines} dense />;
+  return (
+    <DataTable columns={columns} data={lines} dense isDisabled={isDisabled} />
+  );
 };
 
 export const LocationTable = React.memo(LocationTableComponent);

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useNavigate,
   DataTable,
@@ -9,10 +9,11 @@ import {
   InvoiceNodeStatus,
   useTranslation,
   useCurrency,
+  useTableStore,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
-import { getStatusTranslator } from '../../utils';
+import { getStatusTranslator, isInboundDisabled } from '../../utils';
 import { useInbounds, useUpdateInbound, InboundRowFragment } from '../api';
 
 export const InboundListView: FC = () => {
@@ -28,6 +29,15 @@ export const InboundListView: FC = () => {
     pagination,
     filter,
   } = useInbounds();
+
+  const { setDisabledRows } = useTableStore();
+
+  useEffect(() => {
+    const disabledRows = data?.nodes
+      .filter(isInboundDisabled)
+      .map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [data?.nodes]);
 
   const t = useTranslation();
 

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -16,6 +16,14 @@ import { AppBarButtons } from './AppBarButtons';
 import { getStatusTranslator, isInboundDisabled } from '../../utils';
 import { useInbounds, useUpdateInbound, InboundRowFragment } from '../api';
 
+const useDisableInboundRows = (rows?: InboundRowFragment[]) => {
+  const { setDisabledRows } = useTableStore();
+  useEffect(() => {
+    const disabledRows = rows?.filter(isInboundDisabled).map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [rows]);
+};
+
 export const InboundListView: FC = () => {
   const { mutate: onUpdate } = useUpdateInbound();
   const navigate = useNavigate();
@@ -29,15 +37,7 @@ export const InboundListView: FC = () => {
     pagination,
     filter,
   } = useInbounds();
-
-  const { setDisabledRows } = useTableStore();
-
-  useEffect(() => {
-    const disabledRows = data?.nodes
-      .filter(isInboundDisabled)
-      .map(({ id }) => id);
-    if (disabledRows) setDisabledRows(disabledRows);
-  }, [data?.nodes]);
+  useDisableInboundRows(data?.nodes);
 
   const t = useTranslation();
 

--- a/packages/invoices/src/InboundShipment/api/hooks.ts
+++ b/packages/invoices/src/InboundShipment/api/hooks.ts
@@ -20,7 +20,7 @@ import {
   InvoiceNodeStatus,
 } from '@openmsupply-client/common';
 import { ItemRowFragment } from '@openmsupply-client/system';
-import { inboundLinesToSummaryItems } from './../../utils';
+import { inboundLinesToSummaryItems, isInboundDisabled } from './../../utils';
 import { InboundItem } from './../../types';
 import { getInboundQueries, ListParams } from './api';
 import { useInboundShipmentColumns } from '../DetailView/ContentArea';
@@ -57,9 +57,10 @@ export const useInbound = () => {
   );
 };
 
-export const useIsInboundEditable = (): boolean => {
-  const { status } = useInboundFields('status');
-  return status === 'NEW' || status === 'SHIPPED' || status === 'DELIVERED';
+export const useIsInboundDisabled = (): boolean => {
+  const { data } = useInbound();
+  if (!data) return true;
+  return isInboundDisabled(data);
 };
 
 export const useInboundSelector = <T = InboundFragment>(

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 import {
   useNavigate,
   DataTable,
@@ -11,13 +11,22 @@ import {
   InvoiceNodeStatus,
   generateUUID,
   useCurrency,
+  useTableStore,
 } from '@openmsupply-client/common';
 import { NameSearchModal } from '@openmsupply-client/system';
-import { getStatusTranslator } from '../../utils';
+import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { useOutbounds, useCreateOutbound, useUpdateOutbound } from '../api';
 import { OutboundRowFragment } from '../api/operations.generated';
+
+const useDisableOutboundRows = (rows?: OutboundRowFragment[]) => {
+  const { setDisabledRows } = useTableStore();
+  useEffect(() => {
+    const disabledRows = rows?.filter(isOutboundDisabled).map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [rows]);
+};
 
 export const OutboundShipmentListViewComponent: FC = () => {
   const { mutate: onUpdate } = useUpdateOutbound();
@@ -35,6 +44,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
     pagination,
     filter,
   } = useOutbounds();
+  useDisableOutboundRows(data?.nodes);
 
   const { c } = useCurrency();
   const columns = useColumns<OutboundRowFragment>(

--- a/packages/invoices/src/OutboundShipment/api/hooks.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks.ts
@@ -1,3 +1,4 @@
+import { isOutboundDisabled } from './../../utils';
 import { useMemo, useCallback } from 'react';
 import {
   RouteBuilder,
@@ -6,7 +7,6 @@ import {
   useTranslation,
   useNotification,
   useQueryClient,
-  InvoiceNodeStatus,
   useQuerySelector,
   useParams,
   useOmSupplyApi,
@@ -167,12 +167,9 @@ export const useOutboundFields = <KeyOfOutbound extends keyof OutboundFragment>(
 };
 
 export const useIsOutboundDisabled = (): boolean => {
-  const { status } = useOutboundFields('status');
-  return (
-    status === InvoiceNodeStatus.Shipped ||
-    status === InvoiceNodeStatus.Verified ||
-    status === InvoiceNodeStatus.Delivered
-  );
+  const { data } = useOutbound();
+  if (!data) return true;
+  return isOutboundDisabled(data);
 };
 
 const useOutboundSelector = <ReturnType>(

--- a/packages/invoices/src/utils.ts
+++ b/packages/invoices/src/utils.ts
@@ -5,7 +5,7 @@ import {
   useTranslation,
   groupBy,
 } from '@openmsupply-client/common';
-import { OutboundRowFragment, OutboundFragment } from './OutboundShipment/api';
+import { OutboundRowFragment } from './OutboundShipment/api';
 import { InboundLineFragment } from './InboundShipment/api';
 import { InboundItem } from './types';
 
@@ -91,8 +91,12 @@ export const getStatusTranslator =
     );
   };
 
-export const isInvoiceEditable = (outbound: OutboundFragment): boolean => {
-  return outbound.status === 'NEW' || outbound.status === 'ALLOCATED';
+export const isOutboundDisabled = (outbound: OutboundRowFragment): boolean => {
+  return (
+    outbound.status !== InvoiceNodeStatus.Shipped &&
+    outbound.status !== InvoiceNodeStatus.Verified &&
+    outbound.status !== InvoiceNodeStatus.Delivered
+  );
 };
 
 export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {

--- a/packages/invoices/src/utils.ts
+++ b/packages/invoices/src/utils.ts
@@ -95,8 +95,12 @@ export const isInvoiceEditable = (outbound: OutboundFragment): boolean => {
   return outbound.status === 'NEW' || outbound.status === 'ALLOCATED';
 };
 
-export const isInboundEditable = (inbound: InboundRowFragment): boolean => {
-  return inbound.status === 'NEW';
+export const isInboundDisabled = (inbound: InboundRowFragment): boolean => {
+  return (
+    inbound.status !== 'NEW' &&
+    inbound.status !== 'SHIPPED' &&
+    inbound.status !== 'DELIVERED'
+  );
 };
 
 export const createSummaryItem = (

--- a/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import {
   DataTable,
   useColumns,
@@ -9,11 +9,20 @@ import {
   BasicSpinner,
   useTranslation,
   RequisitionNodeStatus,
+  useTableStore,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
 import { RequestRowFragment, useUpdateRequest, useRequests } from '../api';
-import { getRequisitionTranslator } from '../../utils';
+import { getRequisitionTranslator, isRequestDisabled } from '../../utils';
+
+const useDisableRequestRows = (rows?: RequestRowFragment[]) => {
+  const { setDisabledRows } = useTableStore();
+  useEffect(() => {
+    const disabledRows = rows?.filter(isRequestDisabled).map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [rows]);
+};
 
 export const RequestRequisitionListView: FC = () => {
   const navigate = useNavigate();
@@ -30,6 +39,8 @@ export const RequestRequisitionListView: FC = () => {
     pagination,
     onChangePage,
   } = useRequests();
+  useDisableRequestRows(data?.nodes);
+
   const columns = useColumns<RequestRowFragment>(
     [
       [getNameAndColorColumn(), { setter: onUpdate }],

--- a/packages/requisitions/src/RequestRequisition/api/hooks.ts
+++ b/packages/requisitions/src/RequestRequisition/api/hooks.ts
@@ -1,3 +1,4 @@
+import { isRequestDisabled } from './../../utils';
 import { useMemo } from 'react';
 import {
   useConfirmationModal,
@@ -138,11 +139,9 @@ export const useRequestLines = (): UseRequestRequisitionLinesController => {
 };
 
 export const useIsRequestDisabled = (): boolean => {
-  const { status } = useRequestFields('status');
-  return (
-    status === RequisitionNodeStatus.Finalised ||
-    status === RequisitionNodeStatus.Sent
-  );
+  const { data } = useRequest();
+  if (!data) return true;
+  return isRequestDisabled(data);
 };
 
 export const useSaveRequestLines = () => {

--- a/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import {
   useNavigate,
   DataTable,
@@ -6,16 +6,27 @@ import {
   TableProvider,
   createTableStore,
   getNameAndColorColumn,
+  useTableStore,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
+import { isResponseDisabled } from '../../utils';
 import { useUpdateResponse, useResponses, ResponseRowFragment } from '../api';
+
+const useDisableResponseRows = (rows?: ResponseRowFragment[]) => {
+  const { setDisabledRows } = useTableStore();
+  useEffect(() => {
+    const disabledRows = rows?.filter(isResponseDisabled).map(({ id }) => id);
+    if (disabledRows) setDisabledRows(disabledRows);
+  }, [rows]);
+};
 
 export const ResponseRequisitionListView: FC = () => {
   const { mutate: onUpdate } = useUpdateResponse();
   const navigate = useNavigate();
   const { data, onChangeSortBy, sortBy, onChangePage, pagination, filter } =
     useResponses();
+  useDisableResponseRows(data?.nodes);
 
   const columns = useColumns<ResponseRowFragment>(
     [

--- a/packages/requisitions/src/ResponseRequisition/api/hooks.ts
+++ b/packages/requisitions/src/ResponseRequisition/api/hooks.ts
@@ -5,7 +5,6 @@ import {
   useOpenInNewTab,
   useQueryClient,
   useAuthContext,
-  RequisitionNodeStatus,
   useParams,
   useOmSupplyApi,
   UseQueryResult,
@@ -21,6 +20,7 @@ import {
   useTranslation,
 } from '@openmsupply-client/common';
 import { getResponseQueries, ListParams } from './api';
+import { isResponseDisabled } from './../../utils';
 import {
   getSdk,
   ResponseFragment,
@@ -124,8 +124,9 @@ export const useResponseLines = (): UseResponseLinesController => {
 };
 
 export const useIsResponseDisabled = (): boolean => {
-  const { status } = useResponseFields('status');
-  return status === RequisitionNodeStatus.Finalised;
+  const { data } = useResponse();
+  if (!data) return true;
+  return isResponseDisabled(data);
 };
 
 export const useSaveResponseLines = () => {

--- a/packages/requisitions/src/utils.ts
+++ b/packages/requisitions/src/utils.ts
@@ -1,3 +1,4 @@
+import { RequestRowFragment } from './RequestRequisition/api/operations.generated';
 import {
   RequisitionNodeStatus,
   LocaleKey,
@@ -51,4 +52,12 @@ export const getNextResponseStatus = (
   );
   const nextStatus = responseStatuses[currentStatusIdx + 1];
   return nextStatus ?? null;
+};
+
+export const isRequestDisabled = (request: RequestRowFragment): boolean => {
+  return request.status !== RequisitionNodeStatus.Draft;
+};
+
+export const isResponseDisabled = (request: RequestRowFragment): boolean => {
+  return request.status !== RequisitionNodeStatus.New;
 };

--- a/packages/system/src/Location/Components/LocationInputColumn.tsx
+++ b/packages/system/src/Location/Components/LocationInputColumn.tsx
@@ -43,7 +43,7 @@ export const getLocationInputColumn = <
       }
     }
   },
-  Cell: ({ rowData, column, rows, columnIndex, rowIndex }) => {
+  Cell: ({ rowData, column, rows, columnIndex, rowIndex, isDisabled }) => {
     const value = column.accessor({
       rowData,
       rows,
@@ -58,7 +58,7 @@ export const getLocationInputColumn = <
     return (
       <LocationSearchInput
         autoFocus={autoFocus}
-        disabled={false}
+        disabled={!!isDisabled}
         value={value}
         width={column.width}
         onChange={onChange}


### PR DESCRIPTION
Fixes #933 


**I've realised that maybe a lot of this is all wrong! (Disabling of inputs in edit modals). Maybe it would just be better to disable opening the modal rather than disabling it..! That would certainly be a lot easier..**

- Added a field to `CellProps<T>`, `isDisabled`. Which `DataRow` is able to pass into cells.
- Updated each of the cells/columns to have a disabled state.
- Then, also went and triggered a disabled state in the list views and detail modals - but NOT outbound, will make a separate issue for that.
- Also need a separate issue for stocktake edit modal in a finalised state. Should show only the existing stocklines, rather than all of the stock lines available to count.
