### PR TITLE
Tooltips on headers

### DIFF
--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -50,12 +50,30 @@ export const HeaderCell = <T extends RecordWithId>({
     150
   );
 
-  const tooltip = (
+  const showTooltip = !!description || sortable;
+  const tooltip = showTooltip ? (
     <>
       {!!description && <div>{t(description)}</div>}
       {sortable && <div>{t('label.click-to-sort')}</div>}
     </>
+  ) : (
+    ''
   );
+  const HeaderLabel = sortable ? (
+    <TableSortLabel
+      hideSortIcon={false}
+      active={isSorted}
+      direction={direction}
+      IconComponent={SortDescIcon}
+    >
+      <Header column={column} />
+    </TableSortLabel>
+  ) : (
+    <div>
+      <Header column={column} />
+    </div>
+  );
+
   return (
     <TableCell
       role="columnheader"
@@ -82,18 +100,7 @@ export const HeaderCell = <T extends RecordWithId>({
         placement="bottom"
         style={{ whiteSpace: 'pre-line' }}
       >
-        {sortable ? (
-          <TableSortLabel
-            hideSortIcon={false}
-            active={isSorted}
-            direction={direction}
-            IconComponent={SortDescIcon}
-          >
-            <Header column={column} />
-          </TableSortLabel>
-        ) : (
-          <Header column={column} />
-        )}
+        {HeaderLabel}
       </Tooltip>
     </TableCell>
   );

--- a/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -33,7 +33,6 @@ export const useStocktakeColumns = ({
       [
         'itemCode',
         {
-          sortable: false,
           getSortValue: row => {
             return row.item?.code ?? '';
           },

--- a/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
+++ b/packages/inventory/src/Stocktake/DetailView/ContentArea/columns.ts
@@ -33,6 +33,7 @@ export const useStocktakeColumns = ({
       [
         'itemCode',
         {
+          sortable: false,
           getSortValue: row => {
             return row.item?.code ?? '';
           },


### PR DESCRIPTION
Fixes #1051 
Don't show a tooltip if there is nothing to say; and forward the ref to the non-sortable header if there is a description.