### PR TITLE
#989 auto focusing item input

### DIFF
--- a/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -128,7 +128,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
           sx={{ overflowX: 'hidden', ...contentSX }}
         >
           <Slide in={slideConfig.in} direction={slideConfig.direction}>
-            <div> {children}</div>
+            <div>{slideConfig.in && children}</div>
           </Slide>
         </DialogContent>
         <DialogActions

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -44,7 +44,8 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
 
   const onNext = async () => {
     await save(draftLines);
-    if (nextItem) setCurrentItem(nextItem);
+    if (mode === ModalMode.Update && nextItem) setCurrentItem(nextItem);
+    else if (mode === ModalMode.Create) setCurrentItem(null);
     else onClose();
     // Returning true here triggers the slide animation
     return true;

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -68,6 +68,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
         onCancel={onClose}
         mode={mode}
         isOpen={isOpen}
+        hasNext={!!nextItem}
       >
         {(() => {
           if (isLoading) {

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -30,6 +30,7 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
         <ModalLabel label={t('label.item')} />
         <Grid item flex={1}>
           <ItemSearchInput
+            autoFocus={!item}
             disabled={mode === ModalMode.Update}
             currentItemId={item?.id}
             onChange={onChangeItem}

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditModal.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditModal.tsx
@@ -12,6 +12,7 @@ interface StocktakeLineEditModalProps {
   onCancel: () => void;
   onOk: () => void;
   onNext: () => void;
+  hasNext: boolean;
 }
 
 export const StocktakeLineEditModal: FC<StocktakeLineEditModalProps> = ({
@@ -21,6 +22,7 @@ export const StocktakeLineEditModal: FC<StocktakeLineEditModalProps> = ({
   onCancel,
   onOk,
   onNext,
+  hasNext,
 }) => {
   const { Modal } = useDialog({ onClose: onCancel, isOpen });
   const t = useTranslation('inventory');
@@ -37,7 +39,7 @@ export const StocktakeLineEditModal: FC<StocktakeLineEditModalProps> = ({
         <DialogButton
           variant="next"
           onClick={onNext}
-          disabled={mode !== ModalMode.Update}
+          disabled={!hasNext && mode === ModalMode.Update}
         />
       }
       okButton={<DialogButton variant="ok" onClick={onOk} />}

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -183,13 +183,13 @@ export const InboundLineEdit: FC<InboundLineEditProps> = ({
           <DialogButton
             variant="next"
             onClick={async () => {
-              try {
-                await saveLines();
-                setCurrentItem(mode === ModalMode.Update ? nextItem : null);
-                return true;
-              } catch (e) {
-                return false;
-              }
+              await saveLines();
+              if (mode === ModalMode.Update && nextItem) {
+                setCurrentItem(nextItem);
+              } else if (mode === ModalMode.Create) setCurrentItem(null);
+              else onClose();
+              // Returning true here triggers the slide animation
+              return true;
             }}
           />
         }

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditForm.tsx
@@ -29,6 +29,7 @@ export const InboundLineEditForm: FC<InboundLineEditProps> = ({
         <ModalLabel label={t('label.item')} justifyContent="flex-end" />
         <Grid item flex={1}>
           <ItemSearchInput
+            autoFocus={!item}
             disabled={disabled}
             currentItemId={item?.id}
             onChange={(newItem: ItemRowFragment | null) =>

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -59,8 +59,12 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
   const { next, disabled: nextDisabled } = useNextItem(currentItem?.id);
   const { setIsDirty } = useDirtyCheck();
 
-  const onNext = () => {
-    setCurrentItem(next);
+  const onNext = async () => {
+    await mutate(draftOutboundLines);
+    if (mode === ModalMode.Update && next) setCurrentItem(next);
+    else if (mode === ModalMode.Create) setCurrentItem(null);
+    else onClose();
+    // Returning true here triggers the slide animation
     return true;
   };
 
@@ -81,7 +85,7 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
       nextButton={
         <DialogButton
-          disabled={mode === ModalMode.Create || nextDisabled}
+          disabled={mode === ModalMode.Update && nextDisabled}
           variant="next"
           onClick={onNext}
         />

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -49,6 +49,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
         <ModalLabel label={t('label.item')} />
         <Grid item flex={1}>
           <ItemSearchInput
+            autoFocus={!item}
             disabled={disabled}
             currentItemId={item?.id}
             onChange={onChangeItem}

--- a/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEdit.tsx
@@ -38,10 +38,13 @@ export const RequestLineEdit = ({
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
       nextButton={
         <DialogButton
-          disabled={!hasNext || mode === ModalMode.Create}
+          disabled={!hasNext && mode === ModalMode.Update}
           variant="next"
-          onClick={() => {
-            next && setCurrentItem(next);
+          onClick={async () => {
+            await save();
+            if (mode === ModalMode.Update && next) setCurrentItem(next);
+            else if (mode === ModalMode.Create) setCurrentItem(null);
+            else onClose();
             // Returning true here triggers the slide animation
             return true;
           }}

--- a/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -88,6 +88,7 @@ export const RequestLineEditForm = ({
             {t('label.stock-details', { ns: 'replenishment' })}
           </Typography>
           <ItemSearchInput
+            autoFocus={!item}
             width={300}
             disabled={disabled}
             currentItemId={item?.id}

--- a/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
+++ b/packages/system/src/Item/Components/ItemSearchInput/ItemSearchInput.tsx
@@ -46,6 +46,7 @@ interface ItemSearchInputProps {
   disabled?: boolean;
   extraFilter?: (item: ItemRowWithStatsFragment) => boolean;
   width?: number;
+  autoFocus?: boolean;
 }
 
 export const ItemSearchInput: FC<ItemSearchInputProps> = ({
@@ -54,6 +55,7 @@ export const ItemSearchInput: FC<ItemSearchInputProps> = ({
   disabled = false,
   extraFilter,
   width = 850,
+  autoFocus = false,
 }) => {
   const { data, isLoading } = useItemsWithStats();
   const t = useTranslation('common');
@@ -68,6 +70,7 @@ export const ItemSearchInput: FC<ItemSearchInputProps> = ({
 
   return (
     <Autocomplete
+      autoFocus={autoFocus}
       disabled={disabled}
       onOpen={selectControl.toggleOn}
       onClose={selectControl.toggleOff}


### PR DESCRIPTION
Fixes #989 

- Just wanted to add a little auto focus... and then..
- I added `openOnFocus` to the autocomplete which was kind of nice, but I was having a little bit of an issue where the list box of the auto complete was not aligning well after a transition animation. Weird. So I left that out and just went with the autoFocus (If you want to see, add `openOnFocus={true}` to the autocomplete..
- I realised the next behaviour was a little inconsistent in all the modals. Some were disabling while the modal was in Create mode. But I wanted it enabled! Especially with the auto focus it makes it really easy to add items with the next button. Though, it does make things a little inconsistent still - the next behaviour during 'update' mode - disabling the next button? Closing the modal when there are no more 'nexts'? Go to 'create mode' when there are no more nexts? 🤷 🤷 🤷 


Some further improvements for a bit better UX
- Add shortcuts to stocktake tabs
- Add shortcuts to the OK/OK&Next buttons/ Cancel has Esc already
- Add shortcut to the "add x" button
- Make the tabbing stay within the table once you're there?
- Even though the UI for the requisition lines probably looks better with the comment in the middle, the tabbing is no ideal and might be a better experience to have the comment be on the right 🤔 