### PR TITLE
#1120 (2) Page title

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -11,6 +11,7 @@ export * from './useDrawer';
 export * from './useEditModal';
 export * from './useEffectAfterMounting';
 export * from './useFilterBy';
+export * from './useGetPageTitle';
 export * from './useHostContext/useHostContext';
 export * from './useIsMountedRef';
 export * from './useIsScreen';

--- a/packages/common/src/hooks/useGetPageTitle/index.ts
+++ b/packages/common/src/hooks/useGetPageTitle/index.ts
@@ -1,0 +1,1 @@
+export * from './useGetPageTitle';

--- a/packages/common/src/hooks/useGetPageTitle/useGetPageTitle.tsx
+++ b/packages/common/src/hooks/useGetPageTitle/useGetPageTitle.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from '@common/intl';
+import { RegexUtils } from '@common/utils';
+
+export const useGetPageTitle = () => {
+  const t = useTranslation('app');
+
+  const mapRouteToTitle = (route: string) => {
+    switch (true) {
+      case RegexUtils.includes('dashboard', route):
+        return t('dashboard');
+      case RegexUtils.includes('outbound-shipment', route):
+        return t('outbound-shipments');
+      case RegexUtils.includes('customer-requisition', route):
+        return t('customer-requisition');
+      case RegexUtils.includes('customers', route):
+        return t('customers');
+      case RegexUtils.includes('inbound-shipment', route):
+        return t('inbound-shipments');
+      case RegexUtils.includes('internal-order', route):
+        return t('internal-order');
+      case RegexUtils.includes('suppliers', route):
+        return t('suppliers');
+      case RegexUtils.includes('items', route):
+        return t('items');
+      case RegexUtils.includes('master-lists', route):
+        return t('master-lists');
+      case RegexUtils.includes('locations', route):
+        return t('locations');
+      case RegexUtils.includes('stocktakes', route):
+        return t('stocktakes');
+      // Stocktakes needs to go before stock so matching is correct
+      case RegexUtils.includes('stock', route):
+        return t('stock');
+      case RegexUtils.includes('sync', route):
+        return t('sync');
+      case RegexUtils.includes('admin', route):
+        return t('admin');
+      default:
+        return '';
+    }
+  };
+
+  const getPageTitle = (route: string) => {
+    return `${mapRouteToTitle(route)} | ${t('app')} `;
+  };
+  return getPageTitle;
+};

