### PR TITLE
Language detection order

### DIFF
--- a/packages/common/src/intl/context/IntlContext.tsx
+++ b/packages/common/src/intl/context/IntlContext.tsx
@@ -47,12 +47,11 @@ export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
         defaultNS,
         detection: {
           order: [
-            'omsBrowserLanguageDetector',
             'querystring',
             'cookie',
             'localStorage',
             'sessionStorage',
-            'navigator',
+            'omsBrowserLanguageDetector',
             'htmlTag',
           ],
         },


### PR DESCRIPTION
Fixes #1241 
Oops. Update the language detection order, so that localStorage is before the new custom navigator detection 🙄