### PR TITLE
Remove duplicated formatting

### DIFF
--- a/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
+++ b/packages/invoices/src/InboundShipment/DetailView/ContentArea/columns.ts
@@ -129,9 +129,9 @@ export const useInboundShipmentColumns = () => {
                 null
               );
 
-              return Formatter.expiryDateString(expiryDate);
+              return expiryDate;
             } else {
-              return Formatter.expiryDateString(rowData.expiryDate);
+              return rowData.expiryDate;
             }
           },
           getSortValue: rowData => {
@@ -183,11 +183,13 @@ export const useInboundShipmentColumns = () => {
           accessor: ({ rowData }) => {
             if ('lines' in rowData) {
               const { lines } = rowData;
-              return c(
-                ArrayUtils.ifTheSameElseDefault(lines, 'sellPricePerPack', '')
-              ).format();
+              return ArrayUtils.ifTheSameElseDefault(
+                lines,
+                'sellPricePerPack',
+                ''
+              );
             } else {
-              return c(rowData.sellPricePerPack).format();
+              return rowData.sellPricePerPack;
             }
           },
           getSortValue: rowData => {

--- a/packages/invoices/src/OutboundShipment/DetailView/columns.ts
+++ b/packages/invoices/src/OutboundShipment/DetailView/columns.ts
@@ -152,9 +152,9 @@ export const useOutboundColumns = ({
                 'expiryDate',
                 null
               );
-              return Formatter.expiryDateString(expiryDate);
+              return expiryDate;
             } else {
-              return Formatter.expiryDateString(rowData.expiryDate);
+              return rowData.expiryDate;
             }
           },
         },


### PR DESCRIPTION
Fixes #1205 

The currency and expiry date formatting is now in the column definitions and if called twice results in an empty string.