### PR TITLE
#1120 Page title hook

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -16,6 +16,7 @@ export * from './useIsMountedRef';
 export * from './useIsScreen';
 export * from './useNotification';
 export * from './useOpenInNewTab';
+export * from './usePageTitle';
 export * from './usePagination';
 export * from './useQueryParams';
 export * from './useSortBy';

--- a/packages/common/src/hooks/usePageTitle/index.ts
+++ b/packages/common/src/hooks/usePageTitle/index.ts
@@ -1,0 +1,1 @@
+export * from './usePageTitle';

--- a/packages/common/src/hooks/usePageTitle/usePageTitle.tsx
+++ b/packages/common/src/hooks/usePageTitle/usePageTitle.tsx
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from '@common/intl';
+
+export const usePageTitle = (title: string) => {
+  const t = useTranslation('common');
+  const [pageTitle, setPageTitle] = useState(title);
+
+  useEffect(() => {
+    const newTitle = `${title} | ${t('app')}`;
+    setPageTitle(newTitle);
+    document.title = newTitle;
+  }, [title]);
+
+  return { pageTitle, setPageTitle };
+};

--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -1,4 +1,5 @@
 {
+  "app": "mSupply",
   "app.admin": "Admin",
   "app.catalogue": "Catalogue",
   "app.customer-requisition": "Requisitions",

--- a/packages/dashboard/src/DashboardService.tsx
+++ b/packages/dashboard/src/DashboardService.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
-import { Grid } from '@openmsupply-client/common';
+import { Grid, usePageTitle, useTranslation } from '@openmsupply-client/common';
 import { StockWidget } from './widgets';
 import {
   InboundShipmentWidget,
   OutboundShipmentWidget,
 } from '@openmsupply-client/invoices';
 
-const Dashboard: React.FC = () => (
-  <Grid
-    container
-    sx={{
-      backgroundColor: 'background.toolbar',
-      paddingBottom: '32px',
-    }}
-    justifyContent="space-evenly"
-  >
-    <InboundShipmentWidget />
-    <OutboundShipmentWidget />
-    <StockWidget />
-  </Grid>
-);
+const Dashboard: React.FC = () => {
+  const t = useTranslation('common');
+  usePageTitle(t('app.dashboard'));
+  return (
+    <Grid
+      container
+      sx={{
+        backgroundColor: 'background.toolbar',
+        paddingBottom: '32px',
+      }}
+      justifyContent="space-evenly"
+    >
+      <InboundShipmentWidget />
+      <OutboundShipmentWidget />
+      <StockWidget />
+    </Grid>
+  );
+};
 
 export default Dashboard;

--- a/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/DetailView.tsx
@@ -8,6 +8,7 @@ import {
   useNavigate,
   RouteBuilder,
   useTranslation,
+  usePageTitle,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { toItemRow, ItemRowFragment } from '@openmsupply-client/system';
@@ -27,6 +28,7 @@ export const DetailView: FC = () => {
     useEditModal<ItemRowFragment>();
   const navigate = useNavigate();
   const t = useTranslation('replenishment');
+  usePageTitle(t('app.inbound-shipments'));
 
   const onRowClick = React.useCallback(
     (line: InboundItem | InboundLineFragment) => {

--- a/packages/invoices/src/InboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/InboundShipment/ListView/ListView.tsx
@@ -10,6 +10,7 @@ import {
   useTranslation,
   useCurrency,
   useTableStore,
+  usePageTitle,
 } from '@openmsupply-client/common';
 import { Toolbar } from './Toolbar';
 import { AppBarButtons } from './AppBarButtons';
@@ -40,6 +41,7 @@ export const InboundListView: FC = () => {
   useDisableInboundRows(data?.nodes);
 
   const t = useTranslation();
+  usePageTitle(t('app.inbound-shipments'));
 
   const columns = useColumns<InboundRowFragment>(
     [

--- a/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/DetailView.tsx
@@ -8,6 +8,7 @@ import {
   useNavigate,
   RouteBuilder,
   useTranslation,
+  usePageTitle,
 } from '@openmsupply-client/common';
 import { toItemRow, ItemRowFragment } from '@openmsupply-client/system';
 import { ContentArea } from './ContentArea';
@@ -22,11 +23,12 @@ import { AppRoute } from '@openmsupply-client/config';
 import { OutboundLineFragment } from '../api/operations.generated';
 
 export const DetailView: FC = () => {
+  const t = useTranslation('distribution');
+  usePageTitle(t('app.outbound-shipments'));
   const isDisabled = useOutbound.utils.isDisabled();
   const { entity, mode, onOpen, onClose, isOpen } =
     useEditModal<ItemRowFragment>();
   const { data, isLoading } = useOutbound.document.get();
-  const t = useTranslation('distribution');
   const navigate = useNavigate();
   const onRowClick = useCallback(
     (item: OutboundLineFragment | OutboundItem) => {

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -10,6 +10,7 @@ import {
   InvoiceNodeStatus,
   useCurrency,
   useTableStore,
+  usePageTitle,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
@@ -28,6 +29,7 @@ const useDisableOutboundRows = (rows?: OutboundRowFragment[]) => {
 export const OutboundShipmentListViewComponent: FC = () => {
   const { mutate: onUpdate } = useOutbound.document.update();
   const t = useTranslation('common');
+  usePageTitle(t('app.outbound-shipments'));
   const navigate = useNavigate();
 
   const {


### PR DESCRIPTION
Fix #1120 

I realise this doesn't *need* to be a hook -- could just be a simple function that calls `document.title = newTitle`, and indeed it's not really using the returned items `pageTitle` and `setPageTitle`. However, if we ever need to do dynamic title updating the `setPageTitle` function would be useful.

Have only implemented this on Dashboard, Outbound and Inbound shipments so far. If this approach is okay, I'll add `usePageTitle` to the other pages before merging. :) 