### PR TITLE
Stabilise translation hook

### DIFF
--- a/packages/common/src/intl/strings/IntlStrings.ts
+++ b/packages/common/src/intl/strings/IntlStrings.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Namespace, useTranslation as useTranslationNext } from 'react-i18next';
 import { TOptions } from 'i18next';
 import { LocaleKey } from '../locales';
@@ -18,5 +19,5 @@ export interface TypedTFunction<Keys> {
 
 export const useTranslation = (ns?: Namespace): TypedTFunction<LocaleKey> => {
   const { t } = useTranslationNext(ns);
-  return (key, options) => (key ? t(key, options) : '');
+  return useCallback((key, options) => (key ? t(key, options) : ''), [t]);
 };


### PR DESCRIPTION
fixes #884 

well, that was simpler than expected.

## Testing

Simple test, from the issue itself. Just add

```
  const [state, setState] = React.useState(0);
  const t = useTranslation();

  useEffect(() => {
    console.log(`** RENDER ${state} **`);
    setState(state + 1);
  }, [t]);
```

to a page and watch the fun.