### PR TITLE
Prevent duplicate alert modals

### DIFF
--- a/packages/common/src/ui/components/modals/AlertModal/AlertModal.tsx
+++ b/packages/common/src/ui/components/modals/AlertModal/AlertModal.tsx
@@ -1,44 +1,38 @@
-import React from 'react';
-import { Grid, Typography } from '@mui/material';
-import { DialogButton } from '../../buttons';
-import { AlertIcon } from '@common/icons';
-import { BasicModal } from '@common/components';
-
+import React, { useContext } from 'react';
+import { AlertModalContext } from './AlertModalContext';
 export interface AlertModalProps {
+  important?: boolean;
   message: React.ReactNode;
   open: boolean;
   onOk: () => void;
   title: string;
 }
 
+// This is really just a convenience component
+// allowing you to use the modal in a declarative syntax
+// without creating multiple overlaying modals
+// Set the important prop only if this is a critical alert
+// which should only be superceded by other critical alerts
+// Apart from the important / non-important distinction,
+// the latest caller wins, and will be displayed
 export const AlertModal: React.FC<AlertModalProps> = ({
+  important,
   message,
   onOk,
   open,
   title,
 }) => {
-  return (
-    <BasicModal open={open} width={400} height={150}>
-      <Grid padding={4} container gap={1} flexDirection="column">
-        <Grid container gap={1}>
-          <Grid item>
-            <AlertIcon color="primary" />
-          </Grid>
-          <Grid item>
-            <Typography
-              id="transition-modal-title"
-              variant="h6"
-              component="span"
-            >
-              {title}
-            </Typography>
-          </Grid>
-        </Grid>
-        <Grid item>{message}</Grid>
-        <Grid item display="flex" justifyContent="flex-end" flex={1}>
-          <DialogButton variant="ok" onClick={onOk} autoFocus />
-        </Grid>
-      </Grid>
-    </BasicModal>
-  );
+  const alertContext = useContext(AlertModalContext);
+  const {
+    setState,
+    open: isCurrentlyOpen,
+    important: isCurrentlyImportant,
+  } = alertContext;
+
+  React.useEffect(() => {
+    if (isCurrentlyOpen && !!isCurrentlyImportant && !important) return;
+    setState({ important, message, onOk, open, title });
+  }, [important, message, onOk, open, title]);
+
+  return <></>;
 };

--- a/packages/common/src/ui/components/modals/AlertModal/AlertModalContext.tsx
+++ b/packages/common/src/ui/components/modals/AlertModal/AlertModalContext.tsx
@@ -1,28 +1,32 @@
-import { createContext } from 'react';
+import React, { createContext } from 'react';
 
 export interface AlertModalState {
   open: boolean;
-  message: string;
+  message: string | React.ReactNode;
   title: string;
   iconType?: 'alert';
   onOk?: () => void;
+  important?: boolean;
 }
 
 export interface AlertModalControllerState extends AlertModalState {
   setState: (state: AlertModalState) => void;
   setOpen: (open: boolean) => void;
-  setMessage: (message: string) => void;
+  setMessage: (message: string | React.ReactNode) => void;
   setTitle: (title: string) => void;
   setOnOk: (onOk: () => void) => void;
+  setImportant: (important: boolean) => void;
 }
 
 export const AlertModalContext = createContext<AlertModalControllerState>({
   open: false,
   message: '',
   title: '',
+  important: false,
   setOpen: () => {},
   setState: () => {},
   setMessage: () => {},
   setTitle: () => {},
   setOnOk: () => {},
+  setImportant: () => {},
 });

--- a/packages/common/src/ui/components/modals/AlertModal/AlertModalProvider.tsx
+++ b/packages/common/src/ui/components/modals/AlertModal/AlertModalProvider.tsx
@@ -4,10 +4,45 @@ import {
   AlertModalControllerState,
   AlertModalState,
 } from './AlertModalContext';
-import { AlertModal } from './AlertModal';
+import { Grid, Typography } from '@mui/material';
+import { DialogButton } from '../../buttons';
+import { AlertIcon } from '@common/icons';
+import { BasicModal } from '@common/components';
+
+const AlertModal = ({
+  open,
+  title,
+  message,
+  onClick,
+}: {
+  open: boolean;
+  title: string;
+  message: string | React.ReactNode;
+  onClick: () => void;
+}) => (
+  <BasicModal open={open} width={400} height={150}>
+    <Grid padding={4} container gap={1} flexDirection="column">
+      <Grid container gap={1}>
+        <Grid item>
+          <AlertIcon color="primary" />
+        </Grid>
+        <Grid item>
+          <Typography id="transition-modal-title" variant="h6" component="span">
+            {title}
+          </Typography>
+        </Grid>
+      </Grid>
+      <Grid item>{message}</Grid>
+      <Grid item display="flex" justifyContent="flex-end" flex={1}>
+        <DialogButton variant="ok" onClick={onClick} autoFocus />
+      </Grid>
+    </Grid>
+  </BasicModal>
+);
 
 export const AlertModalProvider: FC = ({ children }) => {
   const [alertModalState, setState] = useState<AlertModalState>({
+    important: false,
     open: false,
     message: '',
     title: '',
@@ -18,12 +53,14 @@ export const AlertModalProvider: FC = ({ children }) => {
   const alertModalController: AlertModalControllerState = useMemo(
     () => ({
       setState,
-      setMessage: (message: string) =>
+      setMessage: (message: string | React.ReactNode) =>
         setState(state => ({ ...state, message })),
       setTitle: (title: string) => setState(state => ({ ...state, title })),
       setOnOk: () => {},
       setOpen: (open: boolean) => setState(state => ({ ...state, open })),
       ...alertModalState,
+      setImportant: (important: boolean) =>
+        setState(state => ({ ...state, important })),
     }),
     [setState, alertModalState]
   );
@@ -35,7 +72,7 @@ export const AlertModalProvider: FC = ({ children }) => {
         open={open}
         message={message}
         title={title}
-        onOk={() => {
+        onClick={() => {
           alertModalController.setOpen(false);
           onOk && onOk();
         }}

--- a/packages/host/src/components/AuthenticationAlert.tsx
+++ b/packages/host/src/components/AuthenticationAlert.tsx
@@ -53,6 +53,7 @@ export const AuthenticationAlert = () => {
 
   return (
     <AlertModal
+      important
       open={isOn}
       title={t('auth.alert-title')}
       message={message}


### PR DESCRIPTION
Fixes #1134 

Well, that turned out to be a good one to sort out. The `AlertModal` is used in multiple places, at different levels in the document hierarchy. Turns out, the provider wasn't adding anything and multiple instances of the modal were being created 🙄 

A simple test.. In the `Internal Orders` detail page add

```
const [error, setError] = useLocalStorage('/auth/error');
```

and 

```
  React.useEffect(() => {
    setTimeout(() => {
      if (!error) setError(AuthError.Unauthenticated);
    }, 1000);
  }, []);
```

and then change the requisition number in the URL to an invalid one for your store.
you should get two modals, overlayed, with the 'requisition not found' appearing on top.

This PR fixes that.