### PR TITLE
Add rename OmSupplyApi -> GraphQLClient

### DIFF
--- a/packages/common/src/api/GqlContext.tsx
+++ b/packages/common/src/api/GqlContext.tsx
@@ -2,36 +2,33 @@ import React, { FC, useMemo, useEffect, useState, useCallback } from 'react';
 import { createContext } from 'react';
 import { GraphQLClient } from 'graphql-request';
 
-export const createGraphQLClient = (url: string): { client: GraphQLClient } => {
+export const createGql = (url: string): { client: GraphQLClient } => {
   const client = new GraphQLClient(url, { credentials: 'include' });
   return { client };
 };
 
-interface GraphQLClientControl {
+interface GqlControl {
   client: GraphQLClient;
   setHeader: (header: string, value: string) => void;
   setUrl: (url: string) => void;
 }
 
-const GraphQLClientContext = createContext<GraphQLClientControl>({
-  ...createGraphQLClient(''),
+const GqlContext = createContext<GqlControl>({
+  ...createGql(''),
   setHeader: () => {},
   setUrl: () => {},
 });
 
-const { Provider } = GraphQLClientContext;
+const { Provider } = GqlContext;
 
 interface ApiProviderProps {
   url: string;
 }
 
-export const GraphQLClientProvider: FC<ApiProviderProps> = ({
-  url,
-  children,
-}) => {
+export const GqlProvider: FC<ApiProviderProps> = ({ url, children }) => {
   const [{ client }, setApi] = useState<{
     client: GraphQLClient;
-  }>(() => createGraphQLClient(url));
+  }>(() => createGql(url));
 
   const setUrl = useCallback(
     (newUrl: string) => {
@@ -48,7 +45,7 @@ export const GraphQLClientProvider: FC<ApiProviderProps> = ({
   );
 
   useEffect(() => {
-    setApi(createGraphQLClient(url));
+    setApi(createGql(url));
   }, [url]);
 
   const val = useMemo(
@@ -63,7 +60,7 @@ export const GraphQLClientProvider: FC<ApiProviderProps> = ({
   return <Provider value={val}>{children}</Provider>;
 };
 
-export const useGraphQLClient = (): GraphQLClientControl => {
-  const graphQLClientControl = React.useContext(GraphQLClientContext);
+export const useGql = (): GqlControl => {
+  const graphQLClientControl = React.useContext(GqlContext);
   return graphQLClientControl;
 };

--- a/packages/common/src/api/OmSupplyApiContext.tsx
+++ b/packages/common/src/api/OmSupplyApiContext.tsx
@@ -2,36 +2,36 @@ import React, { FC, useMemo, useEffect, useState, useCallback } from 'react';
 import { createContext } from 'react';
 import { GraphQLClient } from 'graphql-request';
 
-export const createOmSupplyApi = (url: string): { client: GraphQLClient } => {
+export const createGraphQLClient = (url: string): { client: GraphQLClient } => {
   const client = new GraphQLClient(url, { credentials: 'include' });
   return { client };
 };
 
-interface OmSupplyApiControl {
+interface GraphQLClientControl {
   client: GraphQLClient;
   setHeader: (header: string, value: string) => void;
   setUrl: (url: string) => void;
 }
 
-const OmSupplyApiContext = createContext<OmSupplyApiControl>({
-  ...createOmSupplyApi(''),
+const GraphQLClientContext = createContext<GraphQLClientControl>({
+  ...createGraphQLClient(''),
   setHeader: () => {},
   setUrl: () => {},
 });
 
-const { Provider, Consumer } = OmSupplyApiContext;
+const { Provider } = GraphQLClientContext;
 
 interface ApiProviderProps {
   url: string;
 }
 
-export const OmSupplyApiProvider: FC<ApiProviderProps> = ({
+export const GraphQLClientProvider: FC<ApiProviderProps> = ({
   url,
   children,
 }) => {
   const [{ client }, setApi] = useState<{
     client: GraphQLClient;
-  }>(() => createOmSupplyApi(url));
+  }>(() => createGraphQLClient(url));
 
   const setUrl = useCallback(
     (newUrl: string) => {
@@ -48,7 +48,7 @@ export const OmSupplyApiProvider: FC<ApiProviderProps> = ({
   );
 
   useEffect(() => {
-    setApi(createOmSupplyApi(url));
+    setApi(createGraphQLClient(url));
   }, [url]);
 
   const val = useMemo(
@@ -63,9 +63,7 @@ export const OmSupplyApiProvider: FC<ApiProviderProps> = ({
   return <Provider value={val}>{children}</Provider>;
 };
 
-export const OmSupplyApiConsumer = Consumer;
-
-export const useOmSupplyApi = (): OmSupplyApiControl => {
-  const omSupplyApiControl = React.useContext(OmSupplyApiContext);
-  return omSupplyApiControl;
+export const useGraphQLClient = (): GraphQLClientControl => {
+  const graphQLClientControl = React.useContext(GraphQLClientContext);
+  return graphQLClientControl;
 };

--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -1,2 +1,2 @@
-export * from './OmSupplyApiContext';
+export * from './GqlContext';
 export * from './hooks';

--- a/packages/common/src/authentication/AuthContext.tsx
+++ b/packages/common/src/authentication/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, FC, useMemo, useState } from 'react';
 import { useLocalStorage } from '../localStorage';
 import Cookies from 'js-cookie';
 import { addMinutes } from 'date-fns';
-import { useOmSupplyApi } from '../api';
+import { useGraphQLClient } from '../api';
 import { useGetRefreshToken } from './api/hooks';
 import { useGetAuthToken } from './api/hooks/useGetAuthToken';
 import { AuthenticationResponse } from './api';
@@ -62,7 +62,7 @@ export const getAuthCookie = (): AuthCookie => {
 };
 
 const useRefreshingAuth = (token?: string) => {
-  const { setHeader } = useOmSupplyApi();
+  const { setHeader } = useGraphQLClient();
   setHeader('Authorization', `Bearer ${token}`);
   useGetRefreshToken(token ?? '');
 };

--- a/packages/common/src/authentication/AuthContext.tsx
+++ b/packages/common/src/authentication/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, FC, useMemo, useState } from 'react';
 import { useLocalStorage } from '../localStorage';
 import Cookies from 'js-cookie';
 import { addMinutes } from 'date-fns';
-import { useGraphQLClient } from '../api';
+import { useGql } from '../api';
 import { useGetRefreshToken } from './api/hooks';
 import { useGetAuthToken } from './api/hooks/useGetAuthToken';
 import { AuthenticationResponse } from './api';
@@ -69,7 +69,7 @@ const setAuthCookie = (cookie: AuthCookie) => {
 };
 
 const useRefreshingAuth = (token?: string) => {
-  const { setHeader } = useGraphQLClient();
+  const { setHeader } = useGql();
   setHeader('Authorization', `Bearer ${token}`);
   useGetRefreshToken(token ?? '');
 };

--- a/packages/common/src/authentication/api/hooks/useAuthApi.ts
+++ b/packages/common/src/authentication/api/hooks/useAuthApi.ts
@@ -1,9 +1,9 @@
-import { useGraphQLClient } from '../../../api';
+import { useGql } from '../../../api';
 import { getAuthQueries } from '../api';
 import { getSdk } from '../operations.generated';
 
 export const useAuthApi = () => {
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const queries = getAuthQueries(getSdk(client));
 
   const keys = {

--- a/packages/common/src/authentication/api/hooks/useAuthApi.ts
+++ b/packages/common/src/authentication/api/hooks/useAuthApi.ts
@@ -1,9 +1,9 @@
-import { useOmSupplyApi } from '../../../api';
+import { useGraphQLClient } from '../../../api';
 import { getAuthQueries } from '../api';
 import { getSdk } from '../operations.generated';
 
 export const useAuthApi = () => {
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const queries = getAuthQueries(getSdk(client));
 
   const keys = {

--- a/packages/common/src/utils/testing.tsx
+++ b/packages/common/src/utils/testing.tsx
@@ -6,7 +6,7 @@ import { SnackbarProvider } from 'notistack';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { TableProvider, createTableStore } from '../ui/layout/tables';
-import { IntlTestProvider, GraphQLClientProvider } from '..';
+import { IntlTestProvider, GqlProvider } from '..';
 import { Environment } from '@openmsupply-client/config';
 import { ConfirmationModalProvider } from '../ui/components/modals';
 import {
@@ -53,7 +53,7 @@ export const TestingProvider: FC<{ locale?: 'en' | 'fr' | 'ar' }> = ({
 }) => (
   <React.Suspense fallback={<span>?</span>}>
     <QueryClientProvider client={queryClient}>
-      <GraphQLClientProvider url={Environment.API_URL}>
+      <GqlProvider url={Environment.API_URL}>
         <SnackbarProvider maxSnack={3}>
           <IntlTestProvider locale={locale}>
             <TableProvider createStore={createTableStore}>
@@ -61,7 +61,7 @@ export const TestingProvider: FC<{ locale?: 'en' | 'fr' | 'ar' }> = ({
             </TableProvider>
           </IntlTestProvider>
         </SnackbarProvider>
-      </GraphQLClientProvider>
+      </GqlProvider>
     </QueryClientProvider>
   </React.Suspense>
 );
@@ -69,7 +69,7 @@ export const TestingProvider: FC<{ locale?: 'en' | 'fr' | 'ar' }> = ({
 export const StoryProvider: FC<StoryProviderProps> = ({ children }) => (
   <React.Suspense fallback={<span>?</span>}>
     <QueryClientProvider client={queryClient}>
-      <GraphQLClientProvider url={Environment.API_URL}>
+      <GqlProvider url={Environment.API_URL}>
         <SnackbarProvider maxSnack={3}>
           <IntlTestProvider locale="en">
             <TableProvider createStore={createTableStore}>
@@ -81,7 +81,7 @@ export const StoryProvider: FC<StoryProviderProps> = ({ children }) => (
             </TableProvider>
           </IntlTestProvider>
         </SnackbarProvider>
-      </GraphQLClientProvider>
+      </GqlProvider>
     </QueryClientProvider>
   </React.Suspense>
 );

--- a/packages/common/src/utils/testing.tsx
+++ b/packages/common/src/utils/testing.tsx
@@ -6,7 +6,7 @@ import { SnackbarProvider } from 'notistack';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { TableProvider, createTableStore } from '../ui/layout/tables';
-import { IntlTestProvider, OmSupplyApiProvider } from '..';
+import { IntlTestProvider, GraphQLClientProvider } from '..';
 import { Environment } from '@openmsupply-client/config';
 import { ConfirmationModalProvider } from '../ui/components/modals';
 import {
@@ -53,7 +53,7 @@ export const TestingProvider: FC<{ locale?: 'en' | 'fr' | 'ar' }> = ({
 }) => (
   <React.Suspense fallback={<span>?</span>}>
     <QueryClientProvider client={queryClient}>
-      <OmSupplyApiProvider url={Environment.API_URL}>
+      <GraphQLClientProvider url={Environment.API_URL}>
         <SnackbarProvider maxSnack={3}>
           <IntlTestProvider locale={locale}>
             <TableProvider createStore={createTableStore}>
@@ -61,7 +61,7 @@ export const TestingProvider: FC<{ locale?: 'en' | 'fr' | 'ar' }> = ({
             </TableProvider>
           </IntlTestProvider>
         </SnackbarProvider>
-      </OmSupplyApiProvider>
+      </GraphQLClientProvider>
     </QueryClientProvider>
   </React.Suspense>
 );
@@ -69,7 +69,7 @@ export const TestingProvider: FC<{ locale?: 'en' | 'fr' | 'ar' }> = ({
 export const StoryProvider: FC<StoryProviderProps> = ({ children }) => (
   <React.Suspense fallback={<span>?</span>}>
     <QueryClientProvider client={queryClient}>
-      <OmSupplyApiProvider url={Environment.API_URL}>
+      <GraphQLClientProvider url={Environment.API_URL}>
         <SnackbarProvider maxSnack={3}>
           <IntlTestProvider locale="en">
             <TableProvider createStore={createTableStore}>
@@ -81,7 +81,7 @@ export const StoryProvider: FC<StoryProviderProps> = ({ children }) => (
             </TableProvider>
           </IntlTestProvider>
         </SnackbarProvider>
-      </OmSupplyApiProvider>
+      </GraphQLClientProvider>
     </QueryClientProvider>
   </React.Suspense>
 );

--- a/packages/dashboard/src/api/hooks.ts
+++ b/packages/dashboard/src/api/hooks.ts
@@ -1,13 +1,9 @@
-import {
-  useAuthContext,
-  useGraphQLClient,
-  useQuery,
-} from '@openmsupply-client/common';
+import { useAuthContext, useGql, useQuery } from '@openmsupply-client/common';
 import { DashboardApi, getDashboardQueries } from './api';
 import { getSdk } from './operations.generated';
 
 export const useDashboardApi = (): DashboardApi => {
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const { storeId } = useAuthContext();
   const queries = getDashboardQueries(getSdk(client), storeId);
   return { ...queries, storeId: storeId };

--- a/packages/dashboard/src/api/hooks.ts
+++ b/packages/dashboard/src/api/hooks.ts
@@ -1,13 +1,13 @@
 import {
   useAuthContext,
-  useOmSupplyApi,
+  useGraphQLClient,
   useQuery,
 } from '@openmsupply-client/common';
 import { DashboardApi, getDashboardQueries } from './api';
 import { getSdk } from './operations.generated';
 
 export const useDashboardApi = (): DashboardApi => {
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const { storeId } = useAuthContext();
   const queries = getDashboardQueries(getSdk(client), storeId);
   return { ...queries, storeId: storeId };

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -12,7 +12,7 @@ import {
   RouteBuilder,
   ErrorBoundary,
   GenericErrorFallback,
-  OmSupplyApiProvider,
+  GraphQLClientProvider,
   IntlProvider,
   RandomLoader,
   ConfirmationModalProvider,
@@ -38,7 +38,7 @@ const Host: FC = () => (
       <React.Suspense fallback={<RandomLoader />}>
         <ErrorBoundary Fallback={GenericErrorFallback}>
           <QueryClientProvider client={queryClient}>
-            <OmSupplyApiProvider url={Environment.API_URL}>
+            <GraphQLClientProvider url={Environment.API_URL}>
               <AuthProvider>
                 <AppThemeProvider>
                   <ConfirmationModalProvider>
@@ -63,7 +63,7 @@ const Host: FC = () => (
                 </AppThemeProvider>
               </AuthProvider>
               <ReactQueryDevtools initialIsOpen />
-            </OmSupplyApiProvider>
+            </GraphQLClientProvider>
           </QueryClientProvider>
         </ErrorBoundary>
       </React.Suspense>

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -12,7 +12,7 @@ import {
   RouteBuilder,
   ErrorBoundary,
   GenericErrorFallback,
-  GraphQLClientProvider,
+  GqlProvider,
   IntlProvider,
   RandomLoader,
   ConfirmationModalProvider,
@@ -38,7 +38,7 @@ const Host: FC = () => (
       <React.Suspense fallback={<RandomLoader />}>
         <ErrorBoundary Fallback={GenericErrorFallback}>
           <QueryClientProvider client={queryClient}>
-            <GraphQLClientProvider url={Environment.API_URL}>
+            <GqlProvider url={Environment.API_URL}>
               <AuthProvider>
                 <AppThemeProvider>
                   <ConfirmationModalProvider>
@@ -63,7 +63,7 @@ const Host: FC = () => (
                 </AppThemeProvider>
               </AuthProvider>
               <ReactQueryDevtools initialIsOpen />
-            </GraphQLClientProvider>
+            </GqlProvider>
           </QueryClientProvider>
         </ErrorBoundary>
       </React.Suspense>

--- a/packages/inventory/src/Stocktake/api/hooks.ts
+++ b/packages/inventory/src/Stocktake/api/hooks.ts
@@ -7,7 +7,7 @@ import {
   useQuerySelector,
   useQueryClient,
   useParams,
-  useGraphQLClient,
+  useGql,
   useMutation,
   UseQueryResult,
   useQuery,
@@ -39,7 +39,7 @@ export const useStocktakeApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const { storeId } = useAuthContext();
   const queries = getStocktakeQueries(getSdk(client), storeId);
   return { ...queries, storeId, keys };

--- a/packages/inventory/src/Stocktake/api/hooks.ts
+++ b/packages/inventory/src/Stocktake/api/hooks.ts
@@ -7,7 +7,7 @@ import {
   useQuerySelector,
   useQueryClient,
   useParams,
-  useOmSupplyApi,
+  useGraphQLClient,
   useMutation,
   UseQueryResult,
   useQuery,
@@ -39,7 +39,7 @@ export const useStocktakeApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const { storeId } = useAuthContext();
   const queries = getStocktakeQueries(getSdk(client), storeId);
   return { ...queries, storeId, keys };

--- a/packages/invoices/src/InboundShipment/api/hooks.ts
+++ b/packages/invoices/src/InboundShipment/api/hooks.ts
@@ -14,7 +14,7 @@ import {
   useParams,
   useQuery,
   useAuthContext,
-  useGraphQLClient,
+  useGql,
   useMutation,
   useFieldsSelector,
   InvoiceNodeStatus,
@@ -39,7 +39,7 @@ export const useInboundApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const queries = getInboundQueries(getSdk(client), storeId);
   return { ...queries, storeId, keys };
 };

--- a/packages/invoices/src/InboundShipment/api/hooks.ts
+++ b/packages/invoices/src/InboundShipment/api/hooks.ts
@@ -14,7 +14,7 @@ import {
   useParams,
   useQuery,
   useAuthContext,
-  useOmSupplyApi,
+  useGraphQLClient,
   useMutation,
   useFieldsSelector,
   InvoiceNodeStatus,
@@ -39,7 +39,7 @@ export const useInboundApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const queries = getInboundQueries(getSdk(client), storeId);
   return { ...queries, storeId, keys };
 };

--- a/packages/invoices/src/OutboundShipment/api/hooks.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks.ts
@@ -9,7 +9,7 @@ import {
   useQueryClient,
   useQuerySelector,
   useParams,
-  useOmSupplyApi,
+  useGraphQLClient,
   UseQueryResult,
   useQuery,
   FieldSelectorControl,
@@ -41,7 +41,7 @@ export const useOutboundApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const sdk = getSdk(client);
   const { storeId } = useAuthContext();
   const queries = getOutboundQueries(sdk, storeId);

--- a/packages/invoices/src/OutboundShipment/api/hooks.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks.ts
@@ -9,7 +9,7 @@ import {
   useQueryClient,
   useQuerySelector,
   useParams,
-  useGraphQLClient,
+  useGql,
   UseQueryResult,
   useQuery,
   FieldSelectorControl,
@@ -41,7 +41,7 @@ export const useOutboundApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const sdk = getSdk(client);
   const { storeId } = useAuthContext();
   const queries = getOutboundQueries(sdk, storeId);

--- a/packages/requisitions/src/RequestRequisition/api/hooks.ts
+++ b/packages/requisitions/src/RequestRequisition/api/hooks.ts
@@ -10,7 +10,7 @@ import {
   useNavigate,
   useMutation,
   useParams,
-  useOmSupplyApi,
+  useGraphQLClient,
   UseQueryResult,
   useQuery,
   FieldSelectorControl,
@@ -47,7 +47,7 @@ export const useRequestApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const { storeId } = useAuthContext();
   const queries = getRequestQueries(getSdk(client), storeId);
   return { ...queries, storeId, keys };

--- a/packages/requisitions/src/RequestRequisition/api/hooks.ts
+++ b/packages/requisitions/src/RequestRequisition/api/hooks.ts
@@ -10,7 +10,7 @@ import {
   useNavigate,
   useMutation,
   useParams,
-  useGraphQLClient,
+  useGql,
   UseQueryResult,
   useQuery,
   FieldSelectorControl,
@@ -47,7 +47,7 @@ export const useRequestApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const { storeId } = useAuthContext();
   const queries = getRequestQueries(getSdk(client), storeId);
   return { ...queries, storeId, keys };

--- a/packages/requisitions/src/ResponseRequisition/api/hooks.ts
+++ b/packages/requisitions/src/ResponseRequisition/api/hooks.ts
@@ -6,7 +6,7 @@ import {
   useQueryClient,
   useAuthContext,
   useParams,
-  useGraphQLClient,
+  useGql,
   UseQueryResult,
   useQuery,
   FieldSelectorControl,
@@ -36,7 +36,7 @@ export const useResponseApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const sdk = getSdk(client);
   const { storeId } = useAuthContext();
   const queries = getResponseQueries(sdk, storeId);

--- a/packages/requisitions/src/ResponseRequisition/api/hooks.ts
+++ b/packages/requisitions/src/ResponseRequisition/api/hooks.ts
@@ -6,7 +6,7 @@ import {
   useQueryClient,
   useAuthContext,
   useParams,
-  useOmSupplyApi,
+  useGraphQLClient,
   UseQueryResult,
   useQuery,
   FieldSelectorControl,
@@ -36,7 +36,7 @@ export const useResponseApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const sdk = getSdk(client);
   const { storeId } = useAuthContext();
   const queries = getResponseQueries(sdk, storeId);

--- a/packages/system/src/Item/api/hooks/useItemApi/useItemApi.ts
+++ b/packages/system/src/Item/api/hooks/useItemApi/useItemApi.ts
@@ -1,9 +1,9 @@
 import { getItemQueries, ListParams } from './../../api';
-import { useAuthContext, useGraphQLClient } from '@openmsupply-client/common';
+import { useAuthContext, useGql } from '@openmsupply-client/common';
 import { getSdk } from '../../operations.generated';
 
 export const useItemApi = () => {
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const { storeId } = useAuthContext();
 
   const keys = {

--- a/packages/system/src/Item/api/hooks/useItemApi/useItemApi.ts
+++ b/packages/system/src/Item/api/hooks/useItemApi/useItemApi.ts
@@ -1,9 +1,9 @@
 import { getItemQueries, ListParams } from './../../api';
-import { useAuthContext, useOmSupplyApi } from '@openmsupply-client/common';
+import { useAuthContext, useGraphQLClient } from '@openmsupply-client/common';
 import { getSdk } from '../../operations.generated';
 
 export const useItemApi = () => {
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const { storeId } = useAuthContext();
 
   const keys = {

--- a/packages/system/src/Location/api/hooks.ts
+++ b/packages/system/src/Location/api/hooks.ts
@@ -1,6 +1,6 @@
 import { useQueryClient, useMutation } from 'react-query';
 import {
-  useOmSupplyApi,
+  useGraphQLClient,
   useAuthContext,
   useQueryParams,
   useQuery,
@@ -16,7 +16,7 @@ export const useLocationApi = () => {
     list: () => [...keys.base(), 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const sdk = getSdk(client);
   const queries = getLocationQueries(sdk, storeId);
   return { ...queries, storeId, keys };

--- a/packages/system/src/Location/api/hooks.ts
+++ b/packages/system/src/Location/api/hooks.ts
@@ -1,6 +1,6 @@
 import { useQueryClient, useMutation } from 'react-query';
 import {
-  useGraphQLClient,
+  useGql,
   useAuthContext,
   useQueryParams,
   useQuery,
@@ -16,7 +16,7 @@ export const useLocationApi = () => {
     list: () => [...keys.base(), 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const sdk = getSdk(client);
   const queries = getLocationQueries(sdk, storeId);
   return { ...queries, storeId, keys };

--- a/packages/system/src/MasterList/api/hooks.ts
+++ b/packages/system/src/MasterList/api/hooks.ts
@@ -1,6 +1,6 @@
 import {
   useQuery,
-  useOmSupplyApi,
+  useGraphQLClient,
   useAuthContext,
   useQueryParams,
 } from '@openmsupply-client/common';
@@ -15,7 +15,7 @@ export const useMasterListApi = () => {
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const sdk = getSdk(client);
   const queries = getMasterListQueries(sdk, storeId);
 

--- a/packages/system/src/MasterList/api/hooks.ts
+++ b/packages/system/src/MasterList/api/hooks.ts
@@ -1,6 +1,6 @@
 import {
   useQuery,
-  useGraphQLClient,
+  useGql,
   useAuthContext,
   useQueryParams,
 } from '@openmsupply-client/common';
@@ -15,7 +15,7 @@ export const useMasterListApi = () => {
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const sdk = getSdk(client);
   const queries = getMasterListQueries(sdk, storeId);
 

--- a/packages/system/src/Name/api/hooks.ts
+++ b/packages/system/src/Name/api/hooks.ts
@@ -1,6 +1,6 @@
 import {
   useQueryParams,
-  useOmSupplyApi,
+  useGraphQLClient,
   useAuthContext,
   useQuery,
 } from '@openmsupply-client/common';
@@ -15,7 +15,7 @@ const useNamesApi = () => {
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const queries = getNameQueries(getSdk(client), storeId);
 
   return { ...queries, storeId, keys };

--- a/packages/system/src/Name/api/hooks.ts
+++ b/packages/system/src/Name/api/hooks.ts
@@ -1,6 +1,6 @@
 import {
   useQueryParams,
-  useGraphQLClient,
+  useGql,
   useAuthContext,
   useQuery,
 } from '@openmsupply-client/common';
@@ -15,7 +15,7 @@ const useNamesApi = () => {
     list: () => [...keys.base(), storeId, 'list'] as const,
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const queries = getNameQueries(getSdk(client), storeId);
 
   return { ...queries, storeId, keys };

--- a/packages/system/src/Stock/api/hooks.ts
+++ b/packages/system/src/Stock/api/hooks.ts
@@ -1,6 +1,6 @@
 import {
   useAuthContext,
-  useGraphQLClient,
+  useGql,
   useQuery,
   useQueryParams,
 } from '@openmsupply-client/common';
@@ -9,7 +9,7 @@ import { getSdk } from './operations.generated';
 import { getStockQueries } from './api';
 
 export const useStockApi = () => {
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const { storeId } = useAuthContext();
   const queries = getStockQueries(getSdk(client), storeId);
   return { ...queries, storeId };

--- a/packages/system/src/Stock/api/hooks.ts
+++ b/packages/system/src/Stock/api/hooks.ts
@@ -1,6 +1,6 @@
 import {
   useAuthContext,
-  useOmSupplyApi,
+  useGraphQLClient,
   useQuery,
   useQueryParams,
 } from '@openmsupply-client/common';
@@ -9,7 +9,7 @@ import { getSdk } from './operations.generated';
 import { getStockQueries } from './api';
 
 export const useStockApi = () => {
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const { storeId } = useAuthContext();
   const queries = getStockQueries(getSdk(client), storeId);
   return { ...queries, storeId };

--- a/packages/system/src/Store/api/hooks.ts
+++ b/packages/system/src/Store/api/hooks.ts
@@ -1,8 +1,4 @@
-import {
-  useGraphQLClient,
-  useQueryParams,
-  useQuery,
-} from '@openmsupply-client/common';
+import { useGql, useQueryParams, useQuery } from '@openmsupply-client/common';
 import { getSdk } from './operations.generated';
 import { getStoreQueries, ListParams } from './api';
 
@@ -14,7 +10,7 @@ const useStoreApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useGraphQLClient();
+  const { client } = useGql();
   const sdk = getSdk(client);
   const queries = getStoreQueries(sdk);
   return { ...queries, keys };

--- a/packages/system/src/Store/api/hooks.ts
+++ b/packages/system/src/Store/api/hooks.ts
@@ -1,5 +1,5 @@
 import {
-  useOmSupplyApi,
+  useGraphQLClient,
   useQueryParams,
   useQuery,
 } from '@openmsupply-client/common';
@@ -14,7 +14,7 @@ const useStoreApi = () => {
     paramList: (params: ListParams) => [...keys.list(), params] as const,
   };
 
-  const { client } = useOmSupplyApi();
+  const { client } = useGraphQLClient();
   const sdk = getSdk(client);
   const queries = getStoreQueries(sdk);
   return { ...queries, keys };


### PR DESCRIPTION
Fixes #976 

- Renamed `OmSupplyApi` -> `GraphQLClient`


Realised there were other options 😭  Think I prefer `GqlClient` or `Gql` 😁 
`useGqlClient` / `useGql` / `GqlProvider` / `GqlClientProvider`

What about you?
