### PR TITLE
authentication check

### DIFF
--- a/packages/common/src/api/GqlContext.tsx
+++ b/packages/common/src/api/GqlContext.tsx
@@ -1,14 +1,83 @@
 import React, { FC, useMemo, useEffect, useState, useCallback } from 'react';
 import { createContext } from 'react';
-import { GraphQLClient } from 'graphql-request';
+import {
+  BatchRequestDocument,
+  GraphQLClient,
+  RequestDocument,
+  Variables,
+} from 'graphql-request';
+import { AuthError } from '../authentication/AuthContext';
+import { LocalStorage } from '../localStorage';
 
-export const createGql = (url: string): { client: GraphQLClient } => {
-  const client = new GraphQLClient(url, { credentials: 'include' });
+class GQLClient extends GraphQLClient {
+  private client: GraphQLClient;
+  private emptyData: object;
+
+  constructor(url: string, options?: RequestInit) {
+    super(url, options);
+    this.client = new GraphQLClient(url, options);
+    this.emptyData = {};
+  }
+
+  public rawRequest<T, V = Variables>(
+    query: string,
+    variables?: V,
+    requestHeaders?: RequestInit['headers']
+  ): Promise<{
+    data: T;
+    extensions?: any;
+    headers: Headers;
+    status: number;
+  }> {
+    return this.client.rawRequest(query, variables, requestHeaders);
+  }
+
+  public request<T, V = Variables>(
+    document: RequestDocument,
+    variables?: V,
+    requestHeaders?: RequestInit['headers']
+  ): Promise<T> {
+    const response = this.client.request(document, variables, requestHeaders);
+    // returning an empty object in order to give the caller a stable reference
+    // without it, the page will re-render continuously
+    return response.then(
+      data => data ?? this.emptyData,
+      ({ response }) => {
+        if (response && response.errors) {
+          if (
+            response.errors.some(
+              ({ message }: { message?: string }) =>
+                message === 'Unauthenticated'
+            )
+          ) {
+            LocalStorage.setItem('/auth/error', AuthError.Unauthenticated);
+          }
+        }
+        return this.emptyData;
+      }
+    );
+  }
+  public batchRequests<T, V = Variables>(
+    documents: BatchRequestDocument<V>[],
+    requestHeaders?: RequestInit['headers']
+  ): Promise<T> {
+    return this.client.batchRequests(documents, requestHeaders);
+  }
+  public setHeaders = (headers: RequestInit['headers']): GraphQLClient =>
+    this.client.setHeaders(headers);
+  public setHeader = (key: string, value: string): GraphQLClient =>
+    this.client.setHeader(key, value);
+  public setEndpoint = (value: string): GraphQLClient =>
+    this.client.setEndpoint(value);
+}
+
+export const createGql = (url: string): { client: GQLClient } => {
+  const client = new GQLClient(url, { credentials: 'include' });
   return { client };
 };
 
 interface GqlControl {
-  client: GraphQLClient;
+  client: GQLClient;
   setHeader: (header: string, value: string) => void;
   setUrl: (url: string) => void;
 }
@@ -27,7 +96,7 @@ interface ApiProviderProps {
 
 export const GqlProvider: FC<ApiProviderProps> = ({ url, children }) => {
   const [{ client }, setApi] = useState<{
-    client: GraphQLClient;
+    client: GQLClient;
   }>(() => createGql(url));
 
   const setUrl = useCallback(

--- a/packages/common/src/api/GqlContext.tsx
+++ b/packages/common/src/api/GqlContext.tsx
@@ -47,7 +47,7 @@ class GQLClient extends GraphQLClient {
           if (
             response.errors.some(
               ({ message }: { message?: string }) =>
-                message === 'Unauthenticated'
+                message === AuthError.Unauthenticated
             )
           ) {
             LocalStorage.setItem('/auth/error', AuthError.Unauthenticated);

--- a/packages/common/src/intl/locales/en/app.json
+++ b/packages/common/src/intl/locales/en/app.json
@@ -1,7 +1,8 @@
 {
   "admin": "Admin",
   "auth.logged-out-message": "You have been logged out of your session due to inactivity. Click OK to return to the login screen.",
-  "auth.logged-out-title": "Session Timed Out",
+  "auth.alert-title": "Session Timed Out",
+  "auth.permission-denied": "Permission denied",
   "button.close-the-menu": "Close the menu",
   "button.go-back": "Go back",
   "button.open-the-menu": "Open the menu",

--- a/packages/common/src/localStorage/keys.ts
+++ b/packages/common/src/localStorage/keys.ts
@@ -1,5 +1,6 @@
 import { SupportedLocales } from '@common/intl';
 import { ThemeOptions } from '@mui/material';
+import { AuthError } from '../authentication/AuthContext';
 
 export type GroupByItem = {
   outboundShipment?: boolean;
@@ -18,6 +19,7 @@ export type LocalStorageRecord = {
   '/theme/custom': ThemeOptions;
   '/theme/logo': string;
   '/mru/credentials': AuthenticationCredentials;
+  '/auth/error': AuthError | undefined;
 };
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -23,7 +23,7 @@ import {
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Login, Viewport } from './components';
 import { Site } from './Site';
-import { LoggedOutAlert } from './components/LoggedOutAlert';
+import { AuthenticationAlert } from './components/AuthenticationAlert';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -54,7 +54,7 @@ const Host: FC = () => (
                   <ConfirmationModalProvider>
                     <AlertModalProvider>
                       <BrowserRouter>
-                        <LoggedOutAlert />
+                        <AuthenticationAlert />
                         <Viewport>
                           <Box display="flex" style={{ minHeight: '100%' }}>
                             <Routes>

--- a/packages/host/src/components/AuthenticationAlert.tsx
+++ b/packages/host/src/components/AuthenticationAlert.tsx
@@ -2,26 +2,27 @@ import { useToggle } from '@common/hooks';
 import { AppRoute } from 'packages/config/src';
 import React, { useEffect } from 'react';
 import {
+  AuthError,
   matchPath,
   RouteBuilder,
-  useAuthContext,
+  useLocalStorage,
   useLocation,
   useNavigate,
 } from '@openmsupply-client/common';
 import { AlertModal } from '@common/components';
 import { useTranslation } from '@common/intl';
 
-export const LoggedOutAlert = () => {
+export const AuthenticationAlert = () => {
   const navigate = useNavigate();
   const { isOn, toggleOff, toggleOn } = useToggle();
   const t = useTranslation('app');
   const location = useLocation();
-  const { token } = useAuthContext();
+  const [error] = useLocalStorage('/auth/error');
 
   useEffect(() => {
-    if (!token) toggleOn();
+    if (!!error) toggleOn();
     return () => toggleOff();
-  }, [token]);
+  }, [error]);
 
   // no need to alert if you are on the login screen!
   if (
@@ -32,12 +33,16 @@ export const LoggedOutAlert = () => {
   ) {
     return null;
   }
+  const message =
+    error === AuthError.Unauthenticated
+      ? t('auth.logged-out-message')
+      : t('auth.permission-denied');
 
   return (
     <AlertModal
       open={isOn}
-      title={t('auth.logged-out-title')}
-      message={t('auth.logged-out-message')}
+      title={t('auth.alert-title')}
+      message={message}
       onOk={() => {
         navigate(AppRoute.Login);
       }}


### PR DESCRIPTION
Fixes #1096, #1101 

Yes, that's right! two-for-one time! 😁 

These two are somewhat interrelated, so I've combined them in one PR. uh, sorry.

Few things
- Checking the response of every gql request and if it has the 'unauthenticated' error, then pop that into local storage. Ideally I would have updated the `AuthContext` directly but there is a problem of dependency. The AuthContext uses a gql request so has to sit under the gql provider. Also slightly annoying using the AuthContext without referencing hooks directly.. so it was good to sidestep that
- The `LoggedOutAlert` is now more generic and so has been renamed
- The `AuthContext` is running an interval, checking the cookie and if it has expired, or no token - sets an `AuthError`
- The `AuthenticationAlert` is using the `AuthError` from `AuthContext` and will re-render if that is updated by the interval in `AuthContext`