### PR TITLE
Auth error state set & reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,18 @@ You may need to install `armv7` i.e. `rustup target add armv7-linux-androideabi`
 yarn android:build-remote_server
 ```
 
-#### MacOS issues
+#### MacOS
 
-If you have the error: `fatal error: 'stdio.h' file not found`. If so, specify a location for the headers using the`CPATH`env var, for example`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/`or`/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/`
+Have been unable to build the aarch64-linux-android target of remote-server on macOS running on apple silicon. Configuration when using an x86 based macOS is also difficult and we recommend building on a linux host if at all possible. 
 
-If the `C_INCLUDE_PATH` env var is set, that may cause compilation issues, as it will include the macOS headers and give you `warning: #error architecture not supported` and `warning: fatal error: too many errors emitted, stopping now [-ferror-limit=]`. In which case `unset C_INCLUDE_PATH`
+Here are some issues encountered when building on macOS:
+
+1. If you have the error: `fatal error: 'stdio.h' file not found`. If so, specify a location for the headers using the`CPATH`env var, for example`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/`or`/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/`
+
+2. If the `C_INCLUDE_PATH` env var is set, that may cause compilation issues, as it will include the macOS headers and give you `warning: #error architecture not supported` and `warning: fatal error: too many errors emitted, stopping now [-ferror-limit=]`. In which case `unset C_INCLUDE_PATH`
+
+
+3. `thread 'rustc' panicked at 'called `Option::unwrap()` on a `None` value', compiler/rustc_codegen_llvm/src/back/archive.rs:358:67`: Install openssl (`brew install openssl`) and set the env var for `OPENSSL_DIR` e.g. `export OPENSSL_DIR=/usr/local/opt/openssl@3`
 
 #### Unsolved issue that will hopefully be fixed at some point:
 

--- a/packages/common/src/authentication/AuthContext.tsx
+++ b/packages/common/src/authentication/AuthContext.tsx
@@ -112,7 +112,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   const { mutateAsync, isLoading: isLoggingIn } = useGetAuthToken();
   const authCookie = getAuthCookie();
   const [cookie, setCookie] = useState<AuthCookie | undefined>(authCookie);
-  const [error, setError] = useLocalStorage('/auth/error');
+  const [error, setError, removeError] = useLocalStorage('/auth/error');
   const storeId = cookie?.store?.id ?? '';
   const { mutateAsync: getStores } = useUserDetails();
   const { setHeader, setSkipRequest } = useGql();
@@ -151,7 +151,7 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
   const setLoginError = (isLoggedIn: boolean, hasValidStore: boolean) => {
     switch (true) {
       case isLoggedIn && hasValidStore: {
-        setError(undefined);
+        removeError();
         break;
       }
       case !isLoggedIn: {

--- a/packages/common/src/authentication/AuthContext.tsx
+++ b/packages/common/src/authentication/AuthContext.tsx
@@ -156,7 +156,6 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
       }
       case !hasValidStore: {
         setError(AuthError.NoStoreAssigned);
-        console.warn('error!', AuthError.NoStoreAssigned);
         break;
       }
       default: {

--- a/packages/common/src/authentication/AuthContext.tsx
+++ b/packages/common/src/authentication/AuthContext.tsx
@@ -154,12 +154,13 @@ export const AuthProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
         setError(undefined);
         break;
       }
+      case !isLoggedIn: {
+        setError(AuthError.Unauthenticated);
+        break;
+      }
       case !hasValidStore: {
         setError(AuthError.NoStoreAssigned);
         break;
-      }
-      default: {
-        setError(AuthError.Unauthenticated);
       }
     }
   };

--- a/packages/common/src/localStorage/LocalStorage.ts
+++ b/packages/common/src/localStorage/LocalStorage.ts
@@ -68,6 +68,18 @@ class LocalStorage {
       return defaultValue;
     }
   }
+
+  removeItem<StorageKey extends Extract<LocalStorageKey, string>>(
+    key: StorageKey
+  ): void {
+    const existingValue = this.getItem(key);
+
+    // no need to alert listeners if already cleared
+    if (existingValue === null) return;
+
+    localStorage.removeItem(this.createStorageKey(key));
+    this.listeners.forEach(listener => listener(key, null));
+  }
 }
 
 export default new LocalStorage();

