### PR TITLE
Render expando only when expanded

### DIFF
--- a/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
+++ b/packages/common/src/ui/layout/tables/components/DataRow/DataRow.tsx
@@ -9,7 +9,7 @@ import {
   useIsFocused,
   useRowStyle,
 } from '../../context';
-import { Collapse, Fade } from '@mui/material';
+import { Fade } from '@mui/material';
 
 interface DataRowProps<T extends RecordWithId> {
   columns: Column<T>[];
@@ -17,7 +17,7 @@ interface DataRowProps<T extends RecordWithId> {
   onClick?: (rowData: T) => void;
   rowData: T;
   rowKey: string;
-  ExpandContent?: FC<{ rowData: T }>;
+  ExpandContent?: FC<{ rowData: T; isExpanded: boolean }>;
   dense?: boolean;
   rowIndex: number;
   keyboardActivated?: boolean;
@@ -108,21 +108,13 @@ export const DataRow = <T extends RecordWithId>({
           })}
         </TableRow>
       </Fade>
-      <tr>
-        <td colSpan={columns.length}>
-          <Collapse
-            sx={{
-              flex: 1,
-              '& .MuiCollapse-wrapperInner': {
-                display: 'flex',
-              },
-            }}
-            in={isExpanded}
-          >
-            {ExpandContent ? <ExpandContent rowData={rowData} /> : null}
-          </Collapse>
-        </td>
-      </tr>
+      {isExpanded && !!ExpandContent ? (
+        <tr>
+          <td colSpan={columns.length}>
+            <ExpandContent rowData={rowData} isExpanded={isExpanded} />
+          </td>
+        </tr>
+      ) : null}
     </>
   );
 };

--- a/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
+++ b/packages/common/src/ui/layout/tables/components/Expand/MiniTable.tsx
@@ -3,6 +3,7 @@ import { Column } from './../../columns/types';
 import { Box, alpha } from '@mui/material';
 import { RecordWithId } from '@common/types';
 import { DataTable } from '../../DataTable';
+import { createTableStore, TableProvider } from '../../context/TableContext';
 
 interface MiniTableProps<T extends RecordWithId> {
   rows: T[];
@@ -30,7 +31,9 @@ export const MiniTable = <T extends RecordWithId>({
           overflow: 'hidden',
         }}
       >
-        <DataTable dense columns={columns} data={rows} />
+        <TableProvider createStore={createTableStore}>
+          <DataTable dense columns={columns} data={rows} />
+        </TableProvider>
       </Box>
     </Box>
   );

--- a/packages/common/src/ui/layout/tables/context/TableContext.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.ts
@@ -172,8 +172,7 @@ export const createTableStore = (): UseBoundStore<TableStore> =>
 
         // Get currently focused row, if any
         const [currentFocusId, currentFocusObj] =
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          rows.find(([_, { isFocused }]) => isFocused === true) || [];
+          rows.find(([, { isFocused }]) => isFocused === true) || [];
 
         // Deduce what the next row is, wrapping around if reaching top/bottom
         const nextIndex =

--- a/packages/common/src/ui/layout/tables/context/TableContext.ts
+++ b/packages/common/src/ui/layout/tables/context/TableContext.ts
@@ -1,4 +1,4 @@
-import create, { UseStore } from 'zustand';
+import create, { UseBoundStore } from 'zustand';
 import createContext from 'zustand/context';
 import { AppSxProp } from '../../../../styles';
 
@@ -47,7 +47,7 @@ const getRowState = (
   ...updates,
 });
 
-export const createTableStore = (): UseStore<TableStore> =>
+export const createTableStore = (): UseBoundStore<TableStore> =>
   create<TableStore>(set => ({
     rowState: {},
     numberSelected: 0,
@@ -172,6 +172,7 @@ export const createTableStore = (): UseStore<TableStore> =>
 
         // Get currently focused row, if any
         const [currentFocusId, currentFocusObj] =
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           rows.find(([_, { isFocused }]) => isFocused === true) || [];
 
         // Deduce what the next row is, wrapping around if reaching top/bottom

--- a/packages/common/src/ui/layout/tables/context/hooks/useExpanded.ts
+++ b/packages/common/src/ui/layout/tables/context/hooks/useExpanded.ts
@@ -8,13 +8,11 @@ interface UseExpandedControl {
 
 export const useExpanded = (rowId: string): UseExpandedControl => {
   const selector = useCallback(
-    (state: TableStore) => {
-      return {
-        rowId,
-        isExpanded: state.rowState[rowId]?.isExpanded ?? false,
-        toggleExpanded: () => state.toggleExpanded(rowId),
-      };
-    },
+    (state: TableStore) => ({
+      rowId,
+      isExpanded: state.rowState[rowId]?.isExpanded ?? false,
+      toggleExpanded: () => state.toggleExpanded(rowId),
+    }),
     [rowId]
   );
 

--- a/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -17,6 +17,7 @@ const Expando = ({
   rowData: StocktakeSummaryItem | StocktakeLineFragment;
 }) => {
   const expandoColumns = useExpansionColumns();
+
   if ('lines' in rowData && rowData.lines.length > 1) {
     return <MiniTable rows={rowData.lines} columns={expandoColumns} />;
   } else {

--- a/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/SidePanel.tsx
@@ -24,7 +24,7 @@ const AdditionalInfoSection: FC = () => {
   const t = useTranslation('common');
 
   const { comment, user, update } = useStocktakeFields(['comment', 'user']);
-  const [bufferedComment, setBufferedComment] = useBufferState(comment);
+  const [bufferedComment, setBufferedComment] = useBufferState(comment ?? '');
   const isDisabled = useIsStocktakeDisabled();
 
   return (

--- a/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/Toolbar.tsx
@@ -72,7 +72,7 @@ export const Toolbar: FC = () => {
         <Grid item>
           <DropdownMenu disabled={isDisabled} label={t('label.actions')}>
             <DropdownMenuItem IconComponent={DeleteIcon} onClick={onDelete}>
-              {t('button.delete-lines', { ns: 'distribution' })}
+              {t('button.delete-lines')}
             </DropdownMenuItem>
           </DropdownMenu>
         </Grid>


### PR DESCRIPTION
Fixes #776 

Well, that took longer than expected! 

The root of the issue was that we are rendering a `DataTable` to show the expando content.. and that wasn't instantiating a new table context. This meant that the expanded state was being reset - by playing with the rendering, the table row had to be rendered and with the reset table context, it wasn't expanded anymore! 🙄 