### PR TITLE
#1097 Table column widths

### DIFF
--- a/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
+++ b/packages/common/src/ui/components/inputs/CurrencyInput/CurrencyInput.tsx
@@ -7,7 +7,7 @@ import { useCurrency } from '@common/intl';
 
 interface CurrencyInputProps extends RCInputProps {
   onChangeNumber: (value: number) => void;
-  maxWidth?: number;
+  maxWidth?: number | string;
 }
 
 // TODO: It would be nice if we were to just use the BasicTextInput or

--- a/packages/common/src/ui/layout/tables/DataTable.tsx
+++ b/packages/common/src/ui/layout/tables/DataTable.tsx
@@ -114,9 +114,6 @@ export const DataTableComponent = <T extends RecordWithId>({
         <TableHead
           sx={{
             backgroundColor: 'background.white',
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
             position: 'sticky',
             top: 0,
             zIndex: 'tableHeader',
@@ -133,7 +130,7 @@ export const DataTableComponent = <T extends RecordWithId>({
             ))}
           </HeaderRow>
         </TableHead>
-        <TableBody sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <TableBody>
           {data.map((row, idx) => (
             <DataRow
               key={row.id}

--- a/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
+++ b/packages/common/src/ui/layout/tables/columns/NameAndColorColumn.tsx
@@ -13,7 +13,6 @@ export const getNameAndColorColumn = <
   T extends RecordWithIdWithRequiredFields
 >(): ColumnDefinition<T> => ({
   label: 'label.name',
-  width: 350,
   setter: () => {
     if (process.env['NODE_ENV']) {
       throw new Error(

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -74,9 +74,9 @@ export interface Column<T extends RecordWithId> {
   onChangeSortBy?: (column: Column<T>) => void;
   sortBy?: SortBy<T>;
 
-  width?: number;
-  minWidth?: number;
-  maxWidth?: number;
+  width?: number | string;
+  minWidth?: number | string;
+  maxWidth?: number | string;
   maxLength?: number;
   backgroundColor?: string;
 

--- a/packages/common/src/ui/layout/tables/columns/types.ts
+++ b/packages/common/src/ui/layout/tables/columns/types.ts
@@ -74,8 +74,8 @@ export interface Column<T extends RecordWithId> {
   onChangeSortBy?: (column: Column<T>) => void;
   sortBy?: SortBy<T>;
 
-  width: number;
-  minWidth: number;
+  width?: number;
+  minWidth?: number;
   maxWidth?: number;
   maxLength?: number;
   backgroundColor?: string;

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -58,15 +58,12 @@ export const DataRow = <T extends RecordWithId>({
             },
             color: isDisabled ? 'gray.main' : 'black',
             backgroundColor: isFocused ? 'background.menu' : null,
-            // minWidth,
             alignItems: 'center',
             height: '40px',
             maxHeight: '45px',
             boxShadow: dense
               ? 'none'
               : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
-            // display: 'flex',
-            // flex: '1 0 auto',
             ...rowStyle,
           }}
           onClick={onRowClick}
@@ -79,7 +76,6 @@ export const DataRow = <T extends RecordWithId>({
                 align={column.align}
                 sx={{
                   borderBottom: 'none',
-                  // justifyContent: 'flex-end',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
                   paddingLeft: paddingX,
@@ -87,7 +83,6 @@ export const DataRow = <T extends RecordWithId>({
                   paddingTop: paddingY,
                   paddingBottom: paddingY,
                   ...(hasOnClick && { cursor: 'pointer' }),
-                  // flex: `${column.width} 0 auto`,
                   minWidth: column.minWidth,
                   maxWidth: column.maxWidth,
                   width: column.width,

--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -41,9 +41,8 @@ export const DataRow = <T extends RecordWithId>({
   const { rowStyle } = useRowStyle(rowData.id);
 
   const onRowClick = () => onClick && onClick(rowData);
-  const minWidth = columns.reduce((sum, { minWidth }) => sum + minWidth, 0);
   const paddingX = dense ? '12px' : '16px';
-  const paddingY = dense ? '4px' : undefined;
+  const paddingY = dense ? '4px' : 0;
 
   useEffect(() => {
     if (isFocused) onRowClick();
@@ -59,15 +58,15 @@ export const DataRow = <T extends RecordWithId>({
             },
             color: isDisabled ? 'gray.main' : 'black',
             backgroundColor: isFocused ? 'background.menu' : null,
-            minWidth,
+            // minWidth,
             alignItems: 'center',
             height: '40px',
             maxHeight: '45px',
             boxShadow: dense
               ? 'none'
               : 'inset 0 0.5px 0 0 rgba(143, 144, 166, 0.5)',
-            display: 'flex',
-            flex: '1 0 auto',
+            // display: 'flex',
+            // flex: '1 0 auto',
             ...rowStyle,
           }}
           onClick={onRowClick}
@@ -80,7 +79,7 @@ export const DataRow = <T extends RecordWithId>({
                 align={column.align}
                 sx={{
                   borderBottom: 'none',
-                  justifyContent: 'flex-end',
+                  // justifyContent: 'flex-end',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
                   paddingLeft: paddingX,
@@ -88,7 +87,7 @@ export const DataRow = <T extends RecordWithId>({
                   paddingTop: paddingY,
                   paddingBottom: paddingY,
                   ...(hasOnClick && { cursor: 'pointer' }),
-                  flex: `${column.width} 0 auto`,
+                  // flex: `${column.width} 0 auto`,
                   minWidth: column.minWidth,
                   maxWidth: column.maxWidth,
                   width: column.width,
@@ -113,8 +112,8 @@ export const DataRow = <T extends RecordWithId>({
           })}
         </TableRow>
       </Fade>
-      <tr style={{ display: 'flex' }}>
-        <td style={{ display: 'flex', flex: 1 }}>
+      <tr>
+        <td colSpan={columns.length}>
           <Collapse
             sx={{
               flex: 1,

--- a/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
+++ b/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
@@ -27,6 +27,7 @@ export const MiniTable = <T extends RecordWithId>({
           backgroundColor: theme => alpha(theme.palette.gray.light, 0.2),
           border: theme => `1px solid ${alpha(theme.palette.gray.light, 0.2)}`,
           '& .MuiTableHead-root': { borderRadius: '16px 16px 0 0' },
+          overflow: 'hidden',
         }}
       >
         <DataTable dense columns={columns} data={rows} />

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -10,10 +10,7 @@ export const HeaderRow: FC<{ dense?: boolean }> = ({ dense, ...props }) => (
   <TableRow
     {...props}
     sx={{
-      // display: 'flex',
-      // flex: '1 0 auto',
       height: !!dense ? '40px' : '60px',
-      alignItems: 'center',
     }}
   />
 );

--- a/packages/common/src/ui/layout/tables/components/Header/Header.tsx
+++ b/packages/common/src/ui/layout/tables/components/Header/Header.tsx
@@ -10,8 +10,8 @@ export const HeaderRow: FC<{ dense?: boolean }> = ({ dense, ...props }) => (
   <TableRow
     {...props}
     sx={{
-      display: 'flex',
-      flex: '1 0 auto',
+      // display: 'flex',
+      // flex: '1 0 auto',
       height: !!dense ? '40px' : '60px',
       alignItems: 'center',
     }}
@@ -88,7 +88,6 @@ export const HeaderCell = <T extends RecordWithId>({
         width,
         minWidth,
         maxWidth,
-        flex: `${width} 0 auto`,
         fontWeight: 'bold',
         fontSize: dense ? '12px' : '14px',
       }}

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -13,26 +13,26 @@ import { DateUtils } from '@common/utils';
 import { SortBy } from '@common/hooks';
 import { ColumnDefinitionSetBuilder, ColumnKey } from '../../utils';
 
-const getColumnWidths = <T extends RecordWithId>(
-  column: ColumnDefinition<T>
-) => {
-  const getDefaultWidth = () => {
-    switch (column.format) {
-      case ColumnFormat.Integer:
-        return 60;
-      default: {
-        return 100;
-      }
-    }
-  };
+// const getColumnWidths = <T extends RecordWithId>(
+//   column: ColumnDefinition<T>
+// ) => {
+//   const getDefaultWidth = () => {
+//     switch (column.format) {
+//       case ColumnFormat.Integer:
+//         return 60;
+//       default: {
+//         return 100;
+//       }
+//     }
+//   };
 
-  const defaultWidth = getDefaultWidth();
+//   const defaultWidth = getDefaultWidth();
 
-  const minWidth = column.minWidth || column.width || defaultWidth;
-  const width = column.width || defaultWidth;
+//   const minWidth = column.minWidth || column.width || defaultWidth;
+//   const width = column.width || defaultWidth;
 
-  return { minWidth, width, maxWidth: column.maxWidth };
-};
+//   return { minWidth, width, maxWidth: column.maxWidth };
+// };
 
 const getSortType = (column: { format?: ColumnFormat }) => {
   switch (column.format) {
@@ -164,7 +164,7 @@ export const createColumnWithDefaults = <T extends RecordWithId>(
     formatter: getDefaultFormatter<T>(column),
     setter: getDefaultColumnSetter<T>(column),
 
-    ...getColumnWidths(column),
+    // ...getColumnWidths(column),
   };
 
   return { ...defaults, ...column };

--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -13,27 +13,6 @@ import { DateUtils } from '@common/utils';
 import { SortBy } from '@common/hooks';
 import { ColumnDefinitionSetBuilder, ColumnKey } from '../../utils';
 
-// const getColumnWidths = <T extends RecordWithId>(
-//   column: ColumnDefinition<T>
-// ) => {
-//   const getDefaultWidth = () => {
-//     switch (column.format) {
-//       case ColumnFormat.Integer:
-//         return 60;
-//       default: {
-//         return 100;
-//       }
-//     }
-//   };
-
-//   const defaultWidth = getDefaultWidth();
-
-//   const minWidth = column.minWidth || column.width || defaultWidth;
-//   const width = column.width || defaultWidth;
-
-//   return { minWidth, width, maxWidth: column.maxWidth };
-// };
-
 const getSortType = (column: { format?: ColumnFormat }) => {
   switch (column.format) {
     case ColumnFormat.Date:
@@ -163,8 +142,6 @@ export const createColumnWithDefaults = <T extends RecordWithId>(
     align: getDefaultColumnAlign(column),
     formatter: getDefaultFormatter<T>(column),
     setter: getDefaultColumnSetter<T>(column),
-
-    // ...getColumnWidths(column),
   };
 
   return { ...defaults, ...column };

--- a/packages/inventory/src/Stocktake/ListView/ListView.tsx
+++ b/packages/inventory/src/Stocktake/ListView/ListView.tsx
@@ -42,7 +42,7 @@ export const StocktakeListView: FC = () => {
 
   const columns = useColumns<StocktakeRowFragment>(
     [
-      'stocktakeNumber',
+      ['stocktakeNumber', { maxWidth: 50 }],
       [
         'status',
         {

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -51,10 +51,10 @@ export const InboundListView: FC = () => {
             getStatusTranslator(t)(status as InvoiceNodeStatus),
         },
       ],
-      'invoiceNumber',
+      ['invoiceNumber', { maxWidth: 80 }],
       'createdDatetime',
       'allocatedDatetime',
-      'comment',
+      ['comment', { maxWidth: 300 }],
       [
         'totalAfterTax',
         {

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -162,7 +162,7 @@ export const useOutboundColumns = ({
       [
         'locationName',
         {
-          width: 180,
+          // width: 180,
           getSortValue: row => {
             if ('lines' in row) {
               const locations = row.lines
@@ -210,7 +210,7 @@ export const useOutboundColumns = ({
       [
         'numberOfPacks',
         {
-          width: 150,
+          // width: 150,
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
@@ -256,7 +256,7 @@ export const useOutboundColumns = ({
       [
         'packSize',
         {
-          width: 150,
+          // width: 150,
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
@@ -301,7 +301,7 @@ export const useOutboundColumns = ({
       {
         label: 'label.unit-price',
         key: 'sellPricePerUnit',
-        width: 200,
+        // width: 200,
         align: ColumnAlign.Right,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
@@ -337,7 +337,7 @@ export const useOutboundColumns = ({
       {
         label: 'label.line-total',
         key: 'lineTotal',
-        width: 200,
+        // width: 200,
         align: ColumnAlign.Right,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -82,6 +82,7 @@ export const useOutboundColumns = ({
       [
         'itemName',
         {
+          maxWidth: 400,
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
@@ -162,7 +163,6 @@ export const useOutboundColumns = ({
       [
         'locationName',
         {
-          // width: 180,
           getSortValue: row => {
             if ('lines' in row) {
               const locations = row.lines
@@ -210,7 +210,6 @@ export const useOutboundColumns = ({
       [
         'numberOfPacks',
         {
-          // width: 150,
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
@@ -256,7 +255,6 @@ export const useOutboundColumns = ({
       [
         'packSize',
         {
-          // width: 150,
           getSortValue: row => {
             if ('lines' in row) {
               const { lines } = row;
@@ -301,7 +299,6 @@ export const useOutboundColumns = ({
       {
         label: 'label.unit-price',
         key: 'sellPricePerUnit',
-        // width: 200,
         align: ColumnAlign.Right,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {
@@ -337,7 +334,6 @@ export const useOutboundColumns = ({
       {
         label: 'label.line-total',
         key: 'lineTotal',
-        // width: 200,
         align: ColumnAlign.Right,
         accessor: ({ rowData }) => {
           if ('lines' in rowData) {

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -54,7 +54,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
       ],
       'invoiceNumber',
       'createdDatetime',
-      'comment',
+      ['comment', { maxWidth: 300 }],
       [
         'totalAfterTax',
         {

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -52,7 +52,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
             getStatusTranslator(t)(status as InvoiceNodeStatus),
         },
       ],
-      'invoiceNumber',
+      ['invoiceNumber', { maxWidth: 80 }],
       'createdDatetime',
       ['comment', { maxWidth: 300 }],
       [

--- a/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
+++ b/packages/requisitions/src/RequestRequisition/ListView/ListView.tsx
@@ -47,6 +47,7 @@ export const RequestRequisitionListView: FC = () => {
       {
         key: 'requisitionNumber',
         label: 'label.number',
+        width: 100,
       },
       [
         'status',
@@ -55,7 +56,7 @@ export const RequestRequisitionListView: FC = () => {
             getRequisitionTranslator(t)(currentStatus as RequisitionNodeStatus),
         },
       ],
-      'comment',
+      ['comment', { minWidth: '30%' }],
       'selection',
     ],
     { sortBy, onChangeSortBy },

--- a/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
+++ b/packages/requisitions/src/ResponseRequisition/ListView/ListView.tsx
@@ -37,6 +37,7 @@ export const ResponseRequisitionListView: FC = () => {
       {
         key: 'requisitionNumber',
         label: 'label.number',
+        width: 100,
       },
       'createdDatetime',
       [
@@ -46,7 +47,7 @@ export const ResponseRequisitionListView: FC = () => {
             getRequisitionTranslator(t)(status as RequisitionNodeStatus),
         },
       ],
-      'comment',
+      ['comment', { minWidth: 400 }],
     ],
     { onChangeSortBy, sortBy },
     [sortBy]

--- a/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -8,7 +8,7 @@ import { useLocations, LocationRowFragment } from '../api';
 
 interface LocationSearchInputProps {
   value: LocationRowFragment | null;
-  width?: number;
+  width?: number | string;
   onChange: (location: LocationRowFragment | null) => void;
   disabled: boolean;
   autoFocus?: boolean;

--- a/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -8,7 +8,7 @@ import { useLocations, LocationRowFragment } from '../api';
 
 interface LocationSearchInputProps {
   value: LocationRowFragment | null;
-  width: number;
+  width?: number;
   onChange: (location: LocationRowFragment | null) => void;
   disabled: boolean;
   autoFocus?: boolean;


### PR DESCRIPTION
Fix #1097 

General gist is:
- remove defaults for column `minWidth` and `width` (Table will auto-width unless custom width style is specified)
- remove "flex" layouts on the table elements (Header, Body, Row) as it was making a mess of the column widths per row once defaults were removed

Have add custom widths to some columns, but they're pretty arbitrary just based on me eye-balling it with the existing data -- will probably want to evolve them over time.

Have checked all the tables, including ones with grouped lines, and they seem to be behaving themselves.