### PR TITLE
Retain placeholder for new invoices

### DIFF
--- a/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
+++ b/packages/common/src/hooks/useDirtyCheck/useDirtyCheck.ts
@@ -1,16 +1,11 @@
-import { useRef } from 'react';
+import create from 'zustand';
 
 type DirtyState = {
   isDirty: boolean;
-  setIsDirty: (value: boolean) => void;
+  setIsDirty: (open: boolean) => void;
 };
 
-export const useDirtyCheck = (): DirtyState => {
-  const ref = useRef<boolean>(false);
-  return {
-    isDirty: ref.current,
-    setIsDirty: isDirty => {
-      ref.current = isDirty;
-    },
-  };
-};
+export const useDirtyCheck = create<DirtyState>(set => ({
+  isDirty: false,
+  setIsDirty: isDirty => set(state => ({ ...state, isDirty })),
+}));

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEdit.tsx
@@ -20,6 +20,7 @@ import {
   useDraftOutboundLines,
   usePackSizeController,
   useNextItem,
+  PackSizeController,
 } from './hooks';
 import {
   allocateQuantities,
@@ -27,6 +28,8 @@ import {
   getAllocatedQuantity,
 } from './utils';
 import { useOutbound } from '../../api';
+import { DraftOutboundLine } from '../../../types';
+
 interface ItemDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -123,41 +126,67 @@ export const OutboundLineEdit: React.FC<ItemDetailsModalProps> = ({
           canAutoAllocate={canAutoAllocate}
         />
 
-        {!!currentItem ? (
-          !isLoading ? (
-            canAutoAllocate ? (
-              <TableProvider createStore={createTableStore}>
-                <OutboundLineEditTable
-                  packSizeController={packSizeController}
-                  onChange={updateQuantity}
-                  rows={draftOutboundLines}
-                />
-              </TableProvider>
-            ) : (
-              <NoStock />
-            )
-          ) : (
-            <Box
-              display="flex"
-              flex={1}
-              height={400}
-              justifyContent="center"
-              alignItems="center"
-            >
-              <InlineSpinner />
-            </Box>
-          )
-        ) : null}
+        <TableWrapper
+          canAutoAllocate={canAutoAllocate}
+          currentItem={currentItem}
+          isLoading={isLoading}
+          packSizeController={packSizeController}
+          updateQuantity={updateQuantity}
+          draftOutboundLines={draftOutboundLines}
+        />
       </Grid>
     </Modal>
   );
 };
 
-const NoStock = () => {
+interface TableProps {
+  canAutoAllocate: boolean;
+  currentItem: ItemRowFragment | null;
+  isLoading: boolean;
+  packSizeController: PackSizeController;
+  updateQuantity: (batchId: string, updateQuantity: number) => void;
+  draftOutboundLines: DraftOutboundLine[];
+}
+
+const TableWrapper: React.FC<TableProps> = ({
+  canAutoAllocate,
+  currentItem,
+  isLoading,
+  packSizeController,
+  updateQuantity,
+  draftOutboundLines,
+}) => {
   const t = useTranslation('distribution');
+
+  if (!currentItem) return null;
+
+  if (isLoading)
+    return (
+      <Box
+        display="flex"
+        flex={1}
+        height={400}
+        justifyContent="center"
+        alignItems="center"
+      >
+        <InlineSpinner />
+      </Box>
+    );
+
+  if (!canAutoAllocate)
+    return (
+      <Box sx={{ margin: 'auto' }}>
+        <Typography>{t('messages.no-stock-available')}</Typography>
+      </Box>
+    );
+
   return (
-    <Box sx={{ margin: 'auto' }}>
-      <Typography>{t('messages.no-stock-available')}</Typography>
-    </Box>
+    <TableProvider createStore={createTableStore}>
+      <OutboundLineEditTable
+        packSizeController={packSizeController}
+        onChange={updateQuantity}
+        rows={draftOutboundLines}
+      />
+    </TableProvider>
   );
 };

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/hooks/useDraftOutboundLines.tsx
@@ -150,9 +150,14 @@ export const useDraftOutboundLines = (
         .sort(SortUtils.byExpiryAsc);
 
       if (status === InvoiceNodeStatus.New) {
-        const placeholder = lines?.find(
+        let placeholder = lines?.find(
           ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
         );
+        if (!placeholder) {
+          placeholder = draftOutboundLines.find(
+            ({ type }) => type === InvoiceLineNodeType.UnallocatedStock
+          );
+        }
         if (placeholder) {
           rows.push(
             createDraftOutboundLine({ invoiceId, invoiceLine: placeholder })


### PR DESCRIPTION
Fixes #1106 

Subtle error, this one. The placeholder row was being added to `draftOutboundLines`.. but then on re-render the existing lines on the invoice are checked for `UNALLOCATED` rows, and since there isn't one, a new placeholder is created.

When updating, the first placeholder line is updated, but that no longer exists in state and fails. To resolve, check for lines from the api first and if that fails, check for lines that you've created. only if that doesn't exist then create a new one.