--- a/packages/common/src/localStorage/useLocalStorage.ts
+++ b/packages/common/src/localStorage/useLocalStorage.ts
@@ -9,7 +9,11 @@ import LocalStorage from './LocalStorage';
  * Will update localStorage whenever the state changes.
  */
 
-type LocalStorageSetter<T> = [value: T | null, setItem: (value: T) => void];
+type LocalStorageSetter<T> = [
+  value: T | null,
+  setItem: (value: T) => void,
+  removeItem: () => void
+];
 
 export const useLocalStorage = <
   StorageKey extends Extract<LocalStorageKey, string>
@@ -36,5 +40,10 @@ export const useLocalStorage = <
     setValue(value);
   };
 
-  return [value, setItem];
+  const removeItem = () => {
+    LocalStorage.removeItem(key);
+    setValue(undefined as LocalStorageRecord[StorageKey]);
+  };
+
+  return [value, setItem, removeItem];
 };

--- a/packages/host/src/Host.tsx
+++ b/packages/host/src/Host.tsx
@@ -20,6 +20,8 @@ import {
   AuthProvider,
   AlertModalProvider,
   EnvUtils,
+  LocalStorage,
+  AuthError,
 } from '@openmsupply-client/common';
 import { AppRoute, Environment } from '@openmsupply-client/config';
 import { Initialise, Login, Viewport } from './components';
@@ -49,13 +51,19 @@ Bugsnag.start({
   appVersion: packageJson.version,
 });
 
+const skipRequest = () =>
+  LocalStorage.getItem('/auth/error') === AuthError.NoStoreAssigned;
+
 const Host = () => (
   <React.Suspense fallback={<div />}>
     <IntlProvider>
       <React.Suspense fallback={<RandomLoader />}>
         <ErrorBoundary Fallback={GenericErrorFallback}>
           <QueryClientProvider client={queryClient}>
-            <GqlProvider url={Environment.GRAPHQL_URL}>
+            <GqlProvider
+              url={Environment.GRAPHQL_URL}
+              skipRequest={skipRequest}
+            >
               <AuthProvider>
                 <AppThemeProvider>
                   <ConfirmationModalProvider>

--- a/packages/host/src/components/AuthenticationAlert.tsx
+++ b/packages/host/src/components/AuthenticationAlert.tsx
@@ -46,7 +46,7 @@ export const AuthenticationAlert = () => {
     }
 
     if (error === AuthError.PermissionDenied) {
-      LocalStorage.setItem('/auth/error', undefined);
+      LocalStorage.removeItem('/auth/error');
       return;
     }
 

--- a/packages/host/src/components/Initialise/hooks.ts
+++ b/packages/host/src/components/Initialise/hooks.ts
@@ -100,7 +100,7 @@ export const useInitialiseForm = () => {
       setIsPolling(true);
     }, POLLING_DELAY);
 
-    LocalStorage.setItem('/auth/error', undefined);
+    LocalStorage.removeItem('/auth/error');
     LocalStorage.addListener<AuthError>((key, value) => {
       if (key === '/auth/error' && value === AuthError.Unauthenticated) {
         // Server is up! and rejecting our request!


### PR DESCRIPTION
Fixes #1237 

This is overboard, possibly? I've wandered off a little here, just to show this:

<img width="674" alt="Screen Shot 2022-05-12 at 4 28 48 PM" src="https://user-images.githubusercontent.com/9192912/167992694-dac1b1b2-a182-4016-8a48-0283e836d54d.png">

which was not being displayed any longer, since the permission denied error was being set after this error was ( the dashboard queries were triggering them), and therefore the permission denied modal was shown instead of this one. To get things working, I've had to add a request check function into GqlContext which allows the skipping of requests.

The _actual_ issue was not very complex. It came from the health supply hub, which is using a copy of `common` and having auth issues, because the line which resets auth state on login was removed. To make things clearer, I've lifted that out to a helper method ( thanks @jmbrunskill for the heads up on that one! )
