### PR TITLE
Add adjustments to react-query props

### DIFF
--- a/packages/common/src/api/hooks/useQuerySelector/README.md
+++ b/packages/common/src/api/hooks/useQuerySelector/README.md
@@ -12,6 +12,7 @@ The intention is to simplify making selector hooks for selecting subsets of data
 
 - Memoise the selector function to ensure a stable reference which won't need to re-run until the data has changed.
 - Rather than using a useQuery to request some entity and passing the entity down, it is often more performant to use multiple selector hooks closer to where the data is used.
+- Make sure to take note of the current react-query options. This hook will not refetch when mounting and but also has not adjusted the cache time.
 
 ### Future considerations
 

--- a/packages/common/src/api/hooks/useQuerySelector/useQuerySelector.ts
+++ b/packages/common/src/api/hooks/useQuerySelector/useQuerySelector.ts
@@ -5,5 +5,5 @@ export const useQuerySelector = <T, ReturnType>(
   queryFn: () => Promise<T>,
   select: (data: T) => ReturnType
 ): UseQueryResult<ReturnType, unknown> => {
-  return useQuery(queryKey, queryFn, { select });
+  return useQuery(queryKey, queryFn, { select, refetchOnMount: false });
 };

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -18,6 +18,7 @@ import {
   ConfirmationModalProvider,
   AuthProvider,
   AlertModalProvider,
+  isProduction,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Login, Viewport } from './components';
@@ -26,8 +27,16 @@ import { Site } from './Site';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
-      retry: false,
+      // These are disabled during development because they're
+      // annoying to have constantly refetching.
+      refetchOnWindowFocus: isProduction(),
+      retry: isProduction(),
+      // This is the default in v4 which is currently in alpha as it is
+      // what most users think the default is.
+      // This will subscribe components of a query only to the data they
+      // destructure. I.e. if the component does not read the isLoading
+      // field, the component will not re-render when the state changes.
+      notifyOnChangeProps: 'tracked',
     },
   },
 });

--- a/packages/inventory/src/Stocktake/api/hooks.ts
+++ b/packages/inventory/src/Stocktake/api/hooks.ts
@@ -53,8 +53,15 @@ const useStocktakeNumber = () => {
 export const useStocktake = (): UseQueryResult<StocktakeFragment> => {
   const stocktakeNumber = useStocktakeNumber();
   const api = useStocktakeApi();
-  return useQuery(api.keys.detail(stocktakeNumber), () =>
-    api.get.byNumber(stocktakeNumber)
+  return useQuery(
+    api.keys.detail(stocktakeNumber),
+    () => api.get.byNumber(stocktakeNumber),
+    // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
   );
 };
 

--- a/packages/invoices/src/InboundShipment/api/hooks.ts
+++ b/packages/invoices/src/InboundShipment/api/hooks.ts
@@ -55,8 +55,15 @@ const useInboundNumber = () => {
 export const useInbound = () => {
   const invoiceNumber = useInboundNumber();
   const api = useInboundApi();
-  return useQuery(api.keys.detail(invoiceNumber), () =>
-    api.get.byNumber(invoiceNumber)
+  return useQuery(
+    api.keys.detail(invoiceNumber),
+    () => api.get.byNumber(invoiceNumber),
+    // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
   );
 };
 

--- a/packages/invoices/src/OutboundShipment/api/hooks.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks.ts
@@ -77,8 +77,15 @@ export const useOutbound = (): UseQueryResult<OutboundFragment> => {
   const outboundNumber = useOutboundNumber();
   const api = useOutboundApi();
 
-  return useQuery(api.keys.detail(outboundNumber), () =>
-    api.get.byNumber(outboundNumber)
+  return useQuery(
+    api.keys.detail(outboundNumber),
+    () => api.get.byNumber(outboundNumber),
+    // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
   );
 };
 

--- a/packages/requisitions/src/RequestRequisition/api/hooks.ts
+++ b/packages/requisitions/src/RequestRequisition/api/hooks.ts
@@ -98,8 +98,15 @@ export const useUpdateRequest = () => {
 export const useRequest = (): UseQueryResult<RequestFragment> => {
   const requestNumber = useRequestNumber();
   const api = useRequestApi();
-  return useQuery(api.keys.detail(requestNumber), () =>
-    api.get.byNumber(requestNumber)
+  return useQuery(
+    api.keys.detail(requestNumber),
+    () => api.get.byNumber(requestNumber),
+    // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
   );
 };
 

--- a/packages/requisitions/src/ResponseRequisition/api/hooks.ts
+++ b/packages/requisitions/src/ResponseRequisition/api/hooks.ts
@@ -80,8 +80,15 @@ export const useResponses = () => {
 export const useResponse = (): UseQueryResult<ResponseFragment> => {
   const responseNumber = useResponseNumber();
   const api = useResponseApi();
-  return useQuery(api.keys.detail(responseNumber), () =>
-    api.get.byNumber(responseNumber)
+  return useQuery(
+    api.keys.detail(responseNumber),
+    () => api.get.byNumber(responseNumber),
+    // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
   );
 };
 

--- a/packages/system/src/MasterList/api/hooks.ts
+++ b/packages/system/src/MasterList/api/hooks.ts
@@ -63,8 +63,15 @@ const useMasterListId = () => {
 export const useMasterList = (): UseQueryResult<MasterListFragment> => {
   const masterListId = useMasterListId();
   const api = useMasterListApi();
-  return useQuery(api.keys.detail(masterListId), () =>
-    api.get.byId(masterListId)
+  return useQuery(
+    api.keys.detail(masterListId),
+    () => api.get.byId(masterListId),
+    // Don't refetch when the edit modal opens, for example. But, don't cache data when this query
+    // is inactive. For example, when navigating away from the page and back again, refetch.
+    {
+      refetchOnMount: false,
+      cacheTime: 0,
+    }
   );
 };
 


### PR DESCRIPTION
Fixes #1001 

- Adds a default option to the react query client for `notifyOnChangeProps`
- Also adds some props to the`useDetailDocument` type hooks