### PR TITLE
Tidy report usage

### DIFF
--- a/packages/common/src/intl/locales/en/app.json
+++ b/packages/common/src/intl/locales/en/app.json
@@ -57,5 +57,5 @@
   "button.login": "Log in",
   "error.login": "Invalid username or password",
   "select-store": "Select store",
-  "select-report": "Select Report"
+  "select-report": "Select Template"
 }

--- a/packages/system/src/Report/components/ReportSelector.tsx
+++ b/packages/system/src/Report/components/ReportSelector.tsx
@@ -49,8 +49,12 @@ export const ReportSelector: FC<ReportSelectorProps> = ({
   ));
 
   const noReports = !isLoading && !data?.nodes.length;
+  const oneReport =
+    !isLoading && data?.nodes.length === 1 ? data.nodes[0] : null;
 
-  return (
+  return !!oneReport ? (
+    <div onClick={() => onClick(oneReport)}>{children}</div>
+  ) : (
     <PaperClickPopover
       placement="bottom"
       width={350}


### PR DESCRIPTION
Fixes #1159 

Renames the selection heading and prints without prompting if there is only one report.
To aid in testing, I've created a new 'invoices' report.. so outbound and inbound will still show the selection popover.