### PR TITLE
Outbound: add item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ android/app/src/main/jniLibs
 android/.idea
 /build/*
 !/build/.npmkeep
+*.keystore

--- a/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
+++ b/packages/invoices/src/OutboundShipment/DetailView/ContentArea.tsx
@@ -134,7 +134,7 @@ export const ContentAreaComponent: FC<ContentAreaProps> = ({
         noDataElement={
           <NothingHere
             body={t('error.no-outbound-items')}
-            onCreate={isDisabled ? undefined : onAddItem}
+            onCreate={isDisabled ? undefined : () => onAddItem()}
             buttonText={t('button.add-item')}
           />
         }


### PR DESCRIPTION
Fixes #1249, #1244

The problem is partly a user error. Clicking the add item in the NothingHere component gave the error, using the app bar button is fine. Just had to update the usage of `addItem` for outbounds