### PR TITLE
#1114 Stockdate date fix

### DIFF
--- a/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
+++ b/packages/common/src/ui/layout/tables/hooks/useColumns/useColumns.tsx
@@ -82,7 +82,7 @@ const getDefaultFormatter = <T extends RecordWithId>(
     case ColumnFormat.Date: {
       return (date: unknown) => {
         const formatDate = useFormatDate();
-        const maybeDate = DateUtils.getDateOrNull(date as string);
+        const maybeDate = DateUtils.getDateOrNull(date as string | null);
         return maybeDate ? formatDate(maybeDate) : '';
       };
     }

--- a/packages/common/src/utils/dates/DateUtils.ts
+++ b/packages/common/src/utils/dates/DateUtils.ts
@@ -13,7 +13,8 @@ import {
 export const MINIMUM_EXPIRY_MONTHS = 3;
 
 export const DateUtils = {
-  getDateOrNull: (date: string): Date | null => {
+  getDateOrNull: (date: string | null): Date | null => {
+    if (!date) return null;
     const maybeDate = new Date(date);
     return isValid(maybeDate) ? maybeDate : null;
   },


### PR DESCRIPTION
Fix #1114 

Turns out the 1/1/1970 date wasn't being saved, it was just a small problem with the Date formatter not handling `null` values correctly.

Slightly tangential: noticed that the sort headers weren't working on this table. Turns out that API isn't accepting those columns as sort keys -- have made an issue for back-end: https://github.com/openmsupply/remote-server/issues/981