### PR TITLE
Open on click nav link

### DIFF
--- a/packages/common/src/hooks/useDrawer/useDrawer.ts
+++ b/packages/common/src/hooks/useDrawer/useDrawer.ts
@@ -9,6 +9,7 @@ type DrawerController = {
   open: () => void;
   close: () => void;
   toggle: () => void;
+  onClick: () => void;
   setHoverOpen: (open: boolean) => void;
   setClickedNavPath: (clicked?: string) => void;
 };
@@ -26,6 +27,13 @@ export const useDrawer = create<DrawerController>(set => {
     close: () => set(state => ({ ...state, isOpen: false, hoverOpen: false })),
     toggle: () =>
       set(state => ({ ...state, isOpen: !state.isOpen, hasUserSet: true })),
+    onClick: () =>
+      set(state => {
+        if (state.isOpen && state.hoverOpen) {
+          return { ...state, isOpen: false, hoverOpen: false };
+        }
+        return state;
+      }),
   };
 });
 

--- a/packages/common/src/hooks/useDrawer/useDrawer.ts
+++ b/packages/common/src/hooks/useDrawer/useDrawer.ts
@@ -12,6 +12,7 @@ type DrawerController = {
   onClick: () => void;
   setHoverOpen: (open: boolean) => void;
   setClickedNavPath: (clicked?: string) => void;
+  onExpand: (clicked?: string) => void;
 };
 
 export const useDrawer = create<DrawerController>(set => {
@@ -33,6 +34,11 @@ export const useDrawer = create<DrawerController>(set => {
           return { ...state, isOpen: false, hoverOpen: false };
         }
         return state;
+      }),
+    onExpand: (clickedNavPath?: string) =>
+      set(state => {
+        const hoverOpen = state.isOpen ? state.hoverOpen : true;
+        return { ...state, hoverOpen, clickedNavPath, isOpen: true };
       }),
   };
 });

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -92,6 +92,8 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   );
 
   const expandChildren = () => {
+    drawer.setHoverOpen(true);
+    drawer.open();
     drawer.setClickedNavPath(to);
   };
 

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -77,7 +77,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
         !end && !!inactive ? (
           <span
             {...linkProps}
-            onClick={expandChildren}
+            onClick={() => drawer.onExpand(to)}
             data-testid={`${to}_hover`}
           />
         ) : (
@@ -94,12 +94,6 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
       ),
     [to]
   );
-
-  const expandChildren = () => {
-    drawer.setHoverOpen(true);
-    drawer.open();
-    drawer.setClickedNavPath(to);
-  };
 
   return (
     <StyledListItem isSelected={selected} to={to}>

--- a/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
+++ b/packages/common/src/ui/components/navigation/AppNavLink/AppNavLink.tsx
@@ -66,6 +66,10 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
   const drawer = useDrawer();
 
   const selected = useSelectedNavMenuItem(to, !!end);
+  const handleClick = () => {
+    if (onClick) onClick();
+    drawer.onClick();
+  };
 
   const CustomLink = React.useMemo(
     () =>
@@ -84,7 +88,7 @@ export const AppNavLink: FC<AppNavLinkProps> = props => {
             role="link"
             aria-label={text}
             title={text}
-            onClick={onClick}
+            onClick={handleClick}
           />
         )
       ),


### PR DESCRIPTION
Fixes #1165 

Opens the drawer (if closed) on click, and if the drawer was opened this way, closes on clicking a menu item.
It does mean that you can open the drawer by clicking on a category menu item and then leave the drawer open by clicking on something in-page, like navigating to a detail page. Still.. this is better than it was.