--- a/packages/common/src/hooks/useHostContext/useHostContext.ts
+++ b/packages/common/src/hooks/useHostContext/useHostContext.ts
@@ -15,6 +15,9 @@ type HostContext = {
 
   setDetailPanelRef: (ref: React.MutableRefObject<null> | null) => void;
   detailPanelRef: React.MutableRefObject<null> | null;
+
+  setPageTitle: (title: string) => void;
+  pageTitle: string;
 };
 
 export const useHostContext = create<HostContext>(set => ({
@@ -37,4 +40,10 @@ export const useHostContext = create<HostContext>(set => ({
   setDetailPanelRef: (refOrNull: React.MutableRefObject<null> | null) =>
     set(state => ({ ...state, detailPanelRef: refOrNull })),
   detailPanelRef: null,
+
+  setPageTitle: (title: string) => {
+    set(state => ({ ...state, pageTitle: title }));
+    document.title = title;
+  },
+  pageTitle: '',
 }));

--- a/packages/common/src/intl/locales/en/app.json
+++ b/packages/common/src/intl/locales/en/app.json
@@ -1,4 +1,5 @@
 {
+  "app": "mSupply",
   "admin": "Admin",
   "auth.logged-out-message": "You have been logged out of your session due to inactivity. Click OK to return to the login screen.",
   "auth.alert-title": "Session Timed Out",

--- a/packages/common/src/intl/locales/en/common.json
+++ b/packages/common/src/intl/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "app.admin": "Admin",
+  "app.login": "Login",
   "app.catalogue": "Catalogue",
   "app.customer-requisition": "Requisitions",
   "app.customers": "Customers",

--- a/packages/host/src/Site.tsx
+++ b/packages/host/src/Site.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import {
   AppFooterPortal,
@@ -11,6 +11,9 @@ import {
   RouteBuilder,
   Navigate,
   Typography,
+  useLocation,
+  useHostContext,
+  useGetPageTitle,
 } from '@openmsupply-client/common';
 import { AppDrawer, AppBar, Footer, NotFound } from './components';
 import { CommandK } from './CommandK';
@@ -31,90 +34,104 @@ const Heading: FC = ({ children }) => (
   </div>
 );
 
-export const Site: FC = () => (
-  <RequireAuthentication>
-    <CommandK>
-      <SnackbarProvider maxSnack={3}>
-        <AppDrawer />
-        <Box flex={1} display="flex" flexDirection="column" overflow="hidden">
-          <AppBar />
-          <Box display="flex" flex={1} overflow="auto">
-            <Routes>
-              <Route
-                path={RouteBuilder.create(AppRoute.Dashboard)
-                  .addWildCard()
-                  .build()}
-                element={<DashboardRouter />}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Catalogue)
-                  .addWildCard()
-                  .build()}
-                element={<CatalogueRouter />}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Distribution)
-                  .addWildCard()
-                  .build()}
-                element={<DistributionRouter />}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Replenishment)
-                  .addWildCard()
-                  .build()}
-                element={<ReplenishmentRouter />}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Suppliers)
-                  .addWildCard()
-                  .build()}
-                element={<Heading>suppliers</Heading>}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Inventory)
-                  .addWildCard()
-                  .build()}
-                element={<InventoryRouter />}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Tools).addWildCard().build()}
-                element={<Heading>tools</Heading>}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Reports)
-                  .addWildCard()
-                  .build()}
-                element={<Heading>reports</Heading>}
-              />
-              <Route
-                path={RouteBuilder.create(AppRoute.Messages)
-                  .addWildCard()
-                  .build()}
-                element={<Heading>messages</Heading>}
-              />
+export const Site: FC = () => {
+  const location = useLocation();
+  const getPageTitle = useGetPageTitle();
+  const { setPageTitle } = useHostContext();
 
-              <Route
-                path={RouteBuilder.create(AppRoute.Admin).addWildCard().build()}
-                element={<Settings />}
-              />
+  useEffect(() => {
+    setPageTitle(getPageTitle(location.pathname));
+  }, [location]);
 
-              <Route
-                path="/"
-                element={
-                  <Navigate
-                    replace
-                    to={RouteBuilder.create(AppRoute.Dashboard).build()}
-                  />
-                }
-              />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+  return (
+    <RequireAuthentication>
+      <CommandK>
+        <SnackbarProvider maxSnack={3}>
+          <AppDrawer />
+          <Box flex={1} display="flex" flexDirection="column" overflow="hidden">
+            <AppBar />
+            <Box display="flex" flex={1} overflow="auto">
+              <Routes>
+                <Route
+                  path={RouteBuilder.create(AppRoute.Dashboard)
+                    .addWildCard()
+                    .build()}
+                  element={<DashboardRouter />}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Catalogue)
+                    .addWildCard()
+                    .build()}
+                  element={<CatalogueRouter />}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Distribution)
+                    .addWildCard()
+                    .build()}
+                  element={<DistributionRouter />}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Replenishment)
+                    .addWildCard()
+                    .build()}
+                  element={<ReplenishmentRouter />}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Suppliers)
+                    .addWildCard()
+                    .build()}
+                  element={<Heading>suppliers</Heading>}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Inventory)
+                    .addWildCard()
+                    .build()}
+                  element={<InventoryRouter />}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Tools)
+                    .addWildCard()
+                    .build()}
+                  element={<Heading>tools</Heading>}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Reports)
+                    .addWildCard()
+                    .build()}
+                  element={<Heading>reports</Heading>}
+                />
+                <Route
+                  path={RouteBuilder.create(AppRoute.Messages)
+                    .addWildCard()
+                    .build()}
+                  element={<Heading>messages</Heading>}
+                />
+
+                <Route
+                  path={RouteBuilder.create(AppRoute.Admin)
+                    .addWildCard()
+                    .build()}
+                  element={<Settings />}
+                />
+
+                <Route
+                  path="/"
+                  element={
+                    <Navigate
+                      replace
+                      to={RouteBuilder.create(AppRoute.Dashboard).build()}
+                    />
+                  }
+                />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Box>
+            <AppFooter />
+            <AppFooterPortal SessionDetails={<Footer />} />
           </Box>
-          <AppFooter />
-          <AppFooterPortal SessionDetails={<Footer />} />
-        </Box>
-        <DetailPanel />
-      </SnackbarProvider>
-    </CommandK>
-  </RequireAuthentication>
-);
+          <DetailPanel />
+        </SnackbarProvider>
+      </CommandK>
+    </RequireAuthentication>
+  );
+};

--- a/packages/host/src/components/Login/Login.tsx
+++ b/packages/host/src/components/Login/Login.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   ArrowRightIcon,
   useTranslation,
@@ -7,6 +7,7 @@ import {
   Box,
   Typography,
   AlertIcon,
+  useHostContext,
 } from '@openmsupply-client/common';
 import { LoginTextInput } from './LoginTextInput';
 import { StoreSearchInput } from '@openmsupply-client/system';
@@ -29,6 +30,11 @@ const StoreAutocompleteInput: React.FC<
 
 export const Login: React.FC = ({}) => {
   const t = useTranslation('app');
+  const { setPageTitle } = useHostContext();
+  useEffect(() => {
+    setPageTitle(`${t('app.login')} | ${t('app')} `);
+  }, []);
+
   const passwordRef = React.useRef(null);
   const {
     isValid,


### PR DESCRIPTION
Fix #1120 (no for real this time ;) )

Was easier to just create a new branch. This contains page title implementation as discussed on #1122. 

Put `pageTitle` and `setPageTitle` into `useHostContext`. However, still had to make a new hook to map routes to titles, as I couldn't access the `useTranslation` hook from within the zustand `create` function.