### PR TITLE
#978 stocktake locations

### DIFF
--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -16,6 +16,8 @@
   "label.suggested": "Suggested",
   "heading.description": "Description",
   "label.locked": "Locked",
+  "label.batch": "Batch",
+  "label.pricing": "Pricing",
   "messages.locked-description": "This will prevent further changes to the stocktake until it is unlocked.",
   "messages.unlocked-description": "This will re-enable changes to the stocktake.",
   "messages.cant-delete-stocktakes": "Can only delete stocktakes with a status of 'New'",

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -17,9 +17,14 @@ import {
   StocktakeLineEditTabs,
   StyledTabContainer,
   StyledTabPanel,
+  Tabs,
 } from './StocktakeLineEditTabs';
 import { useIsStocktakeDisabled } from '../../../api';
-import { BatchTable, PricingTable } from './StocktakeLineEditTables';
+import {
+  LocationTable,
+  BatchTable,
+  PricingTable,
+} from './StocktakeLineEditTables';
 import { StocktakeLineEditModal } from './StocktakeLineEditModal';
 interface StocktakeLineEditProps {
   item: ItemRowFragment | null;
@@ -96,7 +101,7 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                     isDisabled={isDisabled}
                     onAddLine={addLine}
                   >
-                    <StyledTabPanel value={'Batch'}>
+                    <StyledTabPanel value={Tabs.Batch}>
                       <StyledTabContainer>
                         <BatchTable
                           isDisabled={isDisabled}
@@ -106,9 +111,19 @@ export const StocktakeLineEdit: FC<StocktakeLineEditProps> = ({
                       </StyledTabContainer>
                     </StyledTabPanel>
 
-                    <StyledTabPanel value={'Pricing'}>
+                    <StyledTabPanel value={Tabs.Pricing}>
                       <StyledTabContainer>
                         <PricingTable
+                          isDisabled={isDisabled}
+                          batches={draftLines}
+                          update={update}
+                        />
+                      </StyledTabContainer>
+                    </StyledTabPanel>
+
+                    <StyledTabPanel value={Tabs.Location}>
+                      <StyledTabContainer>
+                        <LocationTable
                           isDisabled={isDisabled}
                           batches={draftLines}
                           update={update}

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -174,7 +174,15 @@ export const LocationTable: FC<StocktakeLineEditTableProps> = ({
   const columns = useColumns<DraftStocktakeLine>([
     getCountThisLineColumn(update, theme),
     getBatchColumn(update, theme),
-    [getLocationInputColumn(), { width: 400, setter: update }],
+    [
+      getLocationInputColumn(),
+      {
+        width: 400,
+        setter: patch => update({ ...patch, countThisLine: true }),
+        accessor: ({ rowData }) =>
+          rowData.countThisLine ? rowData.location : null,
+      },
+    ],
   ]);
 
   return (

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -15,6 +15,7 @@ import {
   Theme,
   useTheme,
 } from '@openmsupply-client/common';
+import { getLocationInputColumn } from '@openmsupply-client/system';
 import { DraftStocktakeLine } from './hooks';
 
 interface StocktakeLineEditTableProps {
@@ -150,6 +151,30 @@ export const PricingTable: FC<StocktakeLineEditTableProps> = ({
         setter: patch => update({ ...patch, countThisLine: true }),
       },
     ],
+  ]);
+
+  return (
+    <DataTable
+      isDisabled={isDisabled}
+      columns={columns}
+      data={batches}
+      noDataMessage={t('label.add-new-line')}
+      dense
+    />
+  );
+};
+
+export const LocationTable: FC<StocktakeLineEditTableProps> = ({
+  batches,
+  update,
+  isDisabled,
+}) => {
+  const theme = useTheme();
+  const t = useTranslation('inventory');
+  const columns = useColumns<DraftStocktakeLine>([
+    getCountThisLineColumn(update, theme),
+    getBatchColumn(update, theme),
+    [getLocationInputColumn(), { width: 400, setter: update }],
   ]);
 
   return (

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { useEffect, FC, useState } from 'react';
 import {
   TabContext,
   TabList,
@@ -14,6 +14,7 @@ import {
 export enum Tabs {
   Batch = 'Batch',
   Pricing = 'Pricing',
+  Location = 'Location',
 }
 
 export const StyledTabPanel = styled(TabPanel)({
@@ -33,6 +34,27 @@ export const StocktakeLineEditTabs: FC<{
   const t = useTranslation('inventory');
   const [currentTab, setCurrentTab] = useState(Tabs.Batch);
 
+  useEffect(() => {
+    const keybindings = (e: KeyboardEvent) => {
+      if (e.code === 'Digit1' && e.shiftKey) {
+        e.preventDefault();
+        setCurrentTab(Tabs.Batch);
+      }
+      if (e.code === 'Digit2' && e.shiftKey) {
+        e.preventDefault();
+        setCurrentTab(Tabs.Pricing);
+      }
+      if (e.code === 'Digit3' && e.shiftKey) {
+        e.preventDefault();
+        setCurrentTab(Tabs.Location);
+      }
+    };
+
+    window.addEventListener('keydown', keybindings);
+
+    return () => window.removeEventListener('keydown', keybindings);
+  }, []);
+
   return (
     <TabContext value={currentTab}>
       <Box flex={1} display="flex" justifyContent="space-between">
@@ -43,8 +65,9 @@ export const StocktakeLineEditTabs: FC<{
           centered
           onChange={(_, v) => setCurrentTab(v)}
         >
-          <Tab value={Tabs.Batch} label={Tabs.Batch} />
-          <Tab value={Tabs.Pricing} label={Tabs.Pricing} />
+          <Tab value={Tabs.Batch} label={`${t('label.batch')} (⇧+1)`} />
+          <Tab value={Tabs.Pricing} label={`${t('label.pricing')} (⇧+2)`} />
+          <Tab value={Tabs.Location} label={`${t('label.location')} (⇧+3)`} />
         </TabList>
         <Box flex={1} justifyContent="flex-end" display="flex">
           <ButtonWithIcon

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
@@ -48,6 +48,10 @@ export const StocktakeLineEditTabs: FC<{
         e.preventDefault();
         setCurrentTab(Tabs.Location);
       }
+      if (e.code === 'Equal' && e.shiftKey) {
+        e.preventDefault();
+        onAddLine();
+      }
     };
 
     window.addEventListener('keydown', keybindings);
@@ -75,7 +79,7 @@ export const StocktakeLineEditTabs: FC<{
             color="primary"
             variant="outlined"
             onClick={onAddLine}
-            label={t('label.add-batch', { ns: 'inventory' })}
+            label={`${t('label.add-batch', { ns: 'inventory' })} (+)`}
             Icon={<PlusCircleIcon />}
           />
         </Box>

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks.ts
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks.ts
@@ -52,6 +52,7 @@ const createDraftLine = (
     sellPricePerPack: 0,
     costPricePerPack: 0,
     packSize: 1,
+    location: null,
   };
 };
 

--- a/packages/inventory/src/Stocktake/api/api.ts
+++ b/packages/inventory/src/Stocktake/api/api.ts
@@ -41,6 +41,7 @@ const stocktakeParser = {
       id: line.id,
     }),
     toUpdate: (line: DraftStocktakeLine): UpdateStocktakeLineInput => ({
+      locationId: line.location?.id,
       batch: line.batch ?? '',
       packSize: line.packSize ?? 1,
       costPricePerPack: line.costPricePerPack,
@@ -52,6 +53,7 @@ const stocktakeParser = {
         : undefined,
     }),
     toInsert: (line: DraftStocktakeLine): InsertStocktakeLineInput => ({
+      locationId: line.location?.id,
       batch: line.batch ?? '',
       packSize: line.packSize ?? 1,
       costPricePerPack: line.costPricePerPack,


### PR DESCRIPTION
Fixes #978 

- Simply adding locations to stocktake line editing.
- Off road added keyboard shortcuts to the tabs the same as inbound. 
- Also off road added an experimental shortcut to the add batch button