### PR TITLE
#1074 mSupply man hover background

### DIFF
--- a/packages/common/src/ui/components/buttons/IconButton/IconButton.tsx
+++ b/packages/common/src/ui/components/buttons/IconButton/IconButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconButton as MuiIconButton, Tooltip } from '@mui/material';
+import { IconButton as MuiIconButton, SxProps, Tooltip } from '@mui/material';
 
 interface ButtonProps {
   disabled?: boolean;
@@ -8,6 +8,7 @@ interface ButtonProps {
   label: string;
   width?: string;
   height?: string;
+  sx?: SxProps;
 }
 
 export const IconButton: React.FC<ButtonProps> = ({
@@ -17,10 +18,11 @@ export const IconButton: React.FC<ButtonProps> = ({
   label,
   width,
   height,
+  sx,
 }) => (
   <Tooltip title={disabled ? '' : label}>
     <MuiIconButton
-      sx={{ width, height }}
+      sx={{ width, height, ...sx }}
       disabled={disabled}
       onClick={onClick}
       aria-label={label}

--- a/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -168,6 +168,7 @@ export const AppDrawer: React.FC = () => {
           )}
           onClick={drawer.toggle}
           icon={<AppDrawerIcon />}
+          sx={{ '&:hover': { backgroundColor: 'inherit' } }}
         />
       </ToolbarIconContainer>
       <UpperListContainer onMouseEnter={onHoverOver} onMouseLeave={onHoverOut}>


### PR DESCRIPTION
Fix #1074 

Was a tiny fix -- see what you think. (Seems useful to have the full `sx` props passed down from the `IconButton` anyway.)