### PR TITLE
#1128 Row hover fix

### DIFF
--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -54,7 +54,9 @@ export const DataRow = <T extends RecordWithId>({
         <TableRow
           sx={{
             '&.MuiTableRow-root': {
-              '&:hover': { backgroundColor: 'background.menu' },
+              '&:hover': hasOnClick
+                ? { backgroundColor: 'background.menu' }
+                : {},
             },
             color: isDisabled ? 'gray.main' : 'black',
             backgroundColor: isFocused ? 'background.menu' : null,
@@ -67,7 +69,6 @@ export const DataRow = <T extends RecordWithId>({
             ...rowStyle,
           }}
           onClick={onRowClick}
-          hover={hasOnClick}
         >
           {columns.map((column, columnIndex) => {
             return (


### PR DESCRIPTION
Fix #1128 

This crept in when I was updating the row hover styles the other day. Didn't realise I the hover style also over-rode the effect of the `hover` prop in `<TableRow>`.

Have removed the `hover` prop completely and made the hover style conditional.