### PR TITLE
#1014 filter master lists

### DIFF
--- a/packages/system/src/MasterList/api/api.ts
+++ b/packages/system/src/MasterList/api/api.ts
@@ -30,7 +30,7 @@ export const getMasterListQueries = (sdk: Sdk, storeId: string) => ({
         offset,
         key,
         desc,
-        filter: filterBy,
+        filter: { ...filterBy, existsForStoreId: { equalTo: storeId } },
         storeId,
       });
       return result.masterLists;


### PR DESCRIPTION
Fixes #1014 

- Pretty simple update. If adding an outbound add from master list mutation, would want to use a filter of both `existsForName` (with the customer nameID) and `existsForStore`