### PR TITLE
Force integers for quantities

### DIFF
--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeIntegerCell.tsx
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/NonNegativeIntegerCell.tsx
@@ -5,7 +5,7 @@ import { RecordWithId } from '@common/types';
 import { useBufferState, useDebounceCallback } from '@common/hooks';
 
 // where NonNegative is n >=0
-export const NonNegativeNumberInputCell = <T extends RecordWithId>({
+export const NonNegativeIntegerCell = <T extends RecordWithId>({
   rowData,
   column,
   rows,
@@ -29,8 +29,9 @@ export const NonNegativeNumberInputCell = <T extends RecordWithId>({
       type="number"
       value={buffer}
       onChange={newValue => {
-        setBuffer(newValue.toString());
-        updater({ ...rowData, [column.key]: newValue });
+        const intValue = Math.round(newValue);
+        setBuffer(intValue.toString());
+        updater({ ...rowData, [column.key]: intValue });
       }}
     />
   );

--- a/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/index.ts
+++ b/packages/common/src/ui/layout/tables/components/Cells/NumberInputCell/index.ts
@@ -1,3 +1,3 @@
 export * from './NumberInputCell';
 export * from './PositiveNumberInputCell';
-export * from './NonNegativeNumberInputCell';
+export * from './NonNegativeIntegerCell';

--- a/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -8,7 +8,7 @@ import {
   CurrencyInputCell,
   useTranslation,
   getExpiryDateInputColumn,
-  NonNegativeNumberInputCell,
+  NonNegativeIntegerCell,
   PositiveNumberInputCell,
   CheckboxCell,
   ColumnDescription,
@@ -96,7 +96,7 @@ export const BatchTable: FC<StocktakeLineEditTableProps> = ({
       width: 100,
       accessor: ({ rowData }) =>
         rowData.countThisLine ? rowData.countedNumberOfPacks : '',
-      Cell: NonNegativeNumberInputCell,
+      Cell: NonNegativeIntegerCell,
       setter: patch => update({ ...patch, countThisLine: true }),
     },
     [

--- a/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/TabTables.tsx
@@ -10,7 +10,7 @@ import {
   Theme,
   alpha,
   PositiveNumberInputCell,
-  NonNegativeNumberInputCell,
+  NonNegativeIntegerCell,
 } from '@openmsupply-client/common';
 import { DraftInboundLine } from '../../../../types';
 import { getLocationInputColumn } from '@openmsupply-client/system';
@@ -62,7 +62,7 @@ export const QuantityTableComponent: FC<TableProps> = ({
       [
         'numberOfPacks',
         {
-          Cell: NonNegativeNumberInputCell,
+          Cell: NonNegativeIntegerCell,
           width: 100,
           label: 'label.num-packs',
           setter: updateDraftLine,

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditForm.tsx
@@ -109,7 +109,7 @@ export const OutboundLineEditForm: React.FC<OutboundLineEditFormProps> = ({
               value={quantity}
               onChange={event => {
                 onChangeQuantity(
-                  Number(event.target.value),
+                  Math.round(Number(event.target.value)),
                   packSizeController.selected?.value === -1
                     ? null
                     : Number(packSizeController.selected?.value)

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.ts
@@ -1,7 +1,7 @@
 import {
   useCurrencyFormat,
   useColumns,
-  NonNegativeNumberInputCell,
+  NonNegativeIntegerCell,
   ColumnAlign,
   ExpiryDateCell,
   CheckCell,
@@ -19,7 +19,7 @@ export const useOutboundLineEditColumns = ({
       [
         'numberOfPacks',
         {
-          Cell: NonNegativeNumberInputCell,
+          Cell: NonNegativeIntegerCell,
           width: 100,
           label: 'label.num-packs',
           setter: ({ packSize, id, numberOfPacks }) =>

--- a/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useServiceLineColumns.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/OutboundServiceLineEdit/useServiceLineColumns.tsx
@@ -7,7 +7,7 @@ import {
   XCircleIcon,
   CurrencyInputCell,
   ColumnAlign,
-  NonNegativeNumberInputCell,
+  NonNegativeIntegerCell,
   TextInputCell,
   useFormatCurrency,
 } from '@openmsupply-client/common';
@@ -58,7 +58,7 @@ export const useServiceLineColumns = (
       label: 'label.tax',
       width: 75,
       setter,
-      Cell: NonNegativeNumberInputCell,
+      Cell: NonNegativeIntegerCell,
     },
     {
       key: 'totalAfterTax',

--- a/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditForm.tsx
@@ -150,7 +150,9 @@ export const RequestLineEditForm = ({
                 width={150}
                 onChange={e =>
                   update({
-                    requestedQuantity: Math.max(Number(e.target.value), 0),
+                    requestedQuantity: Math.round(
+                      Math.max(Number(e.target.value), 0)
+                    ),
                   })
                 }
               />

--- a/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
+++ b/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseLineEditForm.tsx
@@ -126,7 +126,9 @@ export const ResponseLineEditForm = ({
                 width={150}
                 onChange={e =>
                   update({
-                    supplyQuantity: Math.max(Number(e.target.value), 0),
+                    supplyQuantity: Math.round(
+                      Math.max(Number(e.target.value), 0)
+                    ),
                   })
                 }
               />


### PR DESCRIPTION
Fixes #1201 
There's a few places where specifying a non-integer value will result in an error. This is an attempt to avoid the errors. Hopefully the rounding isn't too annoying for users 🤷 

## Testing

Create or edit each of these, and specify a real value. The value should round (`<0.5` => `0` and `0.5+` => `1`) when the input field loses focus
- Outbound shipments
- Response requisitions
- Inbound shipments
- Internal orders
- stocktakes