### PR TITLE
Remove add item when disabled

### DIFF
--- a/packages/common/src/intl/locales/en/inventory.json
+++ b/packages/common/src/intl/locales/en/inventory.json
@@ -5,6 +5,7 @@
   "error.no-locations": "There are no Locations to display.",
   "error.no-stock": "There is no stock to display.",
   "error.no-stocktakes": "There are no Stocktakes to display.",
+  "error.no-stocktake-items": "No items have been added to this stocktake.",
   "error.stocktake-not-found": "Stocktake not found",
   "label.add-batch": "Add batch",
   "label.add-new-line": "Add a new line",

--- a/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/ContentArea/ContentArea.tsx
@@ -7,6 +7,7 @@ import {
   useIsGrouped,
   MiniTable,
   createQueryParamsStore,
+  NothingHere,
 } from '@openmsupply-client/common';
 import { useStocktakeColumns, useExpansionColumns } from './columns';
 import { StocktakeLineFragment, useStocktake } from '../../api';
@@ -38,13 +39,18 @@ interface ContentAreaProps {
   onRowClick:
     | null
     | ((item: StocktakeSummaryItem | StocktakeLineFragment) => void);
+  onAddItem: () => void;
 }
 
-export const ContentArea: FC<ContentAreaProps> = ({ onRowClick }) => {
+export const ContentArea: FC<ContentAreaProps> = ({
+  onAddItem,
+  onRowClick,
+}) => {
   const t = useTranslation('inventory');
   const { isGrouped, toggleIsGrouped } = useIsGrouped('inboundShipment');
   const { rows, onChangeSortBy, sortBy } = useStocktake.line.rows(isGrouped);
   const columns = useStocktakeColumns({ onChangeSortBy, sortBy });
+  const isDisabled = useStocktake.utils.isDisabled();
 
   return (
     <Box flexDirection="column" flex={1}>
@@ -63,7 +69,13 @@ export const ContentArea: FC<ContentAreaProps> = ({ onRowClick }) => {
         ExpandContent={Expando}
         columns={columns}
         data={rows}
-        noDataMessage={t('error.no-items')}
+        noDataElement={
+          <NothingHere
+            body={t('error.no-stocktake-items')}
+            onCreate={isDisabled ? undefined : onAddItem}
+            buttonText={t('button.add-item')}
+          />
+        }
       />
     </Box>
   );

--- a/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
+++ b/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
@@ -51,7 +51,10 @@ export const DetailView: FC = () => {
       <AppBarButtons onAddItem={() => onOpen()} />
       <Toolbar />
 
-      <ContentArea onRowClick={!isDisabled ? onRowClick : null} />
+      <ContentArea
+        onRowClick={!isDisabled ? onRowClick : null}
+        onAddItem={() => onOpen()}
+      />
       <Footer />
       <SidePanel />
 

--- a/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
+++ b/packages/invoices/src/InboundShipment/DetailView/ContentArea/ContentArea.tsx
@@ -32,6 +32,7 @@ const Expando = ({
 export const ContentArea: FC<ContentAreaProps> = React.memo(
   ({ onAddItem, onRowClick }) => {
     const t = useTranslation('replenishment');
+    const isDisabled = useInbound.utils.isDisabled();
     const { columns, rows, isGrouped, toggleIsGrouped } =
       useInbound.lines.rows();
 
@@ -57,7 +58,7 @@ export const ContentArea: FC<ContentAreaProps> = React.memo(
           noDataElement={
             <NothingHere
               body={t('error.no-inbound-items')}
-              onCreate={onAddItem}
+              onCreate={isDisabled ? undefined : onAddItem}
               buttonText={t('button.add-item')}
             />
           }

--- a/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -107,6 +107,7 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
   const { isGrouped, toggleIsGrouped } = useIsGrouped('outboundShipment');
   const { rows, onChangeSortBy, sortBy } = useOutbound.line.rows(isGrouped);
   const columns = useOutboundColumns({ onChangeSortBy, sortBy });
+  const isDisabled = useOutbound.utils.isDisabled();
   useHighlightPlaceholderRows(rows);
 
   if (!rows) return null;
@@ -133,7 +134,7 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
         noDataElement={
           <NothingHere
             body={t('error.no-outbound-items')}
-            onCreate={onAddItem}
+            onCreate={isDisabled ? undefined : onAddItem}
             buttonText={t('button.add-item')}
           />
         }

--- a/packages/requisitions/src/RequestRequisition/DetailView/ContentArea.tsx
+++ b/packages/requisitions/src/RequestRequisition/DetailView/ContentArea.tsx
@@ -16,8 +16,9 @@ export const ContentArea = ({ onAddItem, onRowClick }: ContentAreaProps) => {
   const { lines, columns } = useRequest.line.list();
   const { on } = useHideOverStocked();
   const { itemFilter } = useRequest.line.list();
-
+  const isDisabled = useRequest.utils.isDisabled();
   const isFiltered = !!itemFilter || on;
+
   return (
     <DataTable
       onRowClick={onRowClick}
@@ -30,7 +31,7 @@ export const ContentArea = ({ onAddItem, onRowClick }: ContentAreaProps) => {
               ? 'error.no-items-filter-on'
               : 'error.no-requisition-items'
           )}
-          onCreate={onAddItem}
+          onCreate={isDisabled ? undefined : onAddItem}
           buttonText={t('button.add-item')}
         />
       }


### PR DESCRIPTION
Fixes #1235 

Remove the link on the detail view when the record is disabled for the following:
- Inbound shipment
- Outbound shipment
- Internal order

Added bonus: noticed that the stocktake detail wasn't using the <NothingHere/> component, so have popped that in too