### PR TITLE
#1100 Don't mutate if no changes

### DIFF
--- a/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
+++ b/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 
 type DirtyState = {
   isDirty: boolean;
-  setIsDirty: (open: boolean) => void;
+  setIsDirty: (value: boolean) => void;
 };
 
 export const useDirtyCheck = (): DirtyState => {

--- a/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
+++ b/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
@@ -1,16 +1,11 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 
 type DirtyState = {
   isDirty: boolean;
-  setIsDirty: (open: boolean) => void;
+  setIsDirty: (on: boolean) => void;
 };
 
 export const useDirtyCheck = (): DirtyState => {
-  const ref = useRef<boolean>(false);
-  return {
-    isDirty: ref.current,
-    setIsDirty: isDirty => {
-      ref.current = isDirty;
-    },
-  };
+  const [isDirty, setIsDirty] = useState(false);
+  return { isDirty, setIsDirty };
 };

--- a/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
+++ b/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
@@ -1,11 +1,16 @@
-import { useState } from 'react';
+import { useRef } from 'react';
 
 type DirtyState = {
   isDirty: boolean;
-  setIsDirty: (on: boolean) => void;
+  setIsDirty: (open: boolean) => void;
 };
 
 export const useDirtyCheck = (): DirtyState => {
-  const [isDirty, setIsDirty] = useState(false);
-  return { isDirty, setIsDirty };
+  const ref = useRef<boolean>(false);
+  return {
+    isDirty: ref.current,
+    setIsDirty: isDirty => {
+      ref.current = isDirty;
+    },
+  };
 };

--- a/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
+++ b/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
@@ -1,11 +1,16 @@
-import create from 'zustand';
+import { useRef } from 'react';
 
 type DirtyState = {
   isDirty: boolean;
   setIsDirty: (open: boolean) => void;
 };
 
-export const useDirtyCheck = create<DirtyState>(set => ({
-  isDirty: false,
-  setIsDirty: isDirty => set(state => ({ ...state, isDirty })),
-}));
+export const useDirtyCheck = (): DirtyState => {
+  const ref = useRef<boolean>(false);
+  return {
+    isDirty: ref.current,
+    setIsDirty: isDirty => {
+      ref.current = isDirty;
+    },
+  };
+};

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -96,8 +96,8 @@ const useDraftInboundLines = (item: ItemRowFragment | null) => {
   );
 
   const saveLines = async () => {
+    if (isDirty) await mutateAsync(draftLines);
     setIsDirty(false);
-    await mutateAsync(draftLines);
   };
 
   return {

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -55,13 +55,14 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
   } = useDraftOutboundLines(currentItem);
   const packSizeController = usePackSizeController(draftOutboundLines);
   const { next, disabled: nextDisabled } = useNextItem(currentItem?.id);
-  const { setIsDirty } = useDirtyCheck();
+  const { isDirty, setIsDirty } = useDirtyCheck();
 
   const onNext = async () => {
-    await mutate(draftOutboundLines);
+    if (isDirty) await mutate(draftOutboundLines);
     if (mode === ModalMode.Update && next) setCurrentItem(next);
     else if (mode === ModalMode.Create) setCurrentItem(null);
     else onClose();
+    setIsDirty(false);
     // Returning true here triggers the slide animation
     return true;
   };
@@ -98,7 +99,8 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
           variant="ok"
           onClick={async () => {
             try {
-              await mutate(draftOutboundLines);
+              if (isDirty) await mutate(draftOutboundLines);
+              setIsDirty(false);
               onClose();
             } catch (e) {
               // console.log(e);


### PR DESCRIPTION
Fix #1100

Just used the existing `isDirty` state to conditionally run the mutation for saving. Plus set `isDirty` back to `false` in a couple of places where it needed to be.

Currently just affects the Inbound/Output shipment line edit modals. Any other places we should have this? (These are the only places where `useDirtyCheck` hook is being used)