### PR TITLE
Escape stock filter

### DIFF
--- a/packages/common/src/utils/regex/RegexUtils.tsx
+++ b/packages/common/src/utils/regex/RegexUtils.tsx
@@ -44,4 +44,6 @@ export const RegexUtils = {
       RegexUtils.includes(substring, String(object[key]))
     );
   },
+  escapeChars: (regexString: string) =>
+    regexString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
 };

--- a/packages/system/src/Stock/ListView/ListView.tsx
+++ b/packages/system/src/Stock/ListView/ListView.tsx
@@ -9,6 +9,7 @@ import {
   Column,
   SortUtils,
   SortBy,
+  RegexUtils,
 } from '@openmsupply-client/common';
 import { Toolbar } from '../Components';
 import { useStockLines } from '../api';
@@ -47,7 +48,7 @@ export const StockListView: FC = () => {
   );
 
   const filterData = (row: StockRow) => {
-    const re = RegExp(`^${filterString ?? '.'}`, 'i');
+    const re = RegExp(`^${RegexUtils.escapeChars(filterString) ?? '.'}`, 'i');
     return re.test(row.itemName) || re.test(row.itemCode);
   };
 


### PR DESCRIPTION
Fixes #1203 

There's a temporary filter in place to allow filtering by either item code or name - complete with a dodgy regex. Have escaped search chars