### PR TITLE
Refactor userQueryParams for Outbounds

### DIFF
--- a/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
+++ b/packages/common/src/hooks/useFilterBy/useFilterBy.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-interface FilterByConditionByType {
+export interface FilterByConditionByType {
   string: 'equalTo' | 'like';
   date: 'beforeOrEqualTo' | 'afterOrEqualTo' | 'equalTo';
 }

--- a/packages/common/src/hooks/useQueryParams/useQueryParams.ts
+++ b/packages/common/src/hooks/useQueryParams/useQueryParams.ts
@@ -1,7 +1,26 @@
-import { RecordWithId } from './../../types/index';
-import { usePagination, PaginationState } from '../usePagination';
-import { useSortBy, SortState, SortRule } from '../useSortBy';
-import { useFilterBy, FilterState, FilterBy } from '../useFilterBy';
+import create, { SetState, UseBoundStore } from 'zustand';
+import createContext from 'zustand/context';
+import { RecordWithId } from '@common/types';
+import {
+  usePagination,
+  PaginationState,
+  PaginationController,
+} from '../usePagination';
+import {
+  useSortBy,
+  SortState,
+  SortRule,
+  SortController,
+  SortBy,
+} from '../useSortBy';
+import {
+  useFilterBy,
+  FilterState,
+  FilterBy,
+  FilterController,
+  FilterByConditionByType,
+} from '../useFilterBy';
+import { Column } from '../../ui';
 
 export interface QueryParams<T extends RecordWithId>
   extends SortState<T>,
@@ -48,3 +67,140 @@ export const useQueryParams = <T extends RecordWithId>({
     queryParams,
   };
 };
+
+export interface QueryParamsStateNew<T extends RecordWithId> {
+  pagination: PaginationController;
+  sort: SortController<T>;
+  filter: FilterController;
+  paramList: () => {
+    first: number;
+    offset: number;
+    sortBy: SortBy<T>;
+    filterBy: FilterBy | null;
+  };
+}
+
+export const { Provider: QueryParamsProvider, useStore: useQueryParamsStore } =
+  createContext<QueryParamsStateNew<any>>();
+
+export const createQueryParamsStore = <T extends RecordWithId>({
+  initialSortBy,
+  initialFilterBy,
+}: {
+  initialSortBy: SortRule<T>;
+  initialFilterBy?: FilterBy;
+}): UseBoundStore<QueryParamsStateNew<T>> => {
+  const setFilterBy =
+    (set: SetState<QueryParamsStateNew<T>>) => (newFilterBy: FilterBy) =>
+      set(state => {
+        const { filterBy: previousFilterBy, ...rest } = { ...state.filter };
+        const filterBy = { ...previousFilterBy, ...newFilterBy };
+        return { ...state, filter: { ...rest, filterBy } };
+      });
+
+  return create<QueryParamsStateNew<T>>((set, get) => ({
+    pagination: {
+      first: 20,
+      offset: 0,
+      page: 0,
+      onChangeFirst: (first: number) => {
+        set(state => {
+          const { page, ...rest } = state.pagination;
+          return {
+            ...state,
+            pagination: { ...rest, first, offset: page * first, page },
+          };
+        });
+      },
+      onChangePage: (page: number) => {
+        set(state => {
+          const { first, ...rest } = state.pagination;
+          return {
+            ...state,
+            pagination: { ...rest, first, offset: page * first, page },
+          };
+        });
+      },
+      nextPage: () => {
+        set(state => {
+          const { first, page: currentPage, ...rest } = state.pagination;
+          const page = currentPage + 1;
+          return {
+            ...state,
+            pagination: { ...rest, first, offset: page * first, page },
+          };
+        });
+      },
+    },
+    sort: {
+      sortBy: {
+        key: 'initialSortBy.key',
+        isDesc: initialSortBy.isDesc ?? false,
+        direction: getDirection(initialSortBy.isDesc ?? false),
+      },
+      onChangeSortBy: (column: Column<T>) => {
+        let sortBy = { key: '', direction: 'asc' } as SortBy<T>;
+        set(state => {
+          const { key, sortBy: { isDesc: maybeNewIsDesc } = {} } = column;
+          const { sort } = state;
+          const isDesc =
+            sort.sortBy.key === key
+              ? !sort.sortBy.isDesc
+              : !!maybeNewIsDesc ?? false;
+
+          sortBy = {
+            ...sort.sortBy,
+            key,
+            isDesc,
+            direction: getDirection(isDesc),
+          };
+          return { ...state, sort: { ...sort, sortBy } };
+        });
+        return sortBy;
+      },
+    },
+    filter: {
+      filterBy: initialFilterBy ?? null,
+      onChangeStringFilterRule: (
+        key: string,
+        condition: FilterByConditionByType['string'],
+        value: string
+      ) => {
+        if (value === '') {
+          get().filter.onClearFilterRule(key);
+        } else {
+          setFilterBy(set)({ [key]: { [condition]: value } });
+        }
+      },
+
+      onChangeDateFilterRule: (
+        key: string,
+        condition: FilterByConditionByType['date'],
+        value: Date
+      ) => {
+        setFilterBy(set)({ [key]: { [condition]: value } });
+      },
+
+      onClearFilterRule: (key: string) =>
+        set(state => {
+          const { filterBy: previousFilterBy, ...rest } = { ...state.filter };
+          const filterBy = { ...previousFilterBy };
+          delete filterBy[key];
+          return { ...state, filter: { ...rest, filterBy } };
+        }),
+    },
+
+    paramList: () => {
+      const { pagination, sort, filter } = get();
+      return {
+        first: pagination.first,
+        offset: pagination.offset,
+        sortBy: sort.sortBy,
+        filterBy: filter.filterBy,
+      };
+    },
+  }));
+};
+
+const getDirection = (isDesc: boolean): 'asc' | 'desc' =>
+  isDesc ? 'desc' : 'asc';

--- a/packages/common/src/ui/layout/tables/context/TableContext.tsx
+++ b/packages/common/src/ui/layout/tables/context/TableContext.tsx
@@ -1,3 +1,10 @@
+import { RecordWithId } from '@common/types';
+import {
+  createQueryParamsStore,
+  QueryParamsProvider,
+  QueryParamsStateNew,
+} from 'packages/common/src/hooks/useQueryParams';
+import React, { PropsWithChildren } from 'react';
 import create, { UseBoundStore } from 'zustand';
 import createContext from 'zustand/context';
 import { AppSxProp } from '../../../../styles';
@@ -30,8 +37,30 @@ export interface TableStore {
   setRowStyles: (ids: string[], style: AppSxProp) => void;
 }
 
-export const { Provider: TableProvider, useStore: useTableStore } =
-  createContext<TableStore>();
+const { Provider, useStore: useTableStore } = createContext<TableStore>();
+
+const TableProvider = <T extends RecordWithId>({
+  children,
+  queryParamsStore,
+  ...props
+}: PropsWithChildren<{
+  initialStore?: UseBoundStore<TableStore>;
+  createStore: () => UseBoundStore<TableStore>;
+  queryParamsStore?: UseBoundStore<QueryParamsStateNew<T>>;
+}>) => (
+  <Provider {...props}>
+    <QueryParamsProvider
+      createStore={() =>
+        queryParamsStore ??
+        createQueryParamsStore({ initialSortBy: { key: 'none' } })
+      }
+    >
+      {children}
+    </QueryParamsProvider>
+  </Provider>
+);
+
+export { TableProvider, useTableStore };
 
 const getRowState = (
   state: TableStore,

--- a/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
+++ b/packages/invoices/src/OutboundShipment/ListView/ListView.tsx
@@ -11,6 +11,7 @@ import {
   useTableStore,
   NothingHere,
   useToggle,
+  createQueryParamsStore,
 } from '@openmsupply-client/common';
 import { getStatusTranslator, isOutboundDisabled } from '../../utils';
 import { Toolbar } from './Toolbar';
@@ -32,16 +33,9 @@ export const OutboundShipmentListViewComponent: FC = () => {
   const navigate = useNavigate();
   const modalController = useToggle();
 
-  const {
-    data,
-    isError,
-    isLoading,
-    sortBy,
-    onChangeSortBy,
-    onChangePage,
-    pagination,
-    filter,
-  } = useOutbound.document.list();
+  const { data, isError, isLoading, sort, pagination, filter } =
+    useOutbound.document.list();
+  const { onChangeSortBy, sortBy } = sort;
   useDisableOutboundRows(data?.nodes);
 
   const columns = useColumns<OutboundRowFragment>(
@@ -85,7 +79,7 @@ export const OutboundShipmentListViewComponent: FC = () => {
 
       <DataTable
         pagination={{ ...pagination, total: data?.totalCount }}
-        onChangePage={onChangePage}
+        onChangePage={pagination.onChangePage}
         columns={columns}
         data={data?.nodes ?? []}
         isError={isError}
@@ -104,10 +98,13 @@ export const OutboundShipmentListViewComponent: FC = () => {
   );
 };
 
-export const OutboundShipmentListView: FC = () => {
-  return (
-    <TableProvider createStore={createTableStore}>
-      <OutboundShipmentListViewComponent />
-    </TableProvider>
-  );
-};
+export const OutboundShipmentListView: FC = () => (
+  <TableProvider
+    createStore={createTableStore}
+    queryParamsStore={createQueryParamsStore({
+      initialSortBy: { key: 'otherPartyName' },
+    })}
+  >
+    <OutboundShipmentListViewComponent />
+  </TableProvider>
+);

--- a/packages/invoices/src/OutboundShipment/api/hooks/document/useOutbounds.ts
+++ b/packages/invoices/src/OutboundShipment/api/hooks/document/useOutbounds.ts
@@ -1,21 +1,14 @@
-import { useQuery, useQueryParams } from '@openmsupply-client/common';
+import { useQuery } from '@openmsupply-client/common';
+import { useQueryParamsStore } from 'packages/common/src/hooks/useQueryParams';
 import { useOutboundApi } from './../utils/useOutboundApi';
-import { OutboundRowFragment } from './../../operations.generated';
 
 export const useOutbounds = () => {
-  const queryParams = useQueryParams<OutboundRowFragment>({
-    initialSortBy: { key: 'otherPartyName' },
-  });
+  const queryParams = useQueryParamsStore();
   const api = useOutboundApi();
 
   return {
-    ...useQuery(api.keys.paramList(queryParams), () =>
-      api.get.list({
-        first: queryParams.first,
-        offset: queryParams.offset,
-        sortBy: queryParams.sortBy,
-        filterBy: queryParams.filter.filterBy,
-      })
+    ...useQuery(api.keys.paramList(queryParams.paramList()), () =>
+      api.get.list(queryParams.paramList())
     ),
     ...queryParams,
   };


### PR DESCRIPTION
Fixes #1204 

Am creating the PR at this stage.. there is more refactoring to do, but I want to reduce the number of files in the PR 😉 
This one is the essence of the change - the next steps are:
- replicate these changes across all usages of `useQueryParams`
- remove the hooks `useFilterBy` `useSortBy` & `usePagination`
- rework existing tests

The core of the problem is that the current hooks aren't sharing state.. so a list of items is retrieved by two separate calls, and each has different query params, though the code is expecting to see the same list of results.

I've lifted the queryParams state out, so it is created in the page context. Almost always, this is within the table context, so have created a query params context which is instantiated by the table context. For the cases where the queryParams are used outside of the table context (Name search is one) then the query params context can be instantiated separately.

Will also replace the `useSharedSort` implementation required by this PR: https://github.com/openmsupply/openmsupply-client/pull/1017 as I expect that won't be needed now